### PR TITLE
Define and reuse constant for Whisper head dimensionality

### DIFF
--- a/crates/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs
@@ -25,6 +25,7 @@ use burn::{
     tensor::Distribution,
 };
 
+use super::WHISPER_DEFAULT_D_MODEL;
 use crate::{
     contracts::unpack_shape_contract,
     kits::speech::whisper::blocks::{
@@ -73,9 +74,8 @@ pub struct AudioEncoderConfig {
     /// Number of Audio Layers.
     pub n_layers: usize,
 
-    /// Head Dimension.
-    /// Whisper always uses 64 here.
-    #[config(default = "64")]
+    /// Head Dimensionality.
+    #[config(defaul_value = "WHISPER_DEFAULT_D_MODEL")]
     pub d_head: usize,
 
     /// Head Activation.

--- a/crates/bunsen/src/kits/speech/whisper/blocks/decoder_block.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/decoder_block.rs
@@ -16,6 +16,7 @@ use burn::{
     },
 };
 
+use super::WHISPER_DEFAULT_D_MODEL;
 use crate::blocks::transformers::{
     attention::{
         layer_norm_cross_attn,
@@ -47,9 +48,8 @@ pub struct ResidualDecoderAttentionBlockConfig {
     /// Return the embedding dimensionality.
     pub d_model: usize,
 
-    /// Head Dimension.
-    /// Whisper always uses 64 here.
-    #[config(default = "64")]
+    /// Head Dimensionality.
+    #[config(defaul_value = "WHISPER_DEFAULT_D_MODEL")]
     pub d_head: usize,
 
     /// Dropout.

--- a/crates/bunsen/src/kits/speech/whisper/blocks/decoder_block.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/decoder_block.rs
@@ -81,11 +81,18 @@ impl ResidualDecoderAttentionBlockConfig {
             MultiHeadAttentionConfig::new(self.d_model, self.n_heads()).with_dropout(self.dropout);
         let ln_cfg = LayerNormConfig::new(self.d_model);
 
+        // Whisper doesn't use a key bias;
+        // MHA doesn't let us configure this.
+        let mut attn = mha_cfg.init(device);
+        let mut cross_attn = mha_cfg.init(device);
+        attn.key.bias = None;
+        cross_attn.key.bias = None;
+
         ResidualDecoderAttentionBlock {
             attn_ln: ln_cfg.init(device),
-            attn: mha_cfg.init(device),
+            attn,
             cross_attn_ln: ln_cfg.init(device),
-            cross_attn: mha_cfg.init(device),
+            cross_attn,
             mlp_ln: ln_cfg.init(device),
             mlp: MlpConfig::new(self.d_model).init(device),
         }

--- a/crates/bunsen/src/kits/speech/whisper/blocks/encoder_block.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/encoder_block.rs
@@ -75,9 +75,14 @@ impl ResidualEncoderAttentionBlockConfig {
             MultiHeadAttentionConfig::new(self.d_model, self.n_heads()).with_dropout(self.dropout);
         let ln_cfg = LayerNormConfig::new(self.d_model);
 
+        // Whisper doesn't use a key bias;
+        // MHA doesn't let us configure this.
+        let mut attn = mha_cfg.init(device);
+        attn.key.bias = None;
+
         ResidualEncoderAttentionBlock {
             attn_ln: ln_cfg.init(device),
-            attn: mha_cfg.init(device),
+            attn,
             mlp_ln: ln_cfg.init(device),
             mlp: MlpConfig::new(self.d_model).init(device),
         }

--- a/crates/bunsen/src/kits/speech/whisper/blocks/encoder_block.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/encoder_block.rs
@@ -13,6 +13,7 @@ use burn::{
     prelude::Backend,
 };
 
+use super::WHISPER_DEFAULT_D_MODEL;
 use crate::blocks::transformers::{
     attention::layer_norm_self_attn,
     mlp::{
@@ -41,9 +42,8 @@ pub struct ResidualEncoderAttentionBlockConfig {
     /// Return the embedding dimensionality.
     pub d_model: usize,
 
-    /// Head Dimension.
-    /// Whisper always uses 64 here.
-    #[config(default = "64")]
+    /// Head Dimensionality.
+    #[config(defaul_value = "WHISPER_DEFAULT_D_MODEL")]
     pub d_head: usize,
 
     /// Dropout.

--- a/crates/bunsen/src/kits/speech/whisper/blocks/mod.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/mod.rs
@@ -1,5 +1,8 @@
 //! Whisper Component Blocks
 
+/// Default Whisper Head Dimensionality.
+pub const WHISPER_DEFAULT_D_MODEL: usize = 64;
+
 mod audio_encoder;
 mod decoder_block;
 mod encoder_block;

--- a/crates/bunsen/src/kits/speech/whisper/blocks/text_decoder.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/text_decoder.rs
@@ -22,6 +22,7 @@ use burn::{
     },
 };
 
+use super::WHISPER_DEFAULT_D_MODEL;
 use crate::{
     blocks::transformers::attention::causal_mask,
     kits::speech::whisper::blocks::{
@@ -65,9 +66,8 @@ pub struct TextDecoderConfig {
     /// The number of layers.
     pub n_layers: usize,
 
-    /// Head Dimension.
-    /// Whisper always uses 64 here.
-    #[config(default = "64")]
+    /// Head Dimensionality.
+    #[config(defaul_value = "WHISPER_DEFAULT_D_MODEL")]
     pub d_head: usize,
 
     /// Dropout.

--- a/crates/bunsen/src/kits/speech/whisper/blocks/whisper_model.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/whisper_model.rs
@@ -8,6 +8,7 @@ use burn::{
     },
 };
 
+use super::WHISPER_DEFAULT_D_MODEL;
 use crate::kits::speech::whisper::blocks::{
     AudioEncoder,
     AudioEncoderConfig,
@@ -16,31 +17,6 @@ use crate::kits::speech::whisper::blocks::{
     TextDecoderConfig,
     TextDecoderMeta,
 };
-
-/// API config for a pass in the Whisper model.
-#[derive(Config, Debug)]
-pub struct PassConfig {
-    /// Maximum Context Size.
-    pub max_ctx: usize,
-
-    /// Number of Layers.
-    pub n_layers: usize,
-
-    /// Head Dimension.
-    /// Whisper always uses 64 here.
-    #[config(default = "64")]
-    pub d_head: usize,
-}
-
-impl PassConfig {
-    /// The number of heads for the given model dimension.
-    pub fn n_heads(
-        &self,
-        d_model: usize,
-    ) -> usize {
-        d_model / self.d_head
-    }
-}
 
 /// Whisper API config.
 #[derive(Config, Debug)]
@@ -66,9 +42,8 @@ pub struct WhisperApiConfig {
     /// Number Text Decoder of Layers.
     pub n_decoder_layers: usize,
 
-    /// Head Dimension.
-    /// Whisper always uses 64 here.
-    #[config(default = "64")]
+    /// Head Dimensionality.
+    #[config(defaul_value = "WHISPER_DEFAULT_D_MODEL")]
     pub d_head: usize,
 }
 

--- a/crates/bunsen/src/kits/speech/whisper/pretrained/pytorch_utils.rs
+++ b/crates/bunsen/src/kits/speech/whisper/pretrained/pytorch_utils.rs
@@ -9,7 +9,10 @@ use burn_store::{
     PytorchStore,
 };
 
-use crate::kits::speech::whisper::blocks::WhisperApiConfig;
+use crate::kits::speech::whisper::blocks::{
+    WHISPER_DEFAULT_D_MODEL,
+    WhisperApiConfig,
+};
 
 fn block_layers_from_keys<S: AsRef<str>>(
     kind: &str,
@@ -30,8 +33,8 @@ pub struct PytorchWhisperScanner {
     #[config(default_value = "Some(\"model_state_dict\".to_string())")]
     pub top_level_key: Option<String>,
 
-    /// Head Dimension.
-    #[config(default = "64")]
+    /// Head Dimensionality.
+    #[config(defaul_value = "WHISPER_DEFAULT_D_MODEL")]
     pub d_head: usize,
 }
 

--- a/crates/bunsen/src/kits/speech/whisper/pretrained/pytorch_utils.rs
+++ b/crates/bunsen/src/kits/speech/whisper/pretrained/pytorch_utils.rs
@@ -45,15 +45,24 @@ impl PytorchWhisperScanner {
     pub fn scan_cfg<P: AsRef<Path>>(
         &self,
         path: P,
-    ) -> Result<WhisperApiConfig, Box<dyn std::error::Error>> {
+    ) -> Result<(PytorchStore, WhisperApiConfig), Box<dyn std::error::Error>> {
         let path = path.as_ref();
         let path: PathBuf = path.to_path_buf();
 
-        let store = PytorchStore::from_file(path.clone());
-        let mut store = match &self.top_level_key {
+        let store = PytorchStore::from_file(path.clone())
+            .map_indices_contiguous(false)
+            .with_key_remapping(r"\.attn\.out", ".attn.output")
+            .with_key_remapping(r"\.cross_attn\.out", ".cross_attn.output")
+            .with_key_remapping(r"\.mlp\.2", ".mlp.linear2")
+            .with_key_remapping(r"\.mlp\.0", ".mlp.linear1");
+
+        let store = match &self.top_level_key {
             Some(k) => store.with_top_level_key(k),
             None => store,
         };
+
+        let mut store = store;
+
         let keys = store.keys()?;
 
         let [d_model, n_mels] = store
@@ -84,15 +93,18 @@ impl PytorchWhisperScanner {
         let encoder_layers = block_layers_from_keys("encoder", &keys);
         let decoder_layers = block_layers_from_keys("decoder", &keys);
 
-        Ok(WhisperApiConfig::new(
-            n_mels,
-            vocab_size,
-            d_model,
-            max_audio_ctx,
-            encoder_layers,
-            max_text_ctx,
-            decoder_layers,
-        )
-        .with_d_head(self.d_head))
+        Ok((
+            store,
+            WhisperApiConfig::new(
+                n_mels,
+                vocab_size,
+                d_model,
+                max_audio_ctx,
+                encoder_layers,
+                max_text_ctx,
+                decoder_layers,
+            )
+            .with_d_head(self.d_head),
+        ))
     }
 }

--- a/examples/whisper-dev/Cargo.toml
+++ b/examples/whisper-dev/Cargo.toml
@@ -12,7 +12,7 @@ license.workspace = true
 workspace = true
 
 [features]
-default = ["cuda"]
+default = ["flex"]
 cuda = ["burn/cuda", "bunsen/cuda"]
 metal = ["burn/metal", "bunsen/metal"]
 wgpu = ["burn/wgpu", "bunsen/metal"]

--- a/examples/whisper-dev/Cargo.toml
+++ b/examples/whisper-dev/Cargo.toml
@@ -12,12 +12,15 @@ license.workspace = true
 workspace = true
 
 [features]
-default = []
+default = ["cuda"]
 cuda = ["burn/cuda", "bunsen/cuda"]
+metal = ["burn/metal", "bunsen/metal"]
+wgpu = ["burn/wgpu", "bunsen/metal"]
+flex = ["burn/flex", "bunsen/flex"]
 
 
 [dependencies]
-burn = { workspace = true, features = ["store"] }
+burn = { workspace = true, features = ["store", "fusion"] }
 burn-store = { workspace = true, features = ["pytorch"] }
 
 bunsen = { path = "../../crates/bunsen" }

--- a/examples/whisper-dev/src/main.rs
+++ b/examples/whisper-dev/src/main.rs
@@ -1,17 +1,14 @@
-use std::{
-    collections::BTreeMap,
-    path::{
-        Path,
-        PathBuf,
+use std::path::PathBuf;
+
+use bunsen::{
+    errors::WithOkOrPanic,
+    kits::speech::whisper::{
+        blocks::Whisper,
+        pretrained::PytorchWhisperScanner,
     },
 };
-
-use bunsen::kits::speech::whisper::pretrained::PytorchWhisperScanner;
-use burn_store::{
-    ModuleStore,
-    PytorchStore,
-    TensorSnapshot,
-};
+use burn::prelude::Backend;
+use burn_store::ModuleSnapshot;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
@@ -26,28 +23,43 @@ pub struct Args {
     pub top_level_key: Option<String>,
 }
 
-pub fn pytorch_snapshots<P: AsRef<Path>>(
-    path: P
-) -> Result<BTreeMap<String, TensorSnapshot>, Box<dyn std::error::Error>> {
-    let mut store = PytorchStore::from_file(path.as_ref());
-    let snapshots = store.get_all_snapshots()?.clone();
-    Ok(snapshots)
-}
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
     println!("{:#?}", args);
 
-    let cfg = PytorchWhisperScanner::new()
+    cfg_select! {
+        feature = "cuda" => {
+            run::<burn::backend::cuda::Cuda>(args)
+        }
+        feature = "metal" => {
+            run::<burn::backend::metal::Metal>(args)
+        }
+        feature = "wgpu" => {
+            run::<burn::backend::wgpu::Wgpu>(args)
+        }
+        feature = "flex" => {
+            run::<burn::backend::flex::Flex>(args)
+        }
+        _ => {
+            panic!("No Backend enabled");
+        }
+    }
+}
+
+#[allow(unused)]
+fn run<B: Backend>(args: Args) -> Result<(), Box<dyn std::error::Error>> {
+    let (mut store, cfg) = PytorchWhisperScanner::new()
         .with_top_level_key(args.top_level_key.clone())
         .scan_cfg(PathBuf::from(args.source.clone()))?;
 
     println!("{:#?}", cfg);
+    // println!("keys: {:#?}", store.keys());
 
-    let snapshots = pytorch_snapshots(args.source)?;
-    println!("keys: {:#?}", snapshots.keys());
+    let device = Default::default();
 
-    // mlp.([01]) => mlp.linear\1
+    let mut whisper: Whisper<B> = cfg.to_structure().init(&device);
+
+    whisper.load_from(&mut store).ok_or_panic();
 
     Ok(())
 }


### PR DESCRIPTION
Replaces hardcoded values with a reusable `WHISPER_DEFAULT_D_MODEL` constant for head dimensionality across Whisper modules. This improves code maintainability and avoids duplication.