### PR TITLE
Refactor and add `whisper-dev` example for PyTorch Whisper models

### DIFF
--- a/.idea/bunsen.iml
+++ b/.idea/bunsen.iml
@@ -29,6 +29,7 @@
       <sourceFolder url="file://$MODULE_DIR$/examples/zsl-data-cache/examples" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/examples/zsl-data-cache/examples/pull_shards/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/examples/zsl-data-cache/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/examples/whisper-dev/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/crates/bunsen/target" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
       <excludeFolder url="file://$MODULE_DIR$/demos/bimm/crates/bimm/target" />

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10854,6 +10854,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "whisper-dev"
+version = "0.21.3"
+dependencies = [
+ "bunsen",
+ "burn",
+ "burn-store",
+ "clap",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs
@@ -58,6 +58,7 @@ pub struct AudioEncoderConfig {
 
     /// The embedding size of the model.
     pub d_model: usize,
+
     /// Max audio context size.
     pub max_context: usize,
 

--- a/examples/whisper-dev/Cargo.toml
+++ b/examples/whisper-dev/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "whisper-dev"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+version.workspace = true
+repository.workspace = true
+license.workspace = true
+
+
+[lints]
+workspace = true
+
+[features]
+default = []
+cuda = ["burn/cuda", "bunsen/cuda"]
+
+
+[dependencies]
+burn = { workspace = true, features = ["store"] }
+burn-store = { workspace = true, features = ["pytorch"] }
+
+bunsen = { path = "../../crates/bunsen" }
+
+clap = { workspace = true, features = ["derive"] }
+

--- a/examples/whisper-dev/src/main.rs
+++ b/examples/whisper-dev/src/main.rs
@@ -1,0 +1,66 @@
+use burn_store::{
+    ModuleStore,
+    PytorchStore,
+};
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub struct Args {
+    /// Path to the source model.
+    #[arg(long, default_value = "/media/Data/models/whisper/base.en.pt")]
+    pub source: String,
+
+    /// Path to the source model.
+    #[arg(long, default_value = "model_state_dict")]
+    pub top_level_key: String,
+}
+
+fn block_layers_from_keys<S: AsRef<str>>(
+    kind: &str,
+    keys: &[S],
+) -> usize {
+    keys.iter()
+        .filter(|k| {
+            let k = k.as_ref();
+            k.starts_with(&format!("{kind}.blocks.")) && k.ends_with(".attn.key.weight")
+        })
+        .count()
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+    println!("{:#?}", args);
+
+    let mut store = PytorchStore::from_file(args.source).with_top_level_key("model_state_dict");
+    /*
+    let snapshots = store.get_all_snapshots();
+    println!("{:#?}", snapshots);
+     */
+
+    let keys = store.keys()?;
+    println!("{:#?}", keys);
+
+    let [d_model, n_mels] = store
+        .get_snapshot("encoder.conv1.weight")?
+        .unwrap()
+        .shape
+        .dims();
+
+    let [vocab_size, _] = store
+        .get_snapshot("decoder.token_embedding.weight")?
+        .unwrap()
+        .shape
+        .dims();
+
+    println!("n_mels: {n_mels}");
+    println!("vocab_size: {vocab_size}");
+    println!("d_model: {d_model}");
+
+    let encoder_layers = block_layers_from_keys("encoder", &keys);
+    let decoder_layers = block_layers_from_keys("decoder", &keys);
+    println!("encoder_layers: {encoder_layers}");
+    println!("decoder_layers: {decoder_layers}");
+
+    Ok(())
+}

--- a/examples/whisper-dev/src/main.rs
+++ b/examples/whisper-dev/src/main.rs
@@ -1,8 +1,9 @@
-use burn_store::{
-    ModuleStore,
-    PytorchStore,
-};
+pub mod pytorch_utils;
+
+use std::path::PathBuf;
+
 use clap::Parser;
+use pytorch_utils::PytorchWhisperScanner;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -13,54 +14,18 @@ pub struct Args {
 
     /// Path to the source model.
     #[arg(long, default_value = "model_state_dict")]
-    pub top_level_key: String,
-}
-
-fn block_layers_from_keys<S: AsRef<str>>(
-    kind: &str,
-    keys: &[S],
-) -> usize {
-    keys.iter()
-        .filter(|k| {
-            let k = k.as_ref();
-            k.starts_with(&format!("{kind}.blocks.")) && k.ends_with(".attn.key.weight")
-        })
-        .count()
+    pub top_level_key: Option<String>,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
     println!("{:#?}", args);
 
-    let mut store = PytorchStore::from_file(args.source).with_top_level_key("model_state_dict");
-    /*
-    let snapshots = store.get_all_snapshots();
-    println!("{:#?}", snapshots);
-     */
+    let cfg = PytorchWhisperScanner::new()
+        .with_top_level_key(args.top_level_key.clone())
+        .scan_cfg(PathBuf::from(args.source.clone()))?;
 
-    let keys = store.keys()?;
-    println!("{:#?}", keys);
-
-    let [d_model, n_mels] = store
-        .get_snapshot("encoder.conv1.weight")?
-        .unwrap()
-        .shape
-        .dims();
-
-    let [vocab_size, _] = store
-        .get_snapshot("decoder.token_embedding.weight")?
-        .unwrap()
-        .shape
-        .dims();
-
-    println!("n_mels: {n_mels}");
-    println!("vocab_size: {vocab_size}");
-    println!("d_model: {d_model}");
-
-    let encoder_layers = block_layers_from_keys("encoder", &keys);
-    let decoder_layers = block_layers_from_keys("decoder", &keys);
-    println!("encoder_layers: {encoder_layers}");
-    println!("decoder_layers: {decoder_layers}");
+    println!("{:#?}", cfg);
 
     Ok(())
 }

--- a/examples/whisper-dev/src/pytorch_utils.rs
+++ b/examples/whisper-dev/src/pytorch_utils.rs
@@ -1,0 +1,99 @@
+use std::path::{
+    Path,
+    PathBuf,
+};
+
+use bunsen::kits::speech::whisper::blocks::{
+    PassConfig,
+    WhisperApiConfig,
+};
+use burn::config::Config;
+use burn_store::{
+    ModuleStore,
+    PytorchStore,
+};
+
+fn block_layers_from_keys<S: AsRef<str>>(
+    kind: &str,
+    keys: &[S],
+) -> usize {
+    keys.iter()
+        .filter(|k| {
+            let k = k.as_ref();
+            k.starts_with(&format!("{kind}.blocks.")) && k.ends_with(".attn.key.weight")
+        })
+        .count()
+}
+
+#[derive(Debug, Config)]
+pub struct PytorchWhisperScanner {
+    /// Top-level key in the model state dict.
+    #[config(default_value = "Some(\"model_state_dict\".to_string())")]
+    pub top_level_key: Option<String>,
+}
+
+impl PytorchWhisperScanner {
+    /// Scan a pytorch whisper checkpoint for configuration.
+    ///
+    /// Due to the reader, this will always set `n_heads` to 1.
+    pub fn scan_cfg<P: AsRef<Path>>(
+        &self,
+        path: P,
+    ) -> Result<WhisperApiConfig, Box<dyn std::error::Error>> {
+        let path = path.as_ref();
+        let path: PathBuf = path.to_path_buf();
+
+        let store = PytorchStore::from_file(path.clone());
+        let mut store = match &self.top_level_key {
+            Some(k) => store.with_top_level_key(k),
+            None => store,
+        };
+        let keys = store.keys()?;
+
+        let [d_model, n_mels] = store
+            .get_snapshot("encoder.conv1.weight")?
+            .unwrap()
+            .shape
+            .dims();
+
+        let [vocab_size, _] = store
+            .get_snapshot("decoder.token_embedding.weight")?
+            .unwrap()
+            .shape
+            .dims();
+
+        let [k, _] = store
+            .get_snapshot("encoder.positional_embedding")?
+            .unwrap()
+            .shape
+            .dims();
+        let max_audio_ctx = k * 2;
+
+        let [max_text_ctx, _] = store
+            .get_snapshot("decoder.positional_embedding")?
+            .unwrap()
+            .shape
+            .dims();
+
+        // n_layers isn't recoverable from ModelStore.
+
+        let encoder_layers = block_layers_from_keys("encoder", &keys);
+        let decoder_layers = block_layers_from_keys("decoder", &keys);
+
+        Ok(WhisperApiConfig {
+            n_mels,
+            vocab_size,
+            d_model,
+            audio_encoder: PassConfig {
+                max_ctx: max_audio_ctx,
+                n_heads: 1,
+                n_layers: encoder_layers,
+            },
+            text_decoder: PassConfig {
+                max_ctx: max_text_ctx,
+                n_heads: 1,
+                n_layers: decoder_layers,
+            },
+        })
+    }
+}


### PR DESCRIPTION
Streamlined the `whisper-dev` example by:

- Extracting the `PytorchWhisperScanner` logic to a separate `pytorch_utils.rs` file for scanning PyTorch Whisper checkpoints.
- Modularizing configuration handling in `main.rs`.

Additionally:

- Introduced a new `whisper-dev` example with CLI functionality for inspecting Whisper models and integrated it into the workspace.