### PR TITLE
Modularize Whisper pretrained model support

### DIFF
--- a/crates/bunsen/src/kits/speech/whisper/mod.rs
+++ b/crates/bunsen/src/kits/speech/whisper/mod.rs
@@ -3,4 +3,6 @@
 //! [Whisper][w] is a large-scale, general-purpose speech recognition model.
 //!
 //! [w]: https://github.com/openai/whisper
+
 pub mod blocks;
+pub mod pretrained;

--- a/crates/bunsen/src/kits/speech/whisper/pretrained/mod.rs
+++ b/crates/bunsen/src/kits/speech/whisper/pretrained/mod.rs
@@ -1,0 +1,8 @@
+//! Pretrained Whisper Models.
+
+#[cfg(feature = "store")]
+mod pytorch_utils;
+
+#[cfg(feature = "store")]
+#[doc(inline)]
+pub use pytorch_utils::*;

--- a/crates/bunsen/src/kits/speech/whisper/pretrained/pytorch_utils.rs
+++ b/crates/bunsen/src/kits/speech/whisper/pretrained/pytorch_utils.rs
@@ -3,14 +3,15 @@ use std::path::{
     PathBuf,
 };
 
-use bunsen::kits::speech::whisper::blocks::{
-    PassConfig,
-    WhisperApiConfig,
-};
 use burn::config::Config;
 use burn_store::{
     ModuleStore,
     PytorchStore,
+};
+
+use crate::kits::speech::whisper::blocks::{
+    PassConfig,
+    WhisperApiConfig,
 };
 
 fn block_layers_from_keys<S: AsRef<str>>(
@@ -25,6 +26,7 @@ fn block_layers_from_keys<S: AsRef<str>>(
         .count()
 }
 
+/// Pytorch Whisper Model Scanner.
 #[derive(Debug, Config)]
 pub struct PytorchWhisperScanner {
     /// Top-level key in the model state dict.

--- a/examples/whisper-dev/src/main.rs
+++ b/examples/whisper-dev/src/main.rs
@@ -1,9 +1,7 @@
-pub mod pytorch_utils;
-
 use std::path::PathBuf;
 
+use bunsen::kits::speech::whisper::pretrained::PytorchWhisperScanner;
 use clap::Parser;
-use pytorch_utils::PytorchWhisperScanner;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]


### PR DESCRIPTION
Refactor the codebase to introduce a `pretrained` module for better modularity:

- Moved `PytorchWhisperScanner` to `pretrained/pytorch_utils.rs`.
- Refactored the `whisper-dev` example to utilize `bunsen::kits::speech::whisper::pretrained`.
- Updated `mod.rs` to expose the newly added `pretrained` module.