### PR TITLE
Add Whisper TextDecoder module and refine audio context handling

### DIFF
--- a/crates/bunsen/src/kits/speech/whisper/audio_encoder.rs
+++ b/crates/bunsen/src/kits/speech/whisper/audio_encoder.rs
@@ -116,7 +116,7 @@ impl AudioEncoderConfig {
             act2: self.head_activation.init(device),
 
             positional_embedding: Param::from_tensor(Tensor::random(
-                [self.max_audio_ctx, self.n_audio_states],
+                [self.max_audio_ctx / 2, self.n_audio_states],
                 Distribution::Normal(0.0, 1.0),
                 device,
             )),
@@ -158,7 +158,7 @@ impl<B: Backend> AudioEncoderMeta for AudioEncoder<B> {
     }
 
     fn max_audio_ctx(&self) -> usize {
-        self.positional_embedding.val().dims()[0]
+        2 * self.positional_embedding.val().dims()[0]
     }
 
     fn n_audio_states(&self) -> usize {
@@ -180,16 +180,17 @@ impl<B: Backend> AudioEncoder<B> {
         &self,
         x: Tensor<B, 3>,
     ) -> Tensor<B, 3> {
-        let [ctx_len] = unpack_shape_contract!(
-            ["batch", "n_mels", "ctx_len"],
+        let [_batch, seq_len] = unpack_shape_contract!(
+            ["batch", "n_mels", "seq_len"],
             &x,
-            &["ctx_len"],
+            &["batch", "seq_len"],
             &[("n_mels", self.n_mels())],
         );
+
         assert!(
-            ctx_len <= self.max_audio_ctx(),
+            seq_len <= self.max_audio_ctx(),
             "Audio length {} cannot exceed {}.",
-            ctx_len,
+            seq_len,
             self.max_audio_ctx()
         );
 
@@ -197,6 +198,18 @@ impl<B: Backend> AudioEncoder<B> {
         let x = self.act2.forward(self.conv2.forward(x));
 
         let x = x.swap_dims(1, 2);
+
+        #[cfg(any(debug_assertions, test))]
+        crate::contracts::assert_shape_contract_periodically!(
+            ["batch", "len", "n_audio_states"],
+            &x,
+            &[
+                ("batch", _batch),
+                ("len", seq_len / 2),
+                ("n_audio_states", self.n_audio_states()),
+            ],
+        );
+
         let k = x.dims()[1];
         let x = x + self
             .positional_embedding

--- a/crates/bunsen/src/kits/speech/whisper/audio_encoder.rs
+++ b/crates/bunsen/src/kits/speech/whisper/audio_encoder.rs
@@ -103,6 +103,8 @@ impl AudioEncoderConfig {
         &self,
         device: &B::Device,
     ) -> AudioEncoder<B> {
+        // TODO: Use burn::nn::Embedding
+
         AudioEncoder {
             conv1: Conv1dConfig::new(self.n_mels, self.n_audio_states, 3)
                 .with_padding(PaddingConfig1d::Explicit(1, 1))

--- a/crates/bunsen/src/kits/speech/whisper/audio_encoder.rs
+++ b/crates/bunsen/src/kits/speech/whisper/audio_encoder.rs
@@ -36,11 +36,11 @@ use crate::{
 
 /// Common meta for [`AudioEncoder`] and [`AudioEncoderConfig`].
 pub trait AudioEncoderMeta {
-    /// Return the number of mel spectrogram channels.
+    /// Return the Mel-scale frequency resolution.
     fn n_mels(&self) -> usize;
 
-    /// Return the number of audio context.
-    fn n_audio_ctx(&self) -> usize;
+    /// Return the max audio context size.
+    fn max_audio_ctx(&self) -> usize;
 
     /// Return the number of audio states.
     fn n_audio_states(&self) -> usize;
@@ -55,11 +55,11 @@ pub trait AudioEncoderMeta {
 /// Config for [`AudioEncoder`].
 #[derive(Config, Debug)]
 pub struct AudioEncoderConfig {
-    /// Number of Mel Spectrogram Channels.
+    /// The Mel-scale frequency resolution.
     pub n_mels: usize,
 
     /// Number of Audio Context.
-    pub n_audio_ctx: usize,
+    pub max_audio_ctx: usize,
 
     /// Number of Audio States.
     pub n_audio_states: usize,
@@ -80,8 +80,8 @@ impl AudioEncoderMeta for AudioEncoderConfig {
         self.n_mels
     }
 
-    fn n_audio_ctx(&self) -> usize {
-        self.n_audio_ctx
+    fn max_audio_ctx(&self) -> usize {
+        self.max_audio_ctx
     }
 
     fn n_audio_states(&self) -> usize {
@@ -116,7 +116,7 @@ impl AudioEncoderConfig {
             act2: self.head_activation.init(device),
 
             positional_embedding: Param::from_tensor(Tensor::random(
-                [self.n_audio_ctx, self.n_audio_states],
+                [self.max_audio_ctx, self.n_audio_states],
                 Distribution::Normal(0.0, 1.0),
                 device,
             )),
@@ -157,7 +157,7 @@ impl<B: Backend> AudioEncoderMeta for AudioEncoder<B> {
         self.conv1.weight.dims()[1]
     }
 
-    fn n_audio_ctx(&self) -> usize {
+    fn max_audio_ctx(&self) -> usize {
         self.positional_embedding.val().dims()[0]
     }
 
@@ -180,17 +180,17 @@ impl<B: Backend> AudioEncoder<B> {
         &self,
         x: Tensor<B, 3>,
     ) -> Tensor<B, 3> {
-        let [n_ctx] = unpack_shape_contract!(
-            ["batch", "n_mels", "n_ctx"],
+        let [ctx_len] = unpack_shape_contract!(
+            ["batch", "n_mels", "ctx_len"],
             &x,
-            &["n_ctx"],
+            &["ctx_len"],
             &[("n_mels", self.n_mels())],
         );
         assert!(
-            n_ctx <= self.n_audio_ctx(),
+            ctx_len <= self.max_audio_ctx(),
             "Audio length {} cannot exceed {}.",
-            n_ctx,
-            self.n_audio_ctx()
+            ctx_len,
+            self.max_audio_ctx()
         );
 
         let x = self.act1.forward(self.conv1.forward(x));
@@ -226,7 +226,7 @@ mod tests {
         type B = PerformanceBackend;
         let device = Default::default();
 
-        let n_audio_ctx = 128;
+        let max_audio_ctx = 128;
         let n_mels = 256;
         let n_audio_heads = 4;
         let n_audio_states = n_audio_heads * 32;
@@ -234,14 +234,14 @@ mod tests {
 
         let config = AudioEncoderConfig::new(
             n_mels,
-            n_audio_ctx,
+            max_audio_ctx,
             n_audio_states,
             n_audio_heads,
             n_audio_layers,
         );
 
         assert_eq!(config.n_mels(), n_mels);
-        assert_eq!(config.n_audio_ctx(), n_audio_ctx);
+        assert_eq!(config.max_audio_ctx(), max_audio_ctx);
         assert_eq!(config.n_audio_states(), n_audio_states);
         assert_eq!(config.n_audio_heads(), n_audio_heads);
         assert_eq!(config.n_audio_layers(), n_audio_layers);
@@ -249,13 +249,13 @@ mod tests {
         let encoder: AudioEncoder<B> = config.init(&device);
 
         assert_eq!(encoder.n_mels(), n_mels);
-        assert_eq!(encoder.n_audio_ctx(), n_audio_ctx);
+        assert_eq!(encoder.max_audio_ctx(), max_audio_ctx);
         assert_eq!(encoder.n_audio_states(), n_audio_states);
         assert_eq!(encoder.n_audio_heads(), n_audio_heads);
         assert_eq!(encoder.n_audio_layers(), n_audio_layers);
 
         let batch = 2;
-        let k = n_audio_ctx / 2;
+        let k = max_audio_ctx / 2;
         let x: Tensor<B, 3> = Tensor::random([batch, n_mels, k], Distribution::Default, &device);
 
         let output = encoder.forward(x.clone());

--- a/crates/bunsen/src/kits/speech/whisper/mod.rs
+++ b/crates/bunsen/src/kits/speech/whisper/mod.rs
@@ -3,6 +3,7 @@
 mod audio_encoder;
 mod residual_decoder;
 mod residual_encoder;
+mod text_decoder;
 
 #[doc(inline)]
 pub use audio_encoder::*;
@@ -10,3 +11,5 @@ pub use audio_encoder::*;
 pub use residual_decoder::*;
 #[doc(inline)]
 pub use residual_encoder::*;
+#[doc(inline)]
+pub use text_decoder::*;

--- a/crates/bunsen/src/kits/speech/whisper/text_decoder.rs
+++ b/crates/bunsen/src/kits/speech/whisper/text_decoder.rs
@@ -1,0 +1,143 @@
+use burn::{
+    Tensor,
+    config::Config,
+    module::{
+        Module,
+        Param,
+    },
+    nn::{
+        LayerNorm,
+        LayerNormConfig,
+    },
+    prelude::{
+        Backend,
+        s,
+    },
+    tensor::{
+        Bool,
+        Distribution,
+        Int,
+        module::embedding,
+    },
+};
+
+use crate::{
+    blocks::transformers::attention::causal_mask,
+    kits::speech::whisper::{
+        ResidualDecoderAttentionBlock,
+        ResidualDecoderAttentionBlockConfig,
+    },
+};
+
+/// Config for [`TextDecoder`].
+#[derive(Config, Debug)]
+pub struct TextDecoderConfig {
+    n_vocab: usize,
+    n_text_ctx: usize,
+    n_text_state: usize,
+    n_text_head: usize,
+    n_text_layer: usize,
+}
+
+/// Build attention mask for decoder.
+pub fn attn_decoder_mask<B: Backend>(
+    seq_length: usize,
+    device: &B::Device,
+) -> Tensor<B, 2> {
+    let mut mask = Tensor::<B, 2>::zeros([seq_length, seq_length], device);
+
+    for i in 0..(seq_length - 1) {
+        let values =
+            Tensor::<B, 2>::zeros([1, seq_length - (i + 1)], device).add_scalar(f64::NEG_INFINITY);
+        mask = mask.slice_assign([i..i + 1, i + 1..seq_length], values);
+    }
+
+    mask
+}
+
+impl TextDecoderConfig {
+    /// Initialize text decoder module.
+    pub fn init<B: Backend>(
+        &self,
+        device: &B::Device,
+    ) -> TextDecoder<B> {
+        // TODO: Use burn::nn::Embedding
+
+        TextDecoder {
+            token_embedding: Param::from_tensor(Tensor::random(
+                [self.n_vocab, self.n_text_state],
+                Distribution::Normal(0.0, 1.0),
+                device,
+            )),
+
+            positional_embedding: Param::from_tensor(Tensor::random(
+                [self.n_text_ctx, self.n_text_state],
+                Distribution::Normal(0.0, 1.0),
+                device,
+            )),
+
+            blocks: (0..self.n_text_layer)
+                .map(|_| {
+                    ResidualDecoderAttentionBlockConfig::new(self.n_text_state, self.n_text_head)
+                        .init(device)
+                })
+                .collect(),
+
+            ln: LayerNormConfig::new(self.n_text_state).init(device),
+
+            mask: Param::from_tensor(attn_decoder_mask(self.n_text_ctx, device)),
+
+            n_vocab: self.n_vocab,
+            n_text_ctx: self.n_text_ctx,
+        }
+    }
+}
+
+/// Text decoder module for Whisper speech recognition model.
+#[derive(Module, Debug)]
+pub struct TextDecoder<B: Backend> {
+    token_embedding: Param<Tensor<B, 2>>,
+    positional_embedding: Param<Tensor<B, 2>>,
+    blocks: Vec<ResidualDecoderAttentionBlock<B>>,
+    ln: LayerNorm<B>,
+    mask: Param<Tensor<B, 2>>,
+    n_vocab: usize,
+    n_text_ctx: usize,
+}
+
+impl<B: Backend> TextDecoder<B> {
+    /// Run the decoder.
+    pub fn forward(
+        &self,
+        x: Tensor<B, 2, Int>,
+        xa: Tensor<B, 3>,
+    ) -> Tensor<B, 3> {
+        let [_n_batch, seq_len] = x.dims();
+
+        assert!(
+            seq_len <= self.n_text_ctx,
+            "Token sequence length {} must not exceed {}.",
+            seq_len,
+            self.n_text_ctx
+        );
+
+        let x = embedding(self.token_embedding.val(), x)
+            + self
+                .positional_embedding
+                .val()
+                .slice(s![0..seq_len])
+                .unsqueeze::<3>();
+
+        //let mask = attn_decoder_mask(seq_len);
+
+        let mask: Option<Tensor<B, 3, Bool>> = causal_mask(seq_len, 0, &x.device()).into();
+
+        let x = self
+            .blocks
+            .iter()
+            .fold(x, |z, b| b.forward(z, xa.clone(), mask.clone()).output);
+
+        let x = self.ln.forward(x);
+        x.matmul(self.token_embedding.val().transpose().unsqueeze::<3>())
+    }
+}


### PR DESCRIPTION
### Changes Overview

- Introduced the `TextDecoder` module for Whisper speech-to-text functionality, including configuration options, forward pass capabilities, and support for causal masking.
- Exposed the `text_decoder` module via `mod.rs`.
- Updated `AudioEncoder`:
  - Revised `max_audio_ctx` to half its original size.
  - Adjusted shape assertions to align with the new `max_audio_ctx` value.
  - Renamed `n_audio_ctx` to `max_audio_ctx` for improved clarity across `AudioEncoder`, `AudioEncoderConfig`, and related methods, assertions, and comments.
