### PR TITLE
Refactor MLP and Whisper modules for improved configuration clarity

### DIFF
--- a/crates/bunsen/src/blocks/transformers/mlp.rs
+++ b/crates/bunsen/src/blocks/transformers/mlp.rs
@@ -80,12 +80,12 @@ impl MlpConfig {
         device: &B::Device,
     ) -> Mlp<B> {
         Mlp {
-            c_fc: LinearConfig::new(self.n_embed(), self.hidden_size())
+            linear1: LinearConfig::new(self.n_embed(), self.hidden_size())
                 .with_bias(false)
                 .init(device),
             act: self.activation.init(device),
             act_exponent: self.act_exponent,
-            c_proj: LinearConfig::new(self.hidden_size(), self.n_embed())
+            linear2: LinearConfig::new(self.hidden_size(), self.n_embed())
                 .with_bias(false)
                 .init(device),
         }
@@ -101,7 +101,7 @@ impl MlpConfig {
 #[derive(Module, Debug)]
 pub struct Mlp<B: Backend> {
     /// Feed Forward Layer.
-    pub c_fc: Linear<B>,
+    pub linear1: Linear<B>,
 
     /// Activation.
     pub act: Activation<B>,
@@ -110,12 +110,12 @@ pub struct Mlp<B: Backend> {
     pub act_exponent: Option<f64>,
 
     /// Output Projection.
-    pub c_proj: Linear<B>,
+    pub linear2: Linear<B>,
 }
 
 impl<B: Backend> MlpMeta for Mlp<B> {
     fn n_embed(&self) -> usize {
-        self.c_fc.weight.dims()[0]
+        self.linear1.weight.dims()[0]
     }
 
     fn act_exponent(&self) -> Option<f64> {
@@ -143,7 +143,7 @@ impl<B: Backend> Mlp<B> {
             &[("embed", self.n_embed())]
         );
 
-        let x = self.c_fc.forward(x);
+        let x = self.linear1.forward(x);
         let x = self.act.forward(x);
 
         let x = match self.act_exponent {
@@ -151,7 +151,7 @@ impl<B: Backend> Mlp<B> {
             None => x,
         };
 
-        let x = self.c_proj.forward(x);
+        let x = self.linear2.forward(x);
 
         #[cfg(any(debug_assertions, test))]
         crate::contracts::assert_shape_contract_periodically!(
@@ -217,7 +217,7 @@ mod tests {
                     &[("batch", b), ("time", t), ("embed", n_embed)]
                 );
 
-                let x = mlp.c_fc.forward(x);
+                let x = mlp.linear1.forward(x);
                 assert_shape_contract!(
                     ["batch", "time", "hidden"],
                     &x.dims(),
@@ -232,7 +232,7 @@ mod tests {
                 );
 
                 let x = x.clone() * x;
-                let x = mlp.c_proj.forward(x);
+                let x = mlp.linear2.forward(x);
                 assert_shape_contract!(
                     ["batch", "time", "embed"],
                     &x.dims(),

--- a/crates/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs
@@ -70,11 +70,13 @@ pub struct AudioEncoderConfig {
     /// twice the internal positional embedding.
     pub max_context: usize,
 
-    /// Number of Audio Heads.
-    pub n_heads: usize,
-
     /// Number of Audio Layers.
     pub n_layers: usize,
+
+    /// Head Dimension.
+    /// Whisper always uses 64 here.
+    #[config(default = "64")]
+    pub d_head: usize,
 
     /// Head Activation.
     #[config(default = "ActivationConfig::Gelu")]
@@ -95,7 +97,7 @@ impl AudioEncoderMeta for AudioEncoderConfig {
     }
 
     fn n_heads(&self) -> usize {
-        self.n_heads
+        self.d_model / self.d_head
     }
 
     fn n_layers(&self) -> usize {
@@ -131,7 +133,8 @@ impl AudioEncoderConfig {
 
             blocks: (0..self.n_layers)
                 .map(|_| {
-                    ResidualEncoderAttentionBlockConfig::new(self.d_model, self.n_heads)
+                    ResidualEncoderAttentionBlockConfig::new(self.d_model)
+                        .with_d_head(self.d_head)
                         .init(device)
                 })
                 .collect(),
@@ -269,16 +272,10 @@ mod tests {
         let n_mels = 256;
         let max_audio_ctx = 100;
 
-        let n_audio_heads = 4;
         let n_audio_layers = 2;
 
-        let config = AudioEncoderConfig::new(
-            n_mels,
-            d_model,
-            max_audio_ctx,
-            n_audio_heads,
-            n_audio_layers,
-        );
+        let config = AudioEncoderConfig::new(n_mels, d_model, max_audio_ctx, n_audio_layers);
+        let n_audio_heads = config.n_heads();
 
         assert_eq!(config.n_mels(), n_mels);
         assert_eq!(config.d_model(), d_model);
@@ -301,13 +298,9 @@ mod tests {
         let output = encoder.forward(x.clone());
 
         assert_shape_contract!(
-            ["batch", "seq", "n_audio_states"],
+            ["batch", "seq", "d_model"],
             &output,
-            &[
-                ("batch", batch),
-                ("seq", k / 2),
-                ("n_audio_states", d_model),
-            ],
+            &[("batch", batch), ("seq", k / 2), ("d_model", d_model),],
         );
     }
 }

--- a/crates/bunsen/src/kits/speech/whisper/blocks/decoder_block.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/decoder_block.rs
@@ -47,8 +47,10 @@ pub struct ResidualDecoderAttentionBlockConfig {
     /// Return the embedding dimensionality.
     pub d_model: usize,
 
-    /// Number of Heads.
-    pub n_heads: usize,
+    /// Head Dimension.
+    /// Whisper always uses 64 here.
+    #[config(default = "64")]
+    pub d_head: usize,
 
     /// Dropout.
     #[config(default = "0.0")]
@@ -61,7 +63,7 @@ impl ResidualDecoderAttentionBlockMeta for ResidualDecoderAttentionBlockConfig {
     }
 
     fn n_heads(&self) -> usize {
-        self.n_heads
+        self.d_model / self.d_head
     }
 
     fn dropout(&self) -> f64 {
@@ -76,7 +78,7 @@ impl ResidualDecoderAttentionBlockConfig {
         device: &B::Device,
     ) -> ResidualDecoderAttentionBlock<B> {
         let mha_cfg =
-            MultiHeadAttentionConfig::new(self.d_model, self.n_heads).with_dropout(self.dropout);
+            MultiHeadAttentionConfig::new(self.d_model, self.n_heads()).with_dropout(self.dropout);
         let ln_cfg = LayerNormConfig::new(self.d_model);
 
         ResidualDecoderAttentionBlock {
@@ -204,10 +206,10 @@ mod tests {
         type B = crate::support::testing::PerformanceBackend;
         let device = Default::default();
 
-        let n_heads = 4;
-        let d_model = 32 * n_heads;
+        let d_model = 128;
 
-        let cfg = ResidualDecoderAttentionBlockConfig::new(d_model, n_heads);
+        let cfg = ResidualDecoderAttentionBlockConfig::new(d_model);
+        let n_heads = cfg.n_heads();
 
         assert_eq!(cfg.d_model(), d_model);
         assert_eq!(cfg.n_heads(), n_heads);

--- a/crates/bunsen/src/kits/speech/whisper/blocks/encoder_block.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/encoder_block.rs
@@ -41,8 +41,10 @@ pub struct ResidualEncoderAttentionBlockConfig {
     /// Return the embedding dimensionality.
     pub d_model: usize,
 
-    /// Number of Heads.
-    pub n_heads: usize,
+    /// Head Dimension.
+    /// Whisper always uses 64 here.
+    #[config(default = "64")]
+    pub d_head: usize,
 
     /// Dropout.
     #[config(default = "0.0")]
@@ -55,7 +57,7 @@ impl ResidualEncoderAttentionBlockMeta for ResidualEncoderAttentionBlockConfig {
     }
 
     fn n_heads(&self) -> usize {
-        self.n_heads
+        self.d_model / self.d_head
     }
 
     fn dropout(&self) -> f64 {
@@ -70,7 +72,7 @@ impl ResidualEncoderAttentionBlockConfig {
         device: &B::Device,
     ) -> ResidualEncoderAttentionBlock<B> {
         let mha_cfg =
-            MultiHeadAttentionConfig::new(self.d_model, self.n_heads).with_dropout(self.dropout);
+            MultiHeadAttentionConfig::new(self.d_model, self.n_heads()).with_dropout(self.dropout);
         let ln_cfg = LayerNormConfig::new(self.d_model);
 
         ResidualEncoderAttentionBlock {
@@ -149,9 +151,9 @@ mod tests {
         let device = Default::default();
 
         let d_model = 128;
-        let n_heads = 4;
 
-        let cfg = ResidualEncoderAttentionBlockConfig::new(d_model, n_heads);
+        let cfg = ResidualEncoderAttentionBlockConfig::new(d_model);
+        let n_heads = cfg.n_heads();
 
         assert_eq!(cfg.d_model(), d_model);
         assert_eq!(cfg.n_heads(), n_heads);

--- a/crates/bunsen/src/kits/speech/whisper/blocks/text_decoder.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/text_decoder.rs
@@ -62,11 +62,13 @@ pub struct TextDecoderConfig {
     /// Maximum text context size.
     pub max_context: usize,
 
-    /// The number of heads.
-    pub n_heads: usize,
-
     /// The number of layers.
     pub n_layers: usize,
+
+    /// Head Dimension.
+    /// Whisper always uses 64 here.
+    #[config(default = "64")]
+    pub d_head: usize,
 
     /// Dropout.
     #[config(default = "0.0")]
@@ -87,7 +89,7 @@ impl TextDecoderMeta for TextDecoderConfig {
     }
 
     fn n_heads(&self) -> usize {
-        self.n_heads
+        self.d_model / self.d_head
     }
 
     fn n_layers(&self) -> usize {
@@ -128,7 +130,8 @@ impl TextDecoderConfig {
 
             blocks: (0..self.n_layers)
                 .map(|_| {
-                    ResidualDecoderAttentionBlockConfig::new(self.d_model, self.n_heads)
+                    ResidualDecoderAttentionBlockConfig::new(self.d_model)
+                        .with_d_head(self.d_head)
                         .with_dropout(self.block_dropout)
                         .init(device)
                 })
@@ -253,10 +256,9 @@ mod tests {
         let d_model = 128;
         let vocab_size = 64;
         let max_context = 128;
-        let n_heads = 4;
         let n_layers = 2;
 
-        let config = TextDecoderConfig::new(vocab_size, d_model, max_context, n_heads, n_layers);
+        let config = TextDecoderConfig::new(vocab_size, d_model, max_context, n_layers);
 
         assert_eq!(config.vocab_size(), vocab_size);
         assert_eq!(config.d_model(), d_model);

--- a/crates/bunsen/src/kits/speech/whisper/blocks/whisper_model.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/whisper_model.rs
@@ -23,11 +23,23 @@ pub struct PassConfig {
     /// Maximum Context Size.
     pub max_ctx: usize,
 
-    /// Number of Heads.
-    pub n_heads: usize,
-
     /// Number of Layers.
     pub n_layers: usize,
+
+    /// Head Dimension.
+    /// Whisper always uses 64 here.
+    #[config(default = "64")]
+    pub d_head: usize,
+}
+
+impl PassConfig {
+    /// The number of heads for the given model dimension.
+    pub fn n_heads(
+        &self,
+        d_model: usize,
+    ) -> usize {
+        d_model / self.d_head
+    }
 }
 
 /// Whisper API config.
@@ -42,11 +54,22 @@ pub struct WhisperApiConfig {
     /// Embedding Size of the Model.
     pub d_model: usize,
 
-    /// API config for the encoder pass.
-    pub audio_encoder: PassConfig,
+    /// Maximum Audio Encoder Context Size.
+    pub max_audio_ctx: usize,
 
-    /// API config for the decoder pass.
-    pub text_decoder: PassConfig,
+    /// Number Audio Encoder of Layers.
+    pub n_encoder_layers: usize,
+
+    /// Maximum Text Decoder Context Size.
+    pub max_text_ctx: usize,
+
+    /// Number Text Decoder of Layers.
+    pub n_decoder_layers: usize,
+
+    /// Head Dimension.
+    /// Whisper always uses 64 here.
+    #[config(default = "64")]
+    pub d_head: usize,
 }
 
 impl WhisperApiConfig {
@@ -56,17 +79,17 @@ impl WhisperApiConfig {
             encoder: AudioEncoderConfig::new(
                 self.n_mels,
                 self.d_model,
-                self.audio_encoder.max_ctx,
-                self.audio_encoder.n_heads,
-                self.audio_encoder.n_layers,
-            ),
+                self.max_audio_ctx,
+                self.n_encoder_layers,
+            )
+            .with_d_head(self.d_head),
             decoder: TextDecoderConfig::new(
                 self.vocab_size,
                 self.d_model,
-                self.text_decoder.max_ctx,
-                self.text_decoder.n_heads,
-                self.text_decoder.n_layers,
-            ),
+                self.max_text_ctx,
+                self.n_decoder_layers,
+            )
+            .with_d_head(self.d_head),
         }
     }
 }
@@ -229,30 +252,25 @@ mod tests {
         let vocab_size = 64;
 
         let max_audio_ctx = 128;
-        let n_audio_heads = 4;
         let n_audio_layers = 2;
 
         let max_text_context = 128;
-        let n_text_heads = 4;
         let n_text_layers = 2;
 
-        let config = WhisperApiConfig {
+        let config = WhisperApiConfig::new(
             n_mels,
             vocab_size,
             d_model,
-            audio_encoder: PassConfig {
-                max_ctx: max_audio_ctx,
-                n_heads: n_audio_heads,
-                n_layers: n_audio_layers,
-            },
-            text_decoder: PassConfig {
-                max_ctx: max_text_context,
-                n_heads: n_text_heads,
-                n_layers: n_text_layers,
-            },
-        };
+            max_audio_ctx,
+            n_audio_layers,
+            max_text_context,
+            n_text_layers,
+        );
 
         let structural = config.to_structure();
+
+        let n_audio_heads = structural.encoder.n_heads();
+        let n_text_heads = structural.decoder.n_heads();
 
         assert_eq!(structural.n_mels(), n_mels);
         assert_eq!(structural.vocab_size(), vocab_size);

--- a/crates/bunsen/src/kits/speech/whisper/pretrained/pytorch_utils.rs
+++ b/crates/bunsen/src/kits/speech/whisper/pretrained/pytorch_utils.rs
@@ -9,10 +9,7 @@ use burn_store::{
     PytorchStore,
 };
 
-use crate::kits::speech::whisper::blocks::{
-    PassConfig,
-    WhisperApiConfig,
-};
+use crate::kits::speech::whisper::blocks::WhisperApiConfig;
 
 fn block_layers_from_keys<S: AsRef<str>>(
     kind: &str,
@@ -32,6 +29,10 @@ pub struct PytorchWhisperScanner {
     /// Top-level key in the model state dict.
     #[config(default_value = "Some(\"model_state_dict\".to_string())")]
     pub top_level_key: Option<String>,
+
+    /// Head Dimension.
+    #[config(default = "64")]
+    pub d_head: usize,
 }
 
 impl PytorchWhisperScanner {
@@ -77,25 +78,18 @@ impl PytorchWhisperScanner {
             .shape
             .dims();
 
-        // n_layers isn't recoverable from ModelStore.
-
         let encoder_layers = block_layers_from_keys("encoder", &keys);
         let decoder_layers = block_layers_from_keys("decoder", &keys);
 
-        Ok(WhisperApiConfig {
+        Ok(WhisperApiConfig::new(
             n_mels,
             vocab_size,
             d_model,
-            audio_encoder: PassConfig {
-                max_ctx: max_audio_ctx,
-                n_heads: 1,
-                n_layers: encoder_layers,
-            },
-            text_decoder: PassConfig {
-                max_ctx: max_text_ctx,
-                n_heads: 1,
-                n_layers: decoder_layers,
-            },
-        })
+            max_audio_ctx,
+            encoder_layers,
+            max_text_ctx,
+            decoder_layers,
+        )
+        .with_d_head(self.d_head))
     }
 }

--- a/examples/whisper-dev/src/main.rs
+++ b/examples/whisper-dev/src/main.rs
@@ -47,7 +47,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let snapshots = pytorch_snapshots(args.source)?;
     println!("keys: {:#?}", snapshots.keys());
 
-    // positional_embedding => positional_embedding.weight
+    // mlp.([01]) => mlp.linear\1
 
     Ok(())
 }


### PR DESCRIPTION
- Rename MLP layers (`c_fc` -> `linear1`, `c_proj` -> `linear2`) for consistent terminology.
- Replace `n_heads` field with `d_head` in Whisper modules for dynamic computation of head count.
- Update `WhisperApiConfig` to simplify dependencies (`PassConfig` removed).
- Adjust tests and initialization logic to align with the refactored structures.
