### PR TITLE
Standardize naming conventions in Whisper modules

### DIFF
--- a/crates/bunsen/src/kits/speech/whisper/audio_encoder.rs
+++ b/crates/bunsen/src/kits/speech/whisper/audio_encoder.rs
@@ -38,16 +38,16 @@ pub trait AudioEncoderMeta {
     fn n_mels(&self) -> usize;
 
     /// Return the max audio context size.
-    fn max_audio_ctx(&self) -> usize;
+    fn max_context(&self) -> usize;
 
-    /// Return the number of audio states.
-    fn n_audio_states(&self) -> usize;
+    /// The embedding size of the model.
+    fn d_model(&self) -> usize;
 
-    /// Return the number of audio heads.
-    fn n_audio_heads(&self) -> usize;
+    /// Return the number of heads.
+    fn n_heads(&self) -> usize;
 
-    /// Return the number of audio layers.
-    fn n_audio_layers(&self) -> usize;
+    /// Return the number of layers.
+    fn n_layers(&self) -> usize;
 }
 
 /// Config for [`AudioEncoder`].
@@ -56,17 +56,17 @@ pub struct AudioEncoderConfig {
     /// The Mel-scale frequency resolution.
     pub n_mels: usize,
 
-    /// Number of Audio Context.
-    pub max_audio_ctx: usize,
+    /// Max audio context size.
+    pub max_context: usize,
 
-    /// Number of Audio States.
-    pub n_audio_states: usize,
+    /// The embedding size of the model.
+    pub d_model: usize,
 
     /// Number of Audio Heads.
-    pub n_audio_heads: usize,
+    pub n_heads: usize,
 
     /// Number of Audio Layers.
-    pub n_audio_layers: usize,
+    pub n_layers: usize,
 
     /// Head Activation.
     #[config(default = "ActivationConfig::Gelu")]
@@ -78,20 +78,20 @@ impl AudioEncoderMeta for AudioEncoderConfig {
         self.n_mels
     }
 
-    fn max_audio_ctx(&self) -> usize {
-        self.max_audio_ctx
+    fn max_context(&self) -> usize {
+        self.max_context
     }
 
-    fn n_audio_states(&self) -> usize {
-        self.n_audio_states
+    fn d_model(&self) -> usize {
+        self.d_model
     }
 
-    fn n_audio_heads(&self) -> usize {
-        self.n_audio_heads
+    fn n_heads(&self) -> usize {
+        self.n_heads
     }
 
-    fn n_audio_layers(&self) -> usize {
-        self.n_audio_layers
+    fn n_layers(&self) -> usize {
+        self.n_layers
     }
 }
 
@@ -102,31 +102,28 @@ impl AudioEncoderConfig {
         device: &B::Device,
     ) -> AudioEncoder<B> {
         AudioEncoder {
-            conv1: Conv1dConfig::new(self.n_mels, self.n_audio_states, 3)
+            conv1: Conv1dConfig::new(self.n_mels, self.d_model, 3)
                 .with_padding(PaddingConfig1d::Explicit(1, 1))
                 .init(device),
             act1: self.head_activation.init(device),
 
-            conv2: Conv1dConfig::new(self.n_audio_states, self.n_audio_states, 3)
+            conv2: Conv1dConfig::new(self.d_model, self.d_model, 3)
                 .with_padding(PaddingConfig1d::Explicit(1, 1))
                 .with_stride(2)
                 .init(device),
             act2: self.head_activation.init(device),
 
-            positional_embedding: EmbeddingConfig::new(self.max_audio_ctx / 2, self.n_audio_states)
+            positional_embedding: EmbeddingConfig::new(self.max_context / 2, self.d_model)
                 .init(device),
 
-            blocks: (0..self.n_audio_layers)
+            blocks: (0..self.n_layers)
                 .map(|_| {
-                    ResidualEncoderAttentionBlockConfig::new(
-                        self.n_audio_states,
-                        self.n_audio_heads,
-                    )
-                    .init(device)
+                    ResidualEncoderAttentionBlockConfig::new(self.d_model, self.n_heads)
+                        .init(device)
                 })
                 .collect(),
 
-            ln_post: LayerNormConfig::new(self.n_audio_states).init(device),
+            ln_post: LayerNormConfig::new(self.d_model).init(device),
         }
     }
 }
@@ -152,19 +149,19 @@ impl<B: Backend> AudioEncoderMeta for AudioEncoder<B> {
         self.conv1.weight.dims()[1]
     }
 
-    fn max_audio_ctx(&self) -> usize {
+    fn max_context(&self) -> usize {
         2 * self.positional_embedding.weight.val().dims()[0]
     }
 
-    fn n_audio_states(&self) -> usize {
+    fn d_model(&self) -> usize {
         self.blocks[0].n_states()
     }
 
-    fn n_audio_heads(&self) -> usize {
+    fn n_heads(&self) -> usize {
         self.blocks[0].n_heads()
     }
 
-    fn n_audio_layers(&self) -> usize {
+    fn n_layers(&self) -> usize {
         self.blocks.len()
     }
 }
@@ -189,10 +186,10 @@ impl<B: Backend> AudioEncoder<B> {
         );
 
         assert!(
-            seq_len <= self.max_audio_ctx(),
+            seq_len <= self.max_context(),
             "Audio length {} cannot exceed {}.",
             seq_len,
-            self.max_audio_ctx()
+            self.max_context()
         );
 
         let x = self.act1.forward(self.conv1.forward(x));
@@ -207,7 +204,7 @@ impl<B: Backend> AudioEncoder<B> {
             &[
                 ("batch", _batch),
                 ("len", seq_len / 2),
-                ("n_audio_states", self.n_audio_states()),
+                ("n_audio_states", self.d_model()),
             ],
         );
 
@@ -256,18 +253,18 @@ mod tests {
         );
 
         assert_eq!(config.n_mels(), n_mels);
-        assert_eq!(config.max_audio_ctx(), max_audio_ctx);
-        assert_eq!(config.n_audio_states(), n_audio_states);
-        assert_eq!(config.n_audio_heads(), n_audio_heads);
-        assert_eq!(config.n_audio_layers(), n_audio_layers);
+        assert_eq!(config.max_context(), max_audio_ctx);
+        assert_eq!(config.d_model(), n_audio_states);
+        assert_eq!(config.n_heads(), n_audio_heads);
+        assert_eq!(config.n_layers(), n_audio_layers);
 
         let encoder: AudioEncoder<B> = config.init(&device);
 
         assert_eq!(encoder.n_mels(), n_mels);
-        assert_eq!(encoder.max_audio_ctx(), max_audio_ctx);
-        assert_eq!(encoder.n_audio_states(), n_audio_states);
-        assert_eq!(encoder.n_audio_heads(), n_audio_heads);
-        assert_eq!(encoder.n_audio_layers(), n_audio_layers);
+        assert_eq!(encoder.max_context(), max_audio_ctx);
+        assert_eq!(encoder.d_model(), n_audio_states);
+        assert_eq!(encoder.n_heads(), n_audio_heads);
+        assert_eq!(encoder.n_layers(), n_audio_layers);
 
         let batch = 2;
         let k = max_audio_ctx / 2;

--- a/crates/bunsen/src/kits/speech/whisper/text_decoder.rs
+++ b/crates/bunsen/src/kits/speech/whisper/text_decoder.rs
@@ -30,32 +30,32 @@ use crate::{
 /// Common meta for [`TextDecoder`] and [`TextDecoderConfig`].
 pub trait TextDecoderMeta {
     /// Return the size of the vocabulary.
-    fn n_vocab(&self) -> usize;
+    fn vocab_size(&self) -> usize;
 
-    /// Return the max text context size.
-    fn max_text_context(&self) -> usize;
+    /// Return the max context size.
+    fn max_context(&self) -> usize;
 
-    /// Return the number of text states.
-    fn n_text_state(&self) -> usize;
+    /// The embedding size of the model.
+    fn d_model(&self) -> usize;
 }
 
 /// Config for [`TextDecoder`].
 #[derive(Config, Debug)]
 pub struct TextDecoderConfig {
     /// The size of the vocabulary.
-    pub n_vocab: usize,
+    pub vocab_size: usize,
 
-    /// The max text context size.
-    pub max_text_context: usize,
+    /// Maximum text context size.
+    pub max_context: usize,
 
-    /// The text embedding size.
-    pub n_text_state: usize,
+    /// The embedding size of the model.
+    pub d_model: usize,
 
-    /// The number of decoder heads.
-    pub n_text_head: usize,
+    /// The number of heads.
+    pub n_heads: usize,
 
-    /// The number of decoder layers.
-    pub n_text_layer: usize,
+    /// The number of layers.
+    pub n_layers: usize,
 
     /// Dropout.
     #[config(default = "0.0")]
@@ -63,16 +63,16 @@ pub struct TextDecoderConfig {
 }
 
 impl TextDecoderMeta for TextDecoderConfig {
-    fn n_vocab(&self) -> usize {
-        self.n_vocab
+    fn vocab_size(&self) -> usize {
+        self.vocab_size
     }
 
-    fn max_text_context(&self) -> usize {
-        self.max_text_context
+    fn max_context(&self) -> usize {
+        self.max_context
     }
 
-    fn n_text_state(&self) -> usize {
-        self.n_text_state
+    fn d_model(&self) -> usize {
+        self.d_model
     }
 }
 
@@ -99,20 +99,19 @@ impl TextDecoderConfig {
         device: &B::Device,
     ) -> TextDecoder<B> {
         TextDecoder {
-            token_embedding: EmbeddingConfig::new(self.n_vocab, self.n_text_state).init(device),
+            token_embedding: EmbeddingConfig::new(self.vocab_size, self.d_model).init(device),
 
-            positional_embedding: EmbeddingConfig::new(self.max_text_context, self.n_text_state)
-                .init(device),
+            positional_embedding: EmbeddingConfig::new(self.max_context, self.d_model).init(device),
 
-            blocks: (0..self.n_text_layer)
+            blocks: (0..self.n_layers)
                 .map(|_| {
-                    ResidualDecoderAttentionBlockConfig::new(self.n_text_state, self.n_text_head)
+                    ResidualDecoderAttentionBlockConfig::new(self.d_model, self.n_heads)
                         .with_dropout(self.block_dropout)
                         .init(device)
                 })
                 .collect(),
 
-            ln: LayerNormConfig::new(self.n_text_state).init(device),
+            ln: LayerNormConfig::new(self.d_model).init(device),
             // mask: Param::from_tensor(attn_decoder_mask(self.max_text_context, device)),
         }
     }
@@ -136,15 +135,15 @@ pub struct TextDecoder<B: Backend> {
 }
 
 impl<B: Backend> TextDecoderMeta for TextDecoder<B> {
-    fn n_vocab(&self) -> usize {
+    fn vocab_size(&self) -> usize {
         self.token_embedding.weight.val().dims()[0]
     }
 
-    fn max_text_context(&self) -> usize {
+    fn max_context(&self) -> usize {
         self.positional_embedding.weight.val().dims()[0]
     }
 
-    fn n_text_state(&self) -> usize {
+    fn d_model(&self) -> usize {
         self.blocks[0].n_states()
     }
 }
@@ -166,10 +165,10 @@ impl<B: Backend> TextDecoder<B> {
         let [_n_batch, seq_len] = x.dims();
 
         assert!(
-            seq_len <= self.max_text_context(),
+            seq_len <= self.max_context(),
             "Token sequence length {} must not exceed {}.",
             seq_len,
-            self.max_text_context()
+            self.max_context()
         );
 
         let x = self.token_embedding.forward(x)
@@ -219,43 +218,37 @@ mod tests {
         type B = PerformanceBackend;
         let device = Default::default();
 
-        let n_vocab = 64;
-        let max_text_context = 128;
-        let n_text_head = 4;
-        let n_text_state = n_text_head * 32;
-        let n_text_layer = 2;
+        let d_model = 128;
+        let vocab_size = 64;
+        let max_context = 128;
+        let n_heads = 4;
+        let n_layers = 2;
 
-        let config = TextDecoderConfig::new(
-            n_vocab,
-            max_text_context,
-            n_text_state,
-            n_text_head,
-            n_text_layer,
-        );
+        let config = TextDecoderConfig::new(vocab_size, max_context, d_model, n_heads, n_layers);
 
-        assert_eq!(config.n_vocab(), n_vocab);
-        assert_eq!(config.max_text_context(), max_text_context);
-        assert_eq!(config.n_text_state(), n_text_state);
+        assert_eq!(config.vocab_size(), vocab_size);
+        assert_eq!(config.max_context(), max_context);
+        assert_eq!(config.d_model(), d_model);
 
         let decoder: TextDecoder<B> = config.init(&device);
 
-        assert_eq!(decoder.n_vocab(), n_vocab);
-        assert_eq!(decoder.max_text_context(), max_text_context);
-        assert_eq!(decoder.n_text_state(), n_text_state);
+        assert_eq!(decoder.vocab_size(), vocab_size);
+        assert_eq!(decoder.max_context(), max_context);
+        assert_eq!(decoder.d_model(), d_model);
 
         let batch = 2;
-        let seq_len = max_text_context / 2;
+        let seq_len = max_context / 2;
 
         let x: Tensor<B, 2, Int> = Tensor::zeros([batch, seq_len], &device);
         let xa: Tensor<B, 3> =
-            Tensor::random([batch, seq_len, n_text_state], Default::default(), &device);
+            Tensor::random([batch, seq_len, d_model], Default::default(), &device);
 
         let output = decoder.forward(x.clone(), xa.clone());
 
         assert_shape_contract!(
             ["batch", "seq", "n_vocab"],
             &output,
-            &[("batch", batch), ("seq", seq_len), ("n_vocab", n_vocab),],
+            &[("batch", batch), ("seq", seq_len), ("n_vocab", vocab_size),],
         );
     }
 }

--- a/crates/bunsen/src/kits/speech/whisper/whisper_model.rs
+++ b/crates/bunsen/src/kits/speech/whisper/whisper_model.rs
@@ -74,17 +74,17 @@ impl WhisperApiConfig {
 pub trait WhisperMeta {
     /// Return the embedding size of the model.
     fn d_model(&self) -> usize {
-        self.encoder().n_audio_states()
+        self.encoder().d_model()
     }
 
     /// The max audio context size.
     fn max_encoder_ctx(&self) -> usize {
-        self.encoder().max_audio_ctx()
+        self.encoder().max_context()
     }
 
     /// The max text context size.
     fn max_decoder_ctx(&self) -> usize {
-        self.decoder().max_text_context()
+        self.decoder().max_context()
     }
 
     /// Return the [`AudioEncoder`] meta.
@@ -123,7 +123,7 @@ impl WhisperStructuralConfig {
         let encoder = self.encoder.init(device);
         let decoder = self.decoder.init(device);
 
-        assert_eq!(encoder.n_audio_states(), decoder.n_text_state());
+        assert_eq!(encoder.d_model(), decoder.d_model());
 
         Whisper { encoder, decoder }
     }
@@ -213,16 +213,17 @@ mod tests {
         type B = PerformanceBackend;
         let device = Default::default();
 
+        let d_model = 128;
         let n_mels = 80;
+        let vocab_size = 64;
+
         let max_audio_ctx = 128;
         let n_audio_heads = 4;
-        let d_model = n_audio_heads * 32;
         let n_audio_layers = 2;
 
-        let n_vocab = 64;
         let max_text_context = 128;
-        let n_text_head = 4;
-        let n_text_layer = 2;
+        let n_text_heads = 4;
+        let n_text_layers = 2;
 
         let config = WhisperApiConfig::new(
             n_mels,
@@ -230,10 +231,10 @@ mod tests {
             d_model,
             n_audio_heads,
             n_audio_layers,
-            n_vocab,
+            vocab_size,
             max_text_context,
-            n_text_head,
-            n_text_layer,
+            n_text_heads,
+            n_text_layers,
         );
 
         let structural = config.to_structural_config();
@@ -243,13 +244,13 @@ mod tests {
         assert_eq!(structural.max_decoder_ctx(), max_text_context);
 
         assert_eq!(structural.encoder().n_mels(), n_mels);
-        assert_eq!(structural.encoder().max_audio_ctx(), max_audio_ctx);
-        assert_eq!(structural.encoder().n_audio_states(), d_model);
-        assert_eq!(structural.encoder().n_audio_heads(), n_audio_heads);
-        assert_eq!(structural.encoder().n_audio_layers(), n_audio_layers);
-        assert_eq!(structural.decoder().n_vocab(), n_vocab);
-        assert_eq!(structural.decoder().max_text_context(), max_text_context);
-        assert_eq!(structural.decoder().n_text_state(), d_model);
+        assert_eq!(structural.encoder().max_context(), max_audio_ctx);
+        assert_eq!(structural.encoder().d_model(), d_model);
+        assert_eq!(structural.encoder().n_heads(), n_audio_heads);
+        assert_eq!(structural.encoder().n_layers(), n_audio_layers);
+        assert_eq!(structural.decoder().vocab_size(), vocab_size);
+        assert_eq!(structural.decoder().max_context(), max_text_context);
+        assert_eq!(structural.decoder().d_model(), d_model);
 
         let model: Whisper<B> = structural.init(&device);
 
@@ -258,10 +259,10 @@ mod tests {
         assert_eq!(model.max_decoder_ctx(), max_text_context);
 
         assert_eq!(model.encoder().n_mels(), n_mels);
-        assert_eq!(model.encoder().max_audio_ctx(), max_audio_ctx);
-        assert_eq!(model.encoder().n_audio_states(), d_model);
-        assert_eq!(model.decoder().n_vocab(), n_vocab);
-        assert_eq!(model.decoder().n_text_state(), d_model);
+        assert_eq!(model.encoder().max_context(), max_audio_ctx);
+        assert_eq!(model.encoder().d_model(), d_model);
+        assert_eq!(model.decoder().vocab_size(), vocab_size);
+        assert_eq!(model.decoder().d_model(), d_model);
         assert_eq!(model.max_encoder_ctx(), max_audio_ctx);
         assert_eq!(model.max_decoder_ctx(), max_text_context);
 
@@ -292,7 +293,11 @@ mod tests {
         assert_shape_contract!(
             ["batch", "seq", "n_vocab"],
             &output,
-            &[("batch", batch), ("seq", token_len), ("n_vocab", n_vocab)],
+            &[
+                ("batch", batch),
+                ("seq", token_len),
+                ("n_vocab", vocab_size)
+            ],
         );
     }
 }


### PR DESCRIPTION
### Description

This pull request introduces standardized naming conventions across Whisper modules for better clarity and consistency. Changes include:

- Renaming variables like `n_vocab` to `vocab_size` and `n_text_state` to `d_model`.
- Aligning method and structure field names between `TextDecoder` and `AudioEncoder`.
- Updating corresponding tests, initialization logic, and assertions.
