### PR TITLE
Update embedding utilities and refactor Whisper modules

### DIFF
--- a/crates/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs
@@ -1,10 +1,11 @@
 use burn::{
     Tensor,
     config::Config,
-    module::Module,
+    module::{
+        Module,
+        Param,
+    },
     nn::{
-        Embedding,
-        EmbeddingConfig,
         LayerNorm,
         LayerNormConfig,
         PaddingConfig1d,
@@ -21,6 +22,7 @@ use burn::{
         Backend,
         s,
     },
+    tensor::Distribution,
 };
 
 use crate::{
@@ -38,6 +40,9 @@ pub trait AudioEncoderMeta {
     fn n_mels(&self) -> usize;
 
     /// Return the max audio context size.
+    ///
+    /// Due to the stride reduction of the conv layers, the max context is
+    /// twice the internal positional embedding.
     fn max_context(&self) -> usize;
 
     /// The embedding size of the model.
@@ -60,6 +65,9 @@ pub struct AudioEncoderConfig {
     pub d_model: usize,
 
     /// Max audio context size.
+    ///
+    /// Due to the stride reduction of the conv layers, the max context is
+    /// twice the internal positional embedding.
     pub max_context: usize,
 
     /// Number of Audio Heads.
@@ -101,6 +109,8 @@ impl AudioEncoderConfig {
         &self,
         device: &B::Device,
     ) -> AudioEncoder<B> {
+        let pos_ctx = self.max_context / 2;
+
         AudioEncoder {
             conv1: Conv1dConfig::new(self.n_mels, self.d_model, 3)
                 .with_padding(PaddingConfig1d::Explicit(1, 1))
@@ -113,8 +123,11 @@ impl AudioEncoderConfig {
                 .init(device),
             act2: self.head_activation.init(device),
 
-            positional_embedding: EmbeddingConfig::new(self.max_context / 2, self.d_model)
-                .init(device),
+            positional_embedding: Param::from_tensor(Tensor::random(
+                [pos_ctx, self.d_model],
+                Distribution::Normal(0.0, 1.0),
+                device,
+            )),
 
             blocks: (0..self.n_layers)
                 .map(|_| {
@@ -137,7 +150,7 @@ pub struct AudioEncoder<B: Backend> {
     conv2: Conv1d<B>,
     act2: Activation<B>,
 
-    positional_embedding: Embedding<B>,
+    positional_embedding: Param<Tensor<B, 2>>,
 
     blocks: Vec<ResidualEncoderAttentionBlock<B>>,
 
@@ -154,7 +167,10 @@ impl<B: Backend> AudioEncoderMeta for AudioEncoder<B> {
     }
 
     fn max_context(&self) -> usize {
-        2 * self.positional_embedding.weight.val().dims()[0]
+        let pos_ctx = self.positional_embedding.val().dims()[0];
+        // Due to the stride reduction of the conv layers, the max context is
+        // twice the internal positional embedding.
+        pos_ctx * 2
     }
 
     fn n_heads(&self) -> usize {
@@ -178,12 +194,14 @@ impl<B: Backend> AudioEncoder<B> {
         &self,
         x: Tensor<B, 3>,
     ) -> Tensor<B, 3> {
-        let [_batch, seq_len] = unpack_shape_contract!(
+        #[cfg(any(debug_assertions, test))]
+        let [batch] = unpack_shape_contract!(
             ["batch", "n_mels", "seq_len"],
             &x,
-            &["batch", "seq_len"],
+            &["batch"],
             &[("n_mels", self.n_mels())],
         );
+        let seq_len = x.dims()[2];
 
         assert!(
             seq_len <= self.max_context(),
@@ -199,26 +217,35 @@ impl<B: Backend> AudioEncoder<B> {
 
         #[cfg(any(debug_assertions, test))]
         crate::contracts::assert_shape_contract_periodically!(
-            ["batch", "len", "n_audio_states"],
+            ["batch", "len", "d_model"],
             &x,
             &[
-                ("batch", _batch),
+                ("batch", batch),
                 ("len", seq_len / 2),
-                ("n_audio_states", self.d_model()),
+                ("d_model", self.d_model()),
             ],
         );
 
-        let k = x.dims()[1];
-        let x = x + self
-            .positional_embedding
-            .weight
-            .val()
-            .slice(s![0..k])
-            .unsqueeze::<3>();
+        let x = self.embed(x);
 
-        let x = self.blocks.iter().fold(x, |z, b| b.forward(z));
+        let mut x = x;
+        for b in self.blocks.iter() {
+            x = b.forward(x);
+        }
 
         self.ln_post.forward(x)
+    }
+
+    fn embed(
+        &self,
+        x: Tensor<B, 3>,
+    ) -> Tensor<B, 3> {
+        let k = x.dims()[1];
+        x + self
+            .positional_embedding
+            .val()
+            .slice(s![0..k])
+            .unsqueeze::<3>()
     }
 }
 

--- a/crates/bunsen/src/kits/speech/whisper/blocks/text_decoder.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/text_decoder.rs
@@ -1,7 +1,10 @@
 use burn::{
     Tensor,
     config::Config,
-    module::Module,
+    module::{
+        Module,
+        Param,
+    },
     nn::{
         Embedding,
         EmbeddingConfig,
@@ -14,6 +17,7 @@ use burn::{
     },
     tensor::{
         Bool,
+        Distribution,
         Int,
     },
 };
@@ -25,6 +29,7 @@ use crate::{
         ResidualDecoderAttentionBlockConfig,
         ResidualDecoderAttentionBlockMeta,
     },
+    ops::embedding::unembed,
 };
 
 /// Common meta for [`TextDecoder`] and [`TextDecoderConfig`].
@@ -115,7 +120,11 @@ impl TextDecoderConfig {
         TextDecoder {
             token_embedding: EmbeddingConfig::new(self.vocab_size, self.d_model).init(device),
 
-            positional_embedding: EmbeddingConfig::new(self.max_context, self.d_model).init(device),
+            positional_embedding: Param::from_tensor(Tensor::<B, 2>::random(
+                [self.max_context, self.d_model],
+                Distribution::Normal(0.0, 1.0),
+                device,
+            )),
 
             blocks: (0..self.n_layers)
                 .map(|_| {
@@ -138,7 +147,7 @@ pub struct TextDecoder<B: Backend> {
     pub token_embedding: Embedding<B>,
 
     /// The positional embedding.
-    pub positional_embedding: Embedding<B>,
+    pub positional_embedding: Param<Tensor<B, 2>>,
 
     /// The decoder blocks.
     pub blocks: Vec<ResidualDecoderAttentionBlock<B>>,
@@ -158,7 +167,7 @@ impl<B: Backend> TextDecoderMeta for TextDecoder<B> {
     }
 
     fn max_context(&self) -> usize {
-        self.positional_embedding.weight.val().dims()[0]
+        self.positional_embedding.val().dims()[0]
     }
 
     fn n_heads(&self) -> usize {
@@ -184,8 +193,7 @@ impl<B: Backend> TextDecoder<B> {
         x: Tensor<B, 2, Int>,
         xa: Tensor<B, 3>,
     ) -> Tensor<B, 3> {
-        let [_n_batch, seq_len] = x.dims();
-
+        let [_batch, seq_len] = x.dims();
         assert!(
             seq_len <= self.max_context(),
             "Token sequence length {} must not exceed {}.",
@@ -193,34 +201,36 @@ impl<B: Backend> TextDecoder<B> {
             self.max_context()
         );
 
-        let x = self.token_embedding.forward(x)
-            + self
-                .positional_embedding
-                .weight
-                .val()
-                .slice(s![0..seq_len])
-                .unsqueeze::<3>();
+        let x = self.embed(x);
 
         //let mask = attn_decoder_mask(seq_len);
 
         let mask: Option<Tensor<B, 3, Bool>> = causal_mask(seq_len, 0, &x.device()).into();
 
-        let x = self
-            .blocks
-            .iter()
-            .fold(x, |z, b| b.forward(z, xa.clone(), mask.clone()).output);
+        let mut x = x;
+        for b in self.blocks.iter() {
+            x = b.forward(x, xa.clone(), mask.clone()).output;
+        }
 
         let x = self.ln.forward(x);
-        x.matmul(
-            self.token_embedding
-                .weight
-                .val()
-                .transpose()
-                .unsqueeze::<3>(),
-        )
+
+        unembed(&self.token_embedding, x)
 
         // denorm [batch, seq_len, n_vocab]
         // Needs softmax / beamsearch.
+    }
+
+    fn embed(
+        &self,
+        x: Tensor<B, 2, Int>,
+    ) -> Tensor<B, 3> {
+        let seq_len = x.dims()[1];
+        self.token_embedding.forward(x)
+            + self
+                .positional_embedding
+                .val()
+                .slice(s![0..seq_len])
+                .unsqueeze::<3>()
     }
 }
 

--- a/crates/bunsen/src/ops/embedding/inverse.rs
+++ b/crates/bunsen/src/ops/embedding/inverse.rs
@@ -1,0 +1,86 @@
+use burn::{
+    Tensor,
+    nn::Embedding,
+    prelude::Backend,
+};
+
+/// Argument to [unembed].
+pub trait EmbeddingArg<B: Backend> {
+    /// The embedding layer's weight.
+    fn weight(&self) -> Tensor<B, 2>;
+}
+
+impl<B: Backend> EmbeddingArg<B> for &Embedding<B> {
+    fn weight(&self) -> Tensor<B, 2> {
+        self.weight.val()
+    }
+}
+
+impl<B: Backend> EmbeddingArg<B> for Tensor<B, 2> {
+    fn weight(&self) -> Tensor<B, 2> {
+        self.clone()
+    }
+}
+
+/// Invert an Embedding layer to get logits.
+///
+/// # Arguments
+/// * `emb` - The `[n_vocab, d_model]`, embedding layer to invert.
+/// * `x` - The `[batch, seq_len, d_model]` tensor to unembed.
+///
+/// # Returns
+/// The logits tensor of shape `[batch, seq_len, n_vocab]`.
+pub fn unembed<B: Backend, A: EmbeddingArg<B>>(
+    emb: A,
+    x: Tensor<B, 3>,
+) -> Tensor<B, 3> {
+    x.matmul(emb.weight().transpose().unsqueeze::<3>())
+}
+
+#[cfg(test)]
+mod tests {
+    use burn::tensor::{
+        Distribution,
+        Int,
+    };
+    use serial_test::serial;
+
+    use super::*;
+    use crate::{
+        ops::embedding::identity_embedding,
+        support::testing::PerformanceBackend,
+    };
+
+    #[test]
+    #[serial]
+    fn test_embedding_inverse_to_logits() {
+        type B = PerformanceBackend;
+        let device = Default::default();
+
+        let n_embedding = 10;
+
+        let embedding = identity_embedding(n_embedding, &device);
+
+        let batch = 2;
+        let seq_len = 20;
+
+        let x: Tensor<B, 2, Int> = Tensor::random(
+            [batch, seq_len],
+            Distribution::Uniform(0.0, n_embedding as f64),
+            &device,
+        );
+
+        let e = embedding.forward(x.clone());
+
+        let logits = unembed(&embedding, e.clone());
+        let logits2 = unembed(embedding.weight.val(), e.clone());
+        logits
+            .clone()
+            .into_data()
+            .assert_eq(&logits2.into_data(), true);
+
+        let y: Tensor<B, 2, Int> = logits.argmax(2).squeeze_dim(2);
+
+        y.into_data().assert_eq(&x.into_data(), true);
+    }
+}

--- a/crates/bunsen/src/ops/embedding/mod.rs
+++ b/crates/bunsen/src/ops/embedding/mod.rs
@@ -1,0 +1,9 @@
+//! Embedding operations.
+
+mod inverse;
+mod trivial_builders;
+
+#[doc(inline)]
+pub use inverse::*;
+#[doc(inline)]
+pub use trivial_builders::*;

--- a/crates/bunsen/src/ops/embedding/trivial_builders.rs
+++ b/crates/bunsen/src/ops/embedding/trivial_builders.rs
@@ -1,0 +1,89 @@
+use burn::{
+    module::Param,
+    nn::Embedding,
+    tensor::{
+        Int,
+        Tensor,
+        backend::Backend,
+    },
+};
+
+/// Build an iota embedding.
+///
+/// weight[i, j] = i * d + j  — every row distinct, lookups hand-verifiable.
+pub fn iota_embedding<B: Backend>(
+    n: usize,
+    d: usize,
+    device: &B::Device,
+) -> Embedding<B> {
+    let weight = Tensor::<B, 1, Int>::arange(0..(n * d) as i64, device)
+        .float()
+        .reshape([n, d]);
+    Embedding {
+        weight: Param::from_tensor(weight),
+    }
+}
+
+/// Build a one-hot passthrough embedding.
+///
+/// Square identity (`num_embeddings` == dim == n): embedding acts as a one-hot
+/// passthrough.
+pub fn identity_embedding<B: Backend>(
+    n: usize,
+    device: &B::Device,
+) -> Embedding<B> {
+    Embedding {
+        weight: Param::from_tensor(Tensor::<B, 2>::eye(n, device)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::support::testing::PerformanceBackend;
+
+    #[test]
+    fn test_iota_embedding() {
+        let device = Default::default();
+        let n = 3;
+        let d = 4;
+        let emb = iota_embedding::<PerformanceBackend>(n, d, &device);
+
+        let weight = emb.weight.val();
+        let data = weight.to_data();
+
+        // Verify shape
+        assert_eq!(data.shape, [n, d].into());
+
+        // Verify values: weight[i, j] = i * d + j
+        for i in 0..n {
+            for j in 0..d {
+                let expected = (i * d + j) as f32;
+                let actual = data.iter::<f32>().nth(i * d + j).unwrap();
+                assert_eq!(actual, expected);
+            }
+        }
+    }
+
+    #[test]
+    fn test_identity_embedding() {
+        let device = Default::default();
+        let n = 5;
+        let emb = identity_embedding::<PerformanceBackend>(n, &device);
+
+        let weight = emb.weight.val();
+        let data = weight.to_data();
+
+        // Verify shape
+        assert_eq!(data.shape, [n, n].into());
+
+        // Verify identity matrix: 1.0 on diagonal, 0.0 elsewhere
+        for i in 0..n {
+            for j in 0..n {
+                let expected = if i == j { 1.0 } else { 0.0 };
+                let actual = data.iter::<f32>().nth(i * n + j).unwrap();
+                assert_eq!(actual, expected);
+            }
+        }
+    }
+}

--- a/crates/bunsen/src/ops/embedding/trivial_builders.rs
+++ b/crates/bunsen/src/ops/embedding/trivial_builders.rs
@@ -10,7 +10,7 @@ use burn::{
 
 /// Build an iota embedding.
 ///
-/// weight[i, j] = i * d + j  — every row distinct, lookups hand-verifiable.
+/// `weight[i, j] = i * d + j` - every row distinct, lookups hand-verifiable.
 pub fn iota_embedding<B: Backend>(
     n: usize,
     d: usize,
@@ -26,7 +26,7 @@ pub fn iota_embedding<B: Backend>(
 
 /// Build a one-hot passthrough embedding.
 ///
-/// Square identity (`num_embeddings` == dim == n): embedding acts as a one-hot
+/// Square identity (`num_embeddings == dim == n`): embedding acts as a one-hot
 /// passthrough.
 pub fn identity_embedding<B: Backend>(
     n: usize,

--- a/crates/bunsen/src/ops/mod.rs
+++ b/crates/bunsen/src/ops/mod.rs
@@ -68,6 +68,7 @@ pub mod arange;
 pub mod clamp;
 pub mod conv;
 pub mod drop;
+pub mod embedding;
 pub mod noise;
 pub mod norm;
 pub mod repeat;

--- a/examples/whisper-dev/src/main.rs
+++ b/examples/whisper-dev/src/main.rs
@@ -1,6 +1,17 @@
-use std::path::PathBuf;
+use std::{
+    collections::BTreeMap,
+    path::{
+        Path,
+        PathBuf,
+    },
+};
 
 use bunsen::kits::speech::whisper::pretrained::PytorchWhisperScanner;
+use burn_store::{
+    ModuleStore,
+    PytorchStore,
+    TensorSnapshot,
+};
 use clap::Parser;
 
 #[derive(Parser, Debug)]
@@ -15,6 +26,14 @@ pub struct Args {
     pub top_level_key: Option<String>,
 }
 
+pub fn pytorch_snapshots<P: AsRef<Path>>(
+    path: P
+) -> Result<BTreeMap<String, TensorSnapshot>, Box<dyn std::error::Error>> {
+    let mut store = PytorchStore::from_file(path.as_ref());
+    let snapshots = store.get_all_snapshots()?.clone();
+    Ok(snapshots)
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
     println!("{:#?}", args);
@@ -24,6 +43,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .scan_cfg(PathBuf::from(args.source.clone()))?;
 
     println!("{:#?}", cfg);
+
+    let snapshots = pytorch_snapshots(args.source)?;
+    println!("keys: {:#?}", snapshots.keys());
+
+    // positional_embedding => positional_embedding.weight
 
     Ok(())
 }


### PR DESCRIPTION
- Refactored `TextDecoder` and `AudioEncoder` for consistent use of `Param` with `positional_embedding`.
- Introduced `unembed`, `iota_embedding`, and `identity_embedding` functions to streamline embedding operations.
- Updated documentation for `iota_embedding` for improved clarity.
- Enhanced test coverage for new embedding functionalities.