### PR TITLE
Improve utility methods in Whisper modules and boost test coverage

### DIFF
--- a/crates/bunsen/src/kits/speech/whisper/residual_decoder.rs
+++ b/crates/bunsen/src/kits/speech/whisper/residual_decoder.rs
@@ -129,11 +129,28 @@ impl<B: Backend> ResidualDecoderAttentionBlockMeta for ResidualDecoderAttentionB
 /// Decode record for [`ResidualDecoderAttentionBlock::forward`].
 #[derive(Debug, Clone)]
 pub struct DecodeRecord<B: Backend> {
-    /// Block Output: ``[batch, seq_len, n_states]``.
+    /// Block Output: ``[batch, seq_len, d_model]``.
     pub output: Tensor<B, 3>,
 
     /// Cross-Attention Weights: ``[batch, n_heads, seq_len, seq_len]``.
     pub ca_weights: Tensor<B, 4>,
+}
+
+impl<B: Backend> DecodeRecord<B> {
+    /// Get the batch size.
+    pub fn batch_size(&self) -> usize {
+        self.output.shape()[0]
+    }
+
+    /// Get the embedding size.
+    pub fn d_model(&self) -> usize {
+        self.output.shape()[2]
+    }
+
+    /// Get the sequence length.
+    pub fn seq_len(&self) -> usize {
+        self.output.shape()[1]
+    }
 }
 
 impl<B: Backend> ResidualDecoderAttentionBlock<B> {
@@ -211,7 +228,11 @@ mod tests {
             Tensor::random([1, seq_len, seq_len], Distribution::Bernoulli(0.5), &device);
         let mask = mask.bool();
 
-        let fr = block.forward(x.clone(), xa.clone(), mask.clone().into());
+        let result = block.forward(x.clone(), xa.clone(), mask.clone().into());
+
+        assert_eq!(result.batch_size(), batch);
+        assert_eq!(result.d_model(), d_model);
+        assert_eq!(result.seq_len(), seq_len);
 
         let expected = {
             let self_attn =
@@ -235,24 +256,26 @@ mod tests {
             }
         };
 
-        fr.output
+        result
+            .output
             .clone()
             .into_data()
             .assert_approx_eq::<f64>(&expected.output.clone().into_data(), Default::default());
-        fr.ca_weights
+        result
+            .ca_weights
             .clone()
             .into_data()
             .assert_approx_eq::<f64>(&expected.ca_weights.clone().into_data(), Default::default());
 
         assert_shape_contract!(
             ["batch", "seq_len", "d_model"],
-            &fr.output,
+            &result.output,
             &[("batch", batch), ("seq_len", seq_len), ("d_model", d_model),],
         );
 
         assert_shape_contract!(
             ["batch", "n_heads", "seq_len", "seq_len"],
-            &fr.ca_weights,
+            &result.ca_weights,
             &[("batch", batch), ("n_heads", n_heads), ("seq_len", seq_len)],
         );
     }

--- a/crates/bunsen/src/kits/speech/whisper/whisper_model.rs
+++ b/crates/bunsen/src/kits/speech/whisper/whisper_model.rs
@@ -72,6 +72,16 @@ impl WhisperApiConfig {
 
 /// Common meta for [`Whisper`] and [`WhisperApiConfig`].
 pub trait WhisperMeta {
+    /// Return the Mel-scale frequency resolution.
+    fn n_mels(&self) -> usize {
+        self.encoder().n_mels()
+    }
+
+    /// Return the vocabulary size.
+    fn vocab_size(&self) -> usize {
+        self.decoder().vocab_size()
+    }
+
     /// Return the embedding size of the model.
     fn d_model(&self) -> usize {
         self.encoder().d_model()
@@ -239,6 +249,8 @@ mod tests {
 
         let structural = config.to_structure();
 
+        assert_eq!(structural.n_mels(), n_mels);
+        assert_eq!(structural.vocab_size(), vocab_size);
         assert_eq!(structural.d_model(), d_model);
         assert_eq!(structural.max_encoder_ctx(), max_audio_ctx);
         assert_eq!(structural.max_decoder_ctx(), max_text_context);
@@ -254,6 +266,8 @@ mod tests {
 
         let model: Whisper<B> = structural.init(&device);
 
+        assert_eq!(model.n_mels(), n_mels);
+        assert_eq!(model.vocab_size(), vocab_size);
         assert_eq!(model.d_model(), d_model);
         assert_eq!(model.max_encoder_ctx(), max_audio_ctx);
         assert_eq!(model.max_decoder_ctx(), max_text_context);

--- a/crates/bunsen/src/kits/speech/whisper/whisper_model.rs
+++ b/crates/bunsen/src/kits/speech/whisper/whisper_model.rs
@@ -50,7 +50,7 @@ pub struct WhisperApiConfig {
 
 impl WhisperApiConfig {
     /// Convert to a [`WhisperStructuralConfig`].
-    pub fn to_structural_config(self) -> WhisperStructuralConfig {
+    pub fn to_structure(&self) -> WhisperStructuralConfig {
         WhisperStructuralConfig {
             encoder: AudioEncoderConfig::new(
                 self.n_mels,
@@ -237,7 +237,7 @@ mod tests {
             n_text_layers,
         );
 
-        let structural = config.to_structural_config();
+        let structural = config.to_structure();
 
         assert_eq!(structural.d_model(), d_model);
         assert_eq!(structural.max_encoder_ctx(), max_audio_ctx);


### PR DESCRIPTION

This pull request introduces several enhancements:

- Added `n_mels` and `vocab_size` utility methods in `WhisperMeta`.
- Renamed `to_structural_config` to `to_structure` in `WhisperApiConfig` for naming consistency.
- Introduced `batch_size`, `d_model`, and `seq_len` methods in `DecodeRecord`.
- Enhanced test assertions to improve readability and test coverage.
