### PR TITLE
Introduce `ModuleInit` trait for module initialization standardization

### DIFF
--- a/crates/bunsen/src/blocks/images/conv/cna.rs
+++ b/crates/bunsen/src/blocks/images/conv/cna.rs
@@ -31,9 +31,13 @@ use burn::{
     },
 };
 
-use crate::contracts::{
-    assert_shape_contract_periodically,
-    unpack_shape_contract,
+use crate::{
+    burner::module::ModuleInit,
+    contracts::{
+        assert_shape_contract_periodically,
+        unpack_shape_contract,
+    },
+    errors::BunsenResult,
 };
 
 /// Abstract policy for [`CNA2d`] Config.
@@ -90,6 +94,9 @@ pub trait CNA2dMeta {
 /// [`CNA2d`] Config.
 ///
 /// Implements [`CNA2dMeta`].
+///
+/// Auto-matches the norm layer input channels
+/// to the conv layer's output channels.
 #[derive(Config, Debug)]
 pub struct CNA2dConfig {
     /// The [`Conv2d`] config.
@@ -122,22 +129,6 @@ impl CNA2dMeta for CNA2dConfig {
 }
 
 impl CNA2dConfig {
-    /// Initialize a [`CNA2d`].
-    ///
-    /// Auto-matches the norm layer input channels
-    /// to the conv layer's output channels.
-    pub fn init<B: Backend>(
-        self,
-        device: &B::Device,
-    ) -> CNA2d<B> {
-        let out_channels = self.out_channels();
-        CNA2d {
-            conv: self.conv.init(device),
-            norm: self.norm.with_num_features(out_channels).init(device),
-            act: self.act.init(device),
-        }
-    }
-
     /// Adjust the norm features to match the conv output size.
     ///
     /// [`Self::init`] does this automatically.
@@ -145,6 +136,26 @@ impl CNA2dConfig {
         let features = self.out_channels();
         let norm = self.norm.with_num_features(features);
         Self { norm, ..self }
+    }
+}
+
+/// Auto-matches the norm layer input channels
+/// to the conv layer's output channels.
+impl<B: Backend> ModuleInit<B, CNA2d<B>> for CNA2dConfig {
+    fn try_init(
+        &self,
+        device: &B::Device,
+    ) -> BunsenResult<CNA2d<B>> {
+        let out_channels = self.out_channels();
+        Ok(CNA2d {
+            conv: self.conv.init(device),
+            norm: self
+                .norm
+                .clone()
+                .with_num_features(out_channels)
+                .init(device),
+            act: self.act.init(device),
+        })
     }
 }
 

--- a/crates/bunsen/src/blocks/images/conv/conv_norm.rs
+++ b/crates/bunsen/src/blocks/images/conv/conv_norm.rs
@@ -21,9 +21,12 @@ use burn::{
     },
 };
 
-use crate::contracts::{
-    assert_shape_contract_periodically,
-    unpack_shape_contract,
+use crate::{
+    burner::module::ModuleInit,
+    contracts::{
+        assert_shape_contract_periodically,
+        unpack_shape_contract,
+    },
 };
 
 /// [`ConvNorm2d`] Meta.
@@ -73,18 +76,6 @@ impl From<Conv2dConfig> for ConvNorm2dConfig {
 }
 
 impl ConvNorm2dConfig {
-    /// Initialize a [`ConvNorm2d`].
-    pub fn init<B: Backend>(
-        self,
-        device: &B::Device,
-    ) -> ConvNorm2d<B> {
-        ConvNorm2d {
-            conv: self.conv.init(device),
-
-            norm: BatchNormConfig::new(self.conv.channels[1]).init(device),
-        }
-    }
-
     /// Set the initializer.
     pub fn with_initializer(
         self,
@@ -93,6 +84,19 @@ impl ConvNorm2dConfig {
         Self {
             conv: self.conv.with_initializer(initializer),
         }
+    }
+}
+
+impl<B: Backend> ModuleInit<B, ConvNorm2d<B>> for ConvNorm2dConfig {
+    fn try_init(
+        &self,
+        device: &B::Device,
+    ) -> crate::errors::BunsenResult<ConvNorm2d<B>> {
+        Ok(ConvNorm2d {
+            conv: self.conv.init(device),
+
+            norm: BatchNormConfig::new(self.conv.channels[1]).init(device),
+        })
     }
 }
 

--- a/crates/bunsen/src/blocks/images/patching/patch_embed.rs
+++ b/crates/bunsen/src/blocks/images/patching/patch_embed.rs
@@ -16,7 +16,11 @@ use burn::{
     },
 };
 
-use crate::contracts::assert_shape_contract_periodically;
+use crate::{
+    burner::module::ModuleInit,
+    contracts::assert_shape_contract_periodically,
+    errors::BunsenResult,
+};
 
 /// Common introspection interface for `PatchEmbed` module.
 pub trait PatchEmbedMeta {
@@ -108,21 +112,11 @@ impl PatchEmbedMeta for PatchEmbedConfig {
     }
 }
 
-impl PatchEmbedConfig {
-    /// Initialize a `PatchEmbed` module with the given configuration.
-    ///
-    /// # Arguments
-    ///
-    /// * `device` - The device on which the module will be initialized.
-    ///
-    /// # Returns
-    ///
-    /// * A `PatchEmbed` module configured with the specified parameters.
-    #[must_use]
-    pub fn init<B: Backend>(
+impl<B: Backend> ModuleInit<B, PatchEmbed<B>> for PatchEmbedConfig {
+    fn try_init(
         &self,
         device: &B::Device,
-    ) -> PatchEmbed<B> {
+    ) -> BunsenResult<PatchEmbed<B>> {
         let [h, w] = self.input_resolution;
         assert!(
             h % self.patch_size == 0 && w % self.patch_size == 0,
@@ -132,7 +126,7 @@ impl PatchEmbedConfig {
 
         let stride = [self.patch_size, self.patch_size];
 
-        PatchEmbed {
+        let module = PatchEmbed {
             input_resolution: self.input_resolution,
             patch_size: self.patch_size,
             projection: Conv2dConfig::new([self.d_input, self.d_output], stride)
@@ -142,7 +136,9 @@ impl PatchEmbedConfig {
                 true => Some(LayerNormConfig::new(self.d_output()).init(device)),
                 false => None,
             },
-        }
+        };
+
+        Ok(module)
     }
 }
 
@@ -258,7 +254,10 @@ mod tests {
     use burn::tensor::TensorData;
 
     use super::*;
-    use crate::support::testing::CpuBackend;
+    use crate::{
+        errors::WithOkOrPanic,
+        support::testing::CpuBackend,
+    };
 
     #[test]
     fn test_patch_embed_meta() {
@@ -284,7 +283,7 @@ mod tests {
         assert!(config.enable_patch_norm());
 
         let device = Default::default();
-        let patch_embed = config.init::<B>(&device);
+        let patch_embed: PatchEmbed<B> = config.try_init(&device).ok_or_panic();
 
         assert_eq!(patch_embed.input_resolution(), [224, 224]);
         assert_eq!(patch_embed.patch_size(), 16);
@@ -311,7 +310,7 @@ mod tests {
             enable_patch_norm: true,
         };
         let device = Default::default();
-        let _d = config.init::<B>(&device);
+        let _d: PatchEmbed<B> = config.try_init(&device).ok_or_panic();
     }
 
     #[test]
@@ -325,7 +324,7 @@ mod tests {
             enable_patch_norm: true,
         };
         let device = Default::default();
-        let patch_embed = config.init::<B>(&device);
+        let patch_embed = config.try_init(&device).ok_or_panic();
 
         let input = Tensor::<B, 4>::from_data(
             TensorData::new(vec![1.0; 3 * 224 * 224], [1, 3, 224, 224]),
@@ -347,7 +346,7 @@ mod tests {
             enable_patch_norm: false,
         };
         let device = Default::default();
-        let patch_embed = config.init::<B>(&device);
+        let patch_embed = config.try_init(&device).ok_or_panic();
 
         let input = Tensor::<B, 4>::from_data(
             TensorData::new(vec![1.0; 3 * 224 * 224], [1, 3, 224, 224]),

--- a/crates/bunsen/src/blocks/transformers/attention/csa.rs
+++ b/crates/bunsen/src/blocks/transformers/attention/csa.rs
@@ -36,6 +36,10 @@ use crate::{
         assert_shape_contract_periodically,
         unpack_shape_contract,
     },
+    errors::{
+        BunsenResult,
+        WithOkOrPanic,
+    },
 };
 
 /// Common meta for [`CausalSelfAttention`] and [`CausalSelfAttentionConfig`].
@@ -135,15 +139,15 @@ impl CausalSelfAttentionConfig {
 
 impl CausalSelfAttentionConfig {
     /// Initialize the module.
-    pub fn init<B: Backend>(
-        self,
+    pub fn try_init<B: Backend>(
+        &self,
         layer_index: usize,
         device: &B::Device,
-    ) -> CausalSelfAttention<B> {
+    ) -> BunsenResult<CausalSelfAttention<B>> {
         self.validate();
         let head_dim = self.head_dim();
 
-        CausalSelfAttention {
+        Ok(CausalSelfAttention {
             layer_index,
             head_dim,
             c_q: LinearConfig::new(self.n_embed, self.n_head * head_dim)
@@ -168,7 +172,16 @@ impl CausalSelfAttentionConfig {
             c_proj: LinearConfig::new(self.n_embed, self.n_embed)
                 .with_bias(false)
                 .init(device),
-        }
+        })
+    }
+
+    /// Initialize the module, or panic.
+    pub fn init<B: Backend>(
+        &self,
+        layer_index: usize,
+        device: &B::Device,
+    ) -> CausalSelfAttention<B> {
+        self.try_init(layer_index, device).ok_or_panic()
     }
 }
 
@@ -330,6 +343,7 @@ mod tests {
                 RotaryEmbeddingConfig,
             },
         },
+        burner::module::ModuleInit,
         contracts::assert_shape_contract,
         support::testing::CpuBackend,
     };

--- a/crates/bunsen/src/blocks/transformers/embedding/rotary.rs
+++ b/crates/bunsen/src/blocks/transformers/embedding/rotary.rs
@@ -16,6 +16,14 @@ use burn::{
     },
 };
 
+use crate::{
+    burner::module::ModuleInit,
+    errors::{
+        BunsenError,
+        BunsenResult,
+    },
+};
+
 /// Common meta for [`RotaryEmbedding`] and [`RotaryEmbeddingConfig`].
 pub trait RotaryEmbeddingMeta {
     /// Return the sequence length.
@@ -51,17 +59,17 @@ impl RotaryEmbeddingMeta for RotaryEmbeddingConfig {
     }
 }
 
-impl RotaryEmbeddingConfig {
-    /// Initialize the rotary embedding.
-    pub fn init<B: Backend>(
-        self,
+impl<B: Backend> ModuleInit<B, RotaryEmbedding<B>> for RotaryEmbeddingConfig {
+    fn try_init(
+        &self,
         device: &B::Device,
-    ) -> RotaryEmbedding<B> {
-        assert!(
-            self.head_dim.is_multiple_of(2),
-            "Head dimension must be even: {}",
-            self.head_dim
-        );
+    ) -> BunsenResult<RotaryEmbedding<B>> {
+        if !self.head_dim.is_multiple_of(2) {
+            return Err(BunsenError::Invalid(format!(
+                "Head dimension must be even: {}",
+                self.head_dim
+            )));
+        }
 
         let freq_matrix =
             positional_frequency_table(self.seq_len, self.base, self.head_dim, device);
@@ -83,11 +91,11 @@ impl RotaryEmbeddingConfig {
 
         // [1, T, 1, D/2]
 
-        RotaryEmbedding {
+        Ok(RotaryEmbedding {
             head_dim: self.head_dim,
             cos,
             sin,
-        }
+        })
     }
 }
 

--- a/crates/bunsen/src/blocks/transformers/mlp.rs
+++ b/crates/bunsen/src/blocks/transformers/mlp.rs
@@ -18,6 +18,11 @@ use burn::{
     },
 };
 
+use crate::{
+    burner::module::ModuleInit,
+    errors::BunsenResult,
+};
+
 /// Compute layer normalized mlp.
 ///
 /// ## Arguments
@@ -74,12 +79,18 @@ impl MlpMeta for MlpConfig {
 }
 
 impl MlpConfig {
-    /// Initialize the module.
-    pub fn init<B: Backend>(
-        self,
+    /// Return the size of the hidden layer.
+    pub fn hidden_size(&self) -> usize {
+        self.n_embed * self.expansion_factor
+    }
+}
+
+impl<B: Backend> ModuleInit<B, Mlp<B>> for MlpConfig {
+    fn try_init(
+        &self,
         device: &B::Device,
-    ) -> Mlp<B> {
-        Mlp {
+    ) -> BunsenResult<Mlp<B>> {
+        Ok(Mlp {
             linear1: LinearConfig::new(self.n_embed(), self.hidden_size())
                 .with_bias(false)
                 .init(device),
@@ -88,12 +99,7 @@ impl MlpConfig {
             linear2: LinearConfig::new(self.hidden_size(), self.n_embed())
                 .with_bias(false)
                 .init(device),
-        }
-    }
-
-    /// Return the size of the hidden layer.
-    pub fn hidden_size(&self) -> usize {
-        self.n_embed * self.expansion_factor
+        })
     }
 }
 

--- a/crates/bunsen/src/burner/module/mod.rs
+++ b/crates/bunsen/src/burner/module/mod.rs
@@ -3,6 +3,10 @@
 #[cfg(feature = "reflection")]
 pub mod reflection;
 
+mod module_init;
 mod type_mapper;
+
+#[doc(inline)]
+pub use module_init::*;
 #[doc(inline)]
 pub use type_mapper::*;

--- a/crates/bunsen/src/burner/module/module_init.rs
+++ b/crates/bunsen/src/burner/module/module_init.rs
@@ -1,0 +1,26 @@
+use burn::{
+    module::Module,
+    prelude::Backend,
+};
+
+use crate::errors::{
+    BunsenResult,
+    WithOkOrPanic,
+};
+
+/// Trait for initializing a Module.
+pub trait ModuleInit<B: Backend, M: Module<B>> {
+    /// Initialize a Module.
+    fn try_init(
+        &self,
+        device: &B::Device,
+    ) -> BunsenResult<M>;
+
+    /// Initialize a Module, panicking on error.
+    fn init(
+        &self,
+        device: &B::Device,
+    ) -> M {
+        self.try_init(device).ok_or_panic()
+    }
+}

--- a/crates/bunsen/src/kits/bimm/resnet/basic_block.rs
+++ b/crates/bunsen/src/kits/bimm/resnet/basic_block.rs
@@ -47,6 +47,8 @@ use crate::{
             },
         },
     },
+    burner::module::ModuleInit,
+    errors::BunsenResult,
     kits::bimm::resnet::{
         ResNetDownsample,
         ResNetDownsampleConfig,
@@ -193,12 +195,11 @@ impl BasicBlockMeta for BasicBlockConfig {
     }
 }
 
-impl BasicBlockConfig {
-    /// Initialize a [`BasicBlock`].
-    pub fn init<B: Backend>(
-        self,
+impl<B: Backend> ModuleInit<B, BasicBlock<B>> for BasicBlockConfig {
+    fn try_init(
+        &self,
         device: &B::Device,
-    ) -> BasicBlock<B> {
+    ) -> BunsenResult<BasicBlock<B>> {
         let drop_path_prob = expect_probability(self.drop_path_prob);
 
         let in_planes = self.in_planes();
@@ -253,7 +254,7 @@ impl BasicBlockConfig {
                 .with_bias(false),
         );
 
-        BasicBlock {
+        let module = BasicBlock {
             reduce_first: self.reduce_first,
 
             downsample: downsample.as_ref().map(|cfg| cfg.clone().init(device)),
@@ -274,7 +275,9 @@ impl BasicBlockConfig {
             } else {
                 None
             },
-        }
+        };
+
+        Ok(module)
     }
 }
 

--- a/crates/bunsen/src/kits/bimm/resnet/bottleneck_block.rs
+++ b/crates/bunsen/src/kits/bimm/resnet/bottleneck_block.rs
@@ -48,6 +48,8 @@ use crate::{
             },
         },
     },
+    burner::module::ModuleInit,
+    errors::BunsenResult,
     kits::bimm::resnet::{
         ResNetDownsample,
         ResNetDownsampleConfig,
@@ -256,12 +258,13 @@ impl BottleneckBlockConfig {
     fn effective_first_dilation(&self) -> usize {
         self.first_dilation().unwrap_or(self.dilation())
     }
+}
 
-    /// Initialize a [`BottleneckBlock`].
-    pub fn init<B: Backend>(
-        self,
+impl<B: Backend> ModuleInit<B, BottleneckBlock<B>> for BottleneckBlockConfig {
+    fn try_init(
+        &self,
         device: &B::Device,
-    ) -> BottleneckBlock<B> {
+    ) -> BunsenResult<BottleneckBlock<B>> {
         let drop_path_prob = expect_probability(self.drop_path_prob);
 
         let in_planes = self.in_planes();
@@ -320,7 +323,7 @@ impl BottleneckBlockConfig {
         assert_eq!(cna2.out_channels(), cna3.in_channels());
         assert_eq!(cna3.out_channels(), self.out_planes());
 
-        BottleneckBlock {
+        let module = BottleneckBlock {
             base_width: self.base_width,
             pinch_factor: self.pinch_factor(),
             reduce_first: self.reduce_first,
@@ -344,7 +347,9 @@ impl BottleneckBlockConfig {
             } else {
                 None
             },
-        }
+        };
+
+        Ok(module)
     }
 }
 

--- a/crates/bunsen/src/kits/bimm/resnet/downsample.rs
+++ b/crates/bunsen/src/kits/bimm/resnet/downsample.rs
@@ -21,10 +21,12 @@ use burn::{
 };
 
 use crate::{
+    burner::module::ModuleInit,
     contracts::{
         assert_shape_contract_periodically,
         unpack_shape_contract,
     },
+    errors::BunsenResult,
     ops::conv::{
         build_square_conv2d_padding_config,
         expect_conv_output_shape,
@@ -149,12 +151,11 @@ impl ResNetDownsampleMeta for ResNetDownsampleConfig {
     }
 }
 
-impl ResNetDownsampleConfig {
-    /// Initialize a [`ResNetDownsample`] `Module`.
-    pub fn init<B: Backend>(
-        self,
+impl<B: Backend> ModuleInit<B, ResNetDownsample<B>> for ResNetDownsampleConfig {
+    fn try_init(
+        &self,
         device: &B::Device,
-    ) -> ResNetDownsample<B> {
+    ) -> BunsenResult<ResNetDownsample<B>> {
         let kernel_size = if self.stride == 1 && self.dilation == 1 {
             1
         } else {
@@ -172,11 +173,15 @@ impl ResNetDownsampleConfig {
         .with_dilation(scalar_to_array(dilation))
         .with_bias(false);
 
-        ResNetDownsample {
+        Ok(ResNetDownsample {
             conv: conv.init(device),
 
-            norm: self.norm.with_num_features(self.out_channels).init(device),
-        }
+            norm: self
+                .norm
+                .clone()
+                .with_num_features(self.out_channels)
+                .init(device),
+        })
     }
 }
 

--- a/crates/bunsen/src/kits/bimm/resnet/layer_block.rs
+++ b/crates/bunsen/src/kits/bimm/resnet/layer_block.rs
@@ -13,10 +13,7 @@
 
 use alloc::{
     format,
-    string::{
-        String,
-        ToString,
-    },
+    string::ToString,
     vec::Vec,
 };
 
@@ -43,9 +40,14 @@ use super::{
 };
 use crate::{
     blocks::images::drop::drop_block::DropBlockOptions,
+    burner::module::ModuleInit,
     contracts::{
         assert_shape_contract_periodically,
         unpack_shape_contract,
+    },
+    errors::{
+        BunsenError,
+        BunsenResult,
     },
     ops::conv::stride_div_output_resolution,
     support::validators::expect_probability,
@@ -94,7 +96,7 @@ pub struct LayerBlockContractConfig {
 
 impl LayerBlockContractConfig {
     /// Build the [`ResidualBlockContractConfig`]s for this layer block.
-    pub fn to_block_contracts(self) -> Vec<ResidualBlockContractConfig> {
+    pub fn to_block_contracts(&self) -> Vec<ResidualBlockContractConfig> {
         let mut first_dilation = self.first_dilation;
 
         let mut blocks = Vec::with_capacity(self.num_blocks);
@@ -124,7 +126,7 @@ impl LayerBlockContractConfig {
     }
 
     /// Convert to [`LayerBlockStructureConfig`].
-    pub fn to_structure(self) -> LayerBlockStructureConfig {
+    pub fn to_structure(&self) -> LayerBlockStructureConfig {
         LayerBlockStructureConfig {
             blocks: self
                 .to_block_contracts()
@@ -132,6 +134,15 @@ impl LayerBlockContractConfig {
                 .map(|cfg| cfg.into())
                 .collect(),
         }
+    }
+}
+
+impl<B: Backend> ModuleInit<B, LayerBlock<B>> for LayerBlockContractConfig {
+    fn try_init(
+        &self,
+        device: &B::Device,
+    ) -> BunsenResult<LayerBlock<B>> {
+        self.to_structure().try_init(device)
     }
 }
 
@@ -221,27 +232,23 @@ impl LayerBlockMeta for LayerBlockStructureConfig {
 
 impl LayerBlockStructureConfig {
     /// Check if the config is valid.
-    ///
-    /// # Returns
-    ///
-    /// A `Result<(), String>`
-    pub fn try_validate(&self) -> Result<(), String> {
+    pub fn try_validate(&self) -> BunsenResult<()> {
         if self.is_empty() {
-            return Err("blocks is empty".to_string());
+            return Err(BunsenError::Invalid("blocks is empty".to_string()));
         }
 
         for idx in 1..self.blocks.len() {
             let prev = &self.blocks[idx - 1];
             let curr = &self.blocks[idx];
             if prev.out_planes() != curr.in_planes() {
-                return Err(format!(
+                return Err(BunsenError::Invalid(format!(
                     "block[{}].out_planes({}) != block[{}].in_planes({})\n{:#?}",
                     idx - 1,
                     prev.out_planes(),
                     idx,
                     curr.in_planes(),
                     self,
-                ));
+                )));
             }
         }
         Ok(())
@@ -252,22 +259,6 @@ impl LayerBlockStructureConfig {
         match self.try_validate() {
             Ok(_) => (),
             Err(err) => panic!("{}", err),
-        }
-    }
-
-    /// Initialize a new [`LayerBlock`].
-    pub fn init<B: Backend>(
-        self,
-        device: &B::Device,
-    ) -> LayerBlock<B> {
-        self.expect_valid();
-
-        LayerBlock {
-            blocks: self
-                .blocks
-                .into_iter()
-                .map(|block| block.init(device))
-                .collect(),
         }
     }
 
@@ -304,6 +295,23 @@ impl LayerBlockStructureConfig {
             } else {
                 block.with_drop_block(options.clone())
             }
+        })
+    }
+}
+
+impl<B: Backend> ModuleInit<B, LayerBlock<B>> for LayerBlockStructureConfig {
+    fn try_init(
+        &self,
+        device: &B::Device,
+    ) -> BunsenResult<LayerBlock<B>> {
+        self.try_validate()?;
+
+        Ok(LayerBlock {
+            blocks: self
+                .blocks
+                .iter()
+                .map(|block| block.try_init(device))
+                .collect::<BunsenResult<Vec<ResidualBlock<B>>>>()?,
         })
     }
 }

--- a/crates/bunsen/src/kits/bimm/resnet/mod.rs
+++ b/crates/bunsen/src/kits/bimm/resnet/mod.rs
@@ -9,6 +9,7 @@
 //!
 //! ```rust,no_run
 //! use bunsen::{
+//!     burner::module::ModuleInit,
 //!     data::cache::BunsenDiskCache,
 //!     kits::bimm::resnet::{
 //!         PREFAB_RESNET_MAP,
@@ -28,7 +29,6 @@
 //!
 //! let model: ResNet<Flex> = prefab
 //!     .to_config()
-//!     .to_structure()
 //!     .init(&device)
 //!     .load_pytorch_weights(weights)
 //!     .expect("Failed to load weights")

--- a/crates/bunsen/src/kits/bimm/resnet/residual_block.rs
+++ b/crates/bunsen/src/kits/bimm/resnet/residual_block.rs
@@ -35,6 +35,8 @@ use burn::{
 
 use crate::{
     blocks::images::drop::drop_block::DropBlockOptions,
+    burner::module::ModuleInit,
+    errors::BunsenResult,
     kits::bimm::resnet::{
         BasicBlock,
         BasicBlockConfig,
@@ -87,26 +89,35 @@ pub struct ResidualBlockContractConfig {
 
 impl ResidualBlockContractConfig {
     /// Convert to [`ResidualBlockStructureConfig`].
-    pub fn to_structure(self) -> ResidualBlockStructureConfig {
+    pub fn to_structure(&self) -> ResidualBlockStructureConfig {
         let stride = if self.downsample_input { 2 } else { 1 };
 
-        match self.bottleneck_policy {
+        match &self.bottleneck_policy {
             None => BasicBlockConfig::new(self.in_planes, self.out_planes)
                 .with_stride(stride)
                 .with_dilation(self.dilation)
                 .with_first_dilation(self.first_dilation)
-                .with_normalization(self.normalization)
-                .with_activation(self.activation)
+                .with_normalization(self.normalization.clone())
+                .with_activation(self.activation.clone())
                 .into(),
             Some(policy) => BottleneckBlockConfig::new(self.in_planes, self.out_planes)
                 .with_stride(stride)
                 .with_dilation(self.dilation)
                 .with_first_dilation(self.first_dilation)
-                .with_normalization(self.normalization)
-                .with_activation(self.activation)
-                .with_policy(policy)
+                .with_normalization(self.normalization.clone())
+                .with_activation(self.activation.clone())
+                .with_policy(policy.clone())
                 .into(),
         }
+    }
+}
+
+impl<B: Backend> ModuleInit<B, ResidualBlock<B>> for ResidualBlockContractConfig {
+    fn try_init(
+        &self,
+        device: &B::Device,
+    ) -> BunsenResult<ResidualBlock<B>> {
+        self.to_structure().try_init(device)
     }
 }
 
@@ -214,17 +225,6 @@ impl From<BottleneckBlockConfig> for ResidualBlockStructureConfig {
 }
 
 impl ResidualBlockStructureConfig {
-    /// Initialize a [`ResidualBlock`].
-    pub fn init<B: Backend>(
-        self,
-        device: &B::Device,
-    ) -> ResidualBlock<B> {
-        match self {
-            Self::Basic(config) => config.init(device).into(),
-            Self::Bottleneck(config) => config.init(device).into(),
-        }
-    }
-
     /// Set drop block options.
     pub fn with_drop_block(
         self,
@@ -246,6 +246,18 @@ impl ResidualBlockStructureConfig {
             Self::Basic(config) => config.with_drop_path_prob(drop_path_prob).into(),
             Self::Bottleneck(config) => config.with_drop_path_prob(drop_path_prob).into(),
         }
+    }
+}
+
+impl<B: Backend> ModuleInit<B, ResidualBlock<B>> for ResidualBlockStructureConfig {
+    fn try_init(
+        &self,
+        device: &B::Device,
+    ) -> BunsenResult<ResidualBlock<B>> {
+        Ok(match self {
+            Self::Basic(config) => config.try_init(device)?.into(),
+            Self::Bottleneck(config) => config.try_init(device)?.into(),
+        })
     }
 }
 

--- a/crates/bunsen/src/kits/bimm/resnet/resnet_model.rs
+++ b/crates/bunsen/src/kits/bimm/resnet/resnet_model.rs
@@ -63,6 +63,7 @@ use crate::{
         },
         drop::drop_block::DropBlockOptions,
     },
+    burner::module::ModuleInit,
     errors::{
         BunsenError,
         BunsenResult,
@@ -181,7 +182,7 @@ impl ResNetContractConfig {
     }
 
     /// Convert to a [`ResNetStructureConfig`].
-    pub fn to_structure(self) -> ResNetStructureConfig {
+    pub fn to_structure(&self) -> ResNetStructureConfig {
         ResNetStructureConfig::new(
             ConvNorm2dConfig::from(
                 Conv2dConfig::new([3, self.stem_width], [7, 7])
@@ -204,6 +205,15 @@ impl ResNetContractConfig {
     /// Create a ResNet-18 model.
     pub fn resnet18(num_classes: usize) -> Self {
         Self::new(RESNET18_BLOCKS.to_vec(), num_classes) // .with_bottleneck(true)
+    }
+}
+
+impl<B: Backend> ModuleInit<B, ResNet<B>> for ResNetContractConfig {
+    fn try_init(
+        &self,
+        device: &B::Device,
+    ) -> BunsenResult<ResNet<B>> {
+        self.to_structure().try_init(device)
     }
 }
 
@@ -240,40 +250,6 @@ pub struct ResNetStructureConfig {
 }
 
 impl ResNetStructureConfig {
-    /// Initialize a [`ResNet`] model.
-    pub fn init<B: Backend>(
-        self,
-        device: &B::Device,
-    ) -> ResNet<B> {
-        let mut input_conv_norm = self.input_conv_norm.clone();
-        if let Some(initializer) = &self.input_conv_norm_initializer {
-            input_conv_norm.conv = input_conv_norm.conv.with_initializer(initializer.clone());
-        }
-
-        let head_planes = self.layers.last().unwrap().out_planes();
-
-        ResNet {
-            input_conv_norm: input_conv_norm.init(device),
-            input_act: self.input_act.init(device),
-            input_pool: MaxPool2dConfig::new([3, 3])
-                .with_strides([2, 2])
-                .with_padding({
-                    let d = 1;
-                    PaddingConfig2d::Explicit(d, d, d, d)
-                })
-                .init(),
-
-            layers: self
-                .layers
-                .into_iter()
-                .map(|c| c.init(device))
-                .collect::<Vec<_>>(),
-
-            output_pool: AdaptiveAvgPool2dConfig::new([1, 1]).init(),
-            output_fc: LinearConfig::new(head_planes, self.num_classes).init(device),
-        }
-    }
-
     /// Apply the given standard drop block probability scheme.
     pub fn with_standard_drop_block_prob(
         self,
@@ -346,6 +322,43 @@ impl ResNetStructureConfig {
                 .collect(),
             ..self
         }
+    }
+}
+
+impl<B: Backend> ModuleInit<B, ResNet<B>> for ResNetStructureConfig {
+    fn try_init(
+        &self,
+        device: &B::Device,
+    ) -> BunsenResult<ResNet<B>> {
+        let mut input_conv_norm = self.input_conv_norm.clone();
+        if let Some(initializer) = &self.input_conv_norm_initializer {
+            input_conv_norm.conv = input_conv_norm.conv.with_initializer(initializer.clone());
+        }
+
+        let head_planes = self.layers.last().unwrap().out_planes();
+
+        let module = ResNet {
+            input_conv_norm: input_conv_norm.init(device),
+            input_act: self.input_act.init(device),
+            input_pool: MaxPool2dConfig::new([3, 3])
+                .with_strides([2, 2])
+                .with_padding({
+                    let d = 1;
+                    PaddingConfig2d::Explicit(d, d, d, d)
+                })
+                .init(),
+
+            layers: self
+                .layers
+                .iter()
+                .map(|c| c.init(device))
+                .collect::<Vec<_>>(),
+
+            output_pool: AdaptiveAvgPool2dConfig::new([1, 1]).init(),
+            output_fc: LinearConfig::new(head_planes, self.num_classes).init(device),
+        };
+
+        Ok(module)
     }
 }
 

--- a/crates/bunsen/src/kits/bimm/swin/v2/block_sequence.rs
+++ b/crates/bunsen/src/kits/bimm/swin/v2/block_sequence.rs
@@ -15,10 +15,12 @@ use burn::{
 };
 
 use crate::{
+    burner::module::ModuleInit,
     contracts::{
         assert_shape_contract_periodically,
         define_shape_contract,
     },
+    errors::BunsenResult,
     kits::bimm::swin::v2::swin_block::{
         ShiftedWindowTransformerBlock,
         ShiftedWindowTransformerBlockConfig,
@@ -207,24 +209,22 @@ impl StochasticDepthTransformerBlockSequenceConfig {
             })
             .collect()
     }
+}
 
-    /// Creates a new `BasicLayerConfig` with the specified parameters.
-    ///
-    /// # Arguments
-    ///
-    /// * `device`: Backend device.
-    #[must_use]
-    pub fn init<B: Backend>(
+impl<B: Backend> ModuleInit<B, StochasticDepthTransformerBlockSequence<B>>
+    for StochasticDepthTransformerBlockSequenceConfig
+{
+    fn try_init(
         &self,
         device: &B::Device,
-    ) -> StochasticDepthTransformerBlockSequence<B> {
-        StochasticDepthTransformerBlockSequence {
+    ) -> BunsenResult<StochasticDepthTransformerBlockSequence<B>> {
+        Ok(StochasticDepthTransformerBlockSequence {
             blocks: self
                 .block_configs()
                 .into_iter()
                 .map(|config| config.init(device))
                 .collect(),
-        }
+        })
     }
 }
 
@@ -326,7 +326,10 @@ mod tests {
     use serial_test::serial;
 
     use super::*;
-    use crate::support::testing::PerformanceBackend;
+    use crate::{
+        errors::WithOkOrPanic,
+        support::testing::PerformanceBackend,
+    };
 
     #[test]
     fn test_config() {
@@ -414,7 +417,8 @@ mod tests {
         );
 
         let device = Default::default();
-        let module = config.init::<B>(&device);
+        let module: StochasticDepthTransformerBlockSequence<B> =
+            config.try_init(&device).ok_or_panic();
 
         assert_eq!(module.d_input(), d_input);
         assert_eq!(module.input_resolution(), input_resolution);

--- a/crates/bunsen/src/kits/bimm/swin/v2/mod.rs
+++ b/crates/bunsen/src/kits/bimm/swin/v2/mod.rs
@@ -4,10 +4,13 @@
 //! ## Example
 //!
 //! ```rust,no_run
-//! use bunsen::kits::bimm::swin::v2::swin_model::{
-//!     LayerConfig,
-//!     SwinTransformerV2,
-//!     SwinTransformerV2Config,
+//! use bunsen::{
+//!     burner::module::ModuleInit,
+//!     kits::bimm::swin::v2::swin_model::{
+//!         LayerConfig,
+//!         SwinTransformerV2,
+//!         SwinTransformerV2Config,
+//!     },
 //! };
 //! use burn::backend::Flex;
 //!

--- a/crates/bunsen/src/kits/bimm/swin/v2/patch_merge.rs
+++ b/crates/bunsen/src/kits/bimm/swin/v2/patch_merge.rs
@@ -16,9 +16,14 @@ use burn::{
 };
 
 use crate::{
+    burner::module::ModuleInit,
     contracts::{
         assert_shape_contract_periodically,
         unpack_shape_contract,
+    },
+    errors::{
+        BunsenError,
+        BunsenResult,
     },
     kits::bimm::swin::v2::windowing::{
         window_partition,
@@ -85,39 +90,26 @@ impl PatchMergingMeta for PatchMergingConfig {
     }
 }
 
-impl PatchMergingConfig {
-    /// Create a new `PatchMerging` configuration.
-    ///
-    /// # Arguments
-    ///
-    /// - `device`: The backend device to initialize the module on.
-    ///
-    /// # Returns
-    ///
-    /// A new `PatchMerging` module initialized with the given configuration.
-    ///
-    /// # Panics
-    ///
-    /// If the config is invalid.
-    #[must_use]
-    pub fn init<B: Backend>(
+impl<B: Backend> ModuleInit<B, PatchMerging<B>> for PatchMergingConfig {
+    fn try_init(
         &self,
         device: &B::Device,
-    ) -> PatchMerging<B> {
+    ) -> BunsenResult<PatchMerging<B>> {
         let [h, w] = self.input_resolution;
-        assert!(
-            h % 2 == 0 && w % 2 == 0,
-            "Input resolution must be divisible by 2: {:?}",
-            self.input_resolution
-        );
+        if h % 2 != 0 || w % 2 != 0 {
+            return Err(BunsenError::Invalid(format!(
+                "Input resolution must be divisible by 2: {:?}",
+                self.input_resolution
+            )));
+        }
 
-        PatchMerging {
+        Ok(PatchMerging {
             input_resolution: self.input_resolution,
             reduction: LinearConfig::new(2 * self.d_output(), self.d_output())
                 .with_bias(false)
                 .init(device),
             norm: LayerNormConfig::new(self.d_output()).init(device),
-        }
+        })
     }
 }
 
@@ -303,17 +295,21 @@ mod tests {
     use super::*;
     use crate::{
         blocks::images::patching::patch_embed::{
+            PatchEmbed,
             PatchEmbedConfig,
             PatchEmbedMeta,
         },
-        support::testing::PerformanceBackend,
+        errors::WithOkOrPanic,
+        support::testing::{
+            CpuBackend,
+            PerformanceBackend,
+        },
     };
-
-    type B = PerformanceBackend;
 
     #[test]
     #[serial]
     fn test_collate_patches() {
+        type B = PerformanceBackend;
         let b = 2;
         let h = 4;
         let w = 6;
@@ -334,6 +330,7 @@ mod tests {
 
     #[test]
     fn test_patch_merging_meta() {
+        type B = PerformanceBackend;
         let config = PatchMergingConfig {
             input_resolution: [12, 8],
             d_input: 3,
@@ -346,7 +343,8 @@ mod tests {
         assert_eq!(config.output_height(), 6);
         assert_eq!(config.output_width(), 4);
 
-        let patch_merging = config.init::<B>(&Default::default());
+        let device = Default::default();
+        let patch_merging: PatchMerging<B> = config.try_init(&device).ok_or_panic();
 
         assert_eq!(patch_merging.input_resolution(), [12, 8]);
         assert_eq!(patch_merging.d_input(), 3);
@@ -359,17 +357,19 @@ mod tests {
     #[should_panic(expected = "Input resolution must be divisible by 2")]
     #[test]
     fn test_patch_merging_invalid_resolution() {
+        type B = PerformanceBackend;
         let config = PatchMergingConfig {
             input_resolution: [13, 8], // Invalid height
             d_input: 3,
         };
         let device = Default::default();
-        let _d = config.init::<B>(&device);
+        let _d: PatchMerging<B> = config.try_init(&device).ok_or_panic();
     }
 
     #[test]
     #[serial]
     fn test_patch_merging() {
+        type B = PerformanceBackend;
         let device = Default::default();
 
         let b = 2;
@@ -381,7 +381,7 @@ mod tests {
             input_resolution: [h, w],
             d_input: c,
         };
-        let patch_merging = config.init::<B>(&device);
+        let patch_merging: PatchMerging<B> = config.try_init(&device).ok_or_panic();
 
         let distribution = Distribution::Normal(0., 1.);
         let x = Tensor::random([b, h * w, c], distribution, &device);
@@ -392,6 +392,7 @@ mod tests {
 
     #[test]
     fn test_patch_embed_meta() {
+        type B = CpuBackend;
         let config = PatchEmbedConfig::new([12, 8], 4, 3, 6).with_enable_patch_norm(false);
 
         assert_eq!(config.input_resolution(), [12, 8]);
@@ -403,7 +404,8 @@ mod tests {
         assert_eq!(config.patches_height(), 3);
         assert_eq!(config.patches_width(), 2);
 
-        let patch_embed = config.init::<B>(&Default::default());
+        let device = Default::default();
+        let patch_embed: PatchEmbed<B> = config.try_init(&device).ok_or_panic();
 
         assert_eq!(patch_embed.input_resolution(), [12, 8]);
         assert_eq!(patch_embed.patch_size(), 4);
@@ -418,6 +420,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_patch_embed() {
+        type B = PerformanceBackend;
         let device = Default::default();
 
         let b = 2;
@@ -435,7 +438,7 @@ mod tests {
         {
             let config = PatchEmbedConfig::new([h, w], patch_size, d_input, d_output)
                 .with_enable_patch_norm(false);
-            let patch_embed = config.init::<B>(&device);
+            let patch_embed = config.try_init(&device).ok_or_panic();
 
             let y = patch_embed.forward(x.clone());
             assert_eq!(&y.dims(), &[b, (h / 4) * (w / 4), d_output]);
@@ -450,7 +453,7 @@ mod tests {
         // With Norm.
         {
             let config = PatchEmbedConfig::new([h, w], patch_size, d_input, d_output);
-            let patch_embed = config.init::<B>(&device);
+            let patch_embed = config.try_init(&device).ok_or_panic();
 
             let y = patch_embed.forward(x.clone());
             assert_eq!(&y.dims(), &[b, (h / 4) * (w / 4), d_output]);

--- a/crates/bunsen/src/kits/bimm/swin/v2/swin_block.rs
+++ b/crates/bunsen/src/kits/bimm/swin/v2/swin_block.rs
@@ -27,9 +27,14 @@ use crate::{
         DropPath,
         DropPathConfig,
     },
+    burner::module::ModuleInit,
     contracts::{
         assert_shape_contract_periodically,
         define_shape_contract,
+    },
+    errors::{
+        BunsenResult,
+        WithOkOrPanic,
     },
     kits::bimm::swin::v2::{
         window_attention::{
@@ -97,30 +102,21 @@ impl BlockMlpMeta for BlockMlpConfig {
     }
 }
 
-impl BlockMlpConfig {
-    /// Creates a new `BlockMlp`.
-    ///
-    /// # Arguments
-    ///
-    /// - `device`: The device on which the MLP will be initialized.
-    ///
-    /// # Returns
-    ///
-    /// A new `BlockMlp` instance.
-    pub fn init<B: Backend>(
+impl<B: Backend> ModuleInit<B, BlockMlp<B>> for BlockMlpConfig {
+    fn try_init(
         &self,
         device: &B::Device,
-    ) -> BlockMlp<B> {
+    ) -> BunsenResult<BlockMlp<B>> {
         let d_input = self.d_input();
         let d_hidden = self.d_hidden();
         let d_output = self.d_output();
 
-        BlockMlp {
+        Ok(BlockMlp {
             fc1: LinearConfig::new(d_input, d_hidden).init(device),
             fc2: LinearConfig::new(d_hidden, d_output).init(device),
             act: self.activation.init(device),
             drop: DropoutConfig { prob: self.drop }.init(),
-        }
+        })
     }
 }
 
@@ -434,30 +430,24 @@ impl ShiftedWindowTransformerBlockConfig {
             "input_resolution must be divisible by window size: {self:#?}",
         );
     }
+}
 
-    /// Initializes a new `SwinTransformerBlock`.
-    ///
-    /// # Arguments
-    ///
-    /// * `device` - The device on which the block will be created.
-    ///
-    /// # Returns
-    ///
-    /// A new `SwinTransformerBlock` configured with the specified parameters.
-    #[must_use]
-    pub fn init<B: Backend>(
+impl<B: Backend> ModuleInit<B, ShiftedWindowTransformerBlock<B>>
+    for ShiftedWindowTransformerBlockConfig
+{
+    fn try_init(
         &self,
         device: &B::Device,
-    ) -> ShiftedWindowTransformerBlock<B> {
+    ) -> BunsenResult<ShiftedWindowTransformerBlock<B>> {
         self.check();
 
         let hidden_dim = (self.d_input as f64 * self.mlp_ratio) as usize;
-        let block_mlp = BlockMlpConfig::new(self.d_input)
+        let self1 = &BlockMlpConfig::new(self.d_input)
             .with_d_hidden(Some(hidden_dim))
-            .with_drop(self.drop_rate)
-            .init(device);
+            .with_drop(self.drop_rate);
+        let block_mlp = self1.try_init(device).ok_or_panic();
 
-        let win_attn = WindowAttentionConfig::new(
+        let self2 = &WindowAttentionConfig::new(
             self.d_input,
             [self.window_size, self.window_size],
             self.num_heads,
@@ -466,8 +456,8 @@ impl ShiftedWindowTransformerBlockConfig {
         .with_attn_drop(self.attn_drop_rate)
         .with_proj_drop(self.drop_rate)
         .with_rpb_mlp_hidden_dim(self.attn_rpb_mlp_hidden_dim)
-        .with_rpb_mlp_activation(self.attn_rpb_mlp_activation.clone())
-        .init(device);
+        .with_rpb_mlp_activation(self.attn_rpb_mlp_activation.clone());
+        let win_attn = self2.try_init(device).ok_or_panic();
 
         let shift_mask = if self.shift_size == 0 {
             None
@@ -484,7 +474,7 @@ impl ShiftedWindowTransformerBlockConfig {
             )
         };
 
-        ShiftedWindowTransformerBlock {
+        Ok(ShiftedWindowTransformerBlock {
             input_resolution: self.input_resolution,
             window_size: self.window_size,
             shift_size: self.shift_size,
@@ -496,7 +486,7 @@ impl ShiftedWindowTransformerBlockConfig {
             norm2: LayerNormConfig::new(self.d_input).init(device),
             win_attn,
             block_mlp,
-        }
+        })
     }
 }
 
@@ -733,7 +723,7 @@ mod tests {
             .with_d_output(Some(d_output))
             .with_drop(drop);
 
-        let mlp: BlockMlp<B> = config.init(&device);
+        let mlp: BlockMlp<B> = config.try_init(&device).ok_or_panic();
 
         assert_eq!(mlp.d_input(), config.d_input());
         assert_eq!(mlp.d_hidden(), config.d_hidden());
@@ -758,7 +748,7 @@ mod tests {
         let w = 4;
         let c = 3;
 
-        let distribution = burn::tensor::Distribution::Uniform(0.0, 1.0);
+        let distribution = Distribution::Uniform(0.0, 1.0);
         let input = Tensor::<B, 4>::random([b, h, w, c], distribution, &device);
 
         let idx: Tensor<B, 4> = Tensor::arange(0..input.shape().num_elements() as i64, &device)
@@ -814,7 +804,7 @@ mod tests {
         assert_eq!(config.mlp_ratio(), 4.0);
         assert_eq!(config.drop_path_rate(), 0.0);
 
-        let block = config.init::<B>(&device);
+        let block: ShiftedWindowTransformerBlock<B> = config.init(&device);
 
         assert_eq!(block.d_input(), d_input);
         assert_eq!(block.input_resolution(), input_resolution);
@@ -847,7 +837,7 @@ mod tests {
 
         let config = ShiftedWindowTransformerBlockConfig::new(d_input, input_resolution, num_heads);
 
-        let _d = config.init::<B>(&Default::default());
+        let _d: ShiftedWindowTransformerBlock<B> = config.init(&Default::default());
     }
 
     #[should_panic(expected = "input_resolution must be divisible by window size")]
@@ -862,7 +852,7 @@ mod tests {
 
         let config = ShiftedWindowTransformerBlockConfig::new(d_input, input_resolution, num_heads);
 
-        let _d = config.init::<B>(&Default::default());
+        let _d: ShiftedWindowTransformerBlock<B> = config.init(&Default::default());
     }
 
     #[should_panic(expected = "d_input must be greater than zero")]
@@ -877,7 +867,7 @@ mod tests {
 
         let config = ShiftedWindowTransformerBlockConfig::new(d_input, input_resolution, num_heads);
 
-        let _d = config.init::<B>(&Default::default());
+        let _d: ShiftedWindowTransformerBlock<B> = config.init(&Default::default());
     }
 
     #[should_panic(expected = "num_heads must be greater than zero")]
@@ -892,7 +882,7 @@ mod tests {
 
         let config = ShiftedWindowTransformerBlockConfig::new(d_input, input_resolution, num_heads);
 
-        let _d = config.init::<B>(&Default::default());
+        let _d: ShiftedWindowTransformerBlock<B> = config.init(&Default::default());
     }
 
     #[should_panic(expected = "window_size must be greater than zero")]
@@ -909,7 +899,7 @@ mod tests {
         let config = ShiftedWindowTransformerBlockConfig::new(d_input, input_resolution, num_heads)
             .with_window_size(window_size);
 
-        let _d = config.init::<B>(&Default::default());
+        let _d: ShiftedWindowTransformerBlock<B> = config.init(&Default::default());
     }
 
     #[test]
@@ -931,9 +921,9 @@ mod tests {
             .with_window_size(window_size);
 
         let device = Default::default();
-        let block = config.init::<B>(&device);
+        let block: ShiftedWindowTransformerBlock<B> = config.init(&device);
 
-        let distribution = burn::tensor::Distribution::Uniform(0.0, 1.0);
+        let distribution = Distribution::Uniform(0.0, 1.0);
         let input = Tensor::<B, 3>::random([b, h * w, d_input], distribution, &device);
 
         let output = block.forward(input.clone());

--- a/crates/bunsen/src/kits/bimm/swin/v2/swin_model.rs
+++ b/crates/bunsen/src/kits/bimm/swin/v2/swin_model.rs
@@ -42,9 +42,14 @@ use crate::{
             PatchEmbedMeta,
         },
     },
+    burner::module::ModuleInit,
     contracts::{
         assert_shape_contract_periodically,
         unpack_shape_contract,
+    },
+    errors::{
+        BunsenResult,
+        WithOkOrPanic,
     },
     kits::bimm::swin::v2::{
         block_sequence::{
@@ -352,17 +357,18 @@ impl SwinTransformerV2Config {
             block_configs,
         })
     }
+}
 
-    /// Initialize a new [`SwinTransformerV2`] model.
-    #[must_use]
-    pub fn init<B: Backend>(
-        self,
+impl<B: Backend> ModuleInit<B, SwinTransformerV2<B>> for SwinTransformerV2Config {
+    fn try_init(
+        &self,
         device: &B::Device,
-    ) -> SwinTransformerV2<B> {
+    ) -> BunsenResult<SwinTransformerV2<B>> {
         let plan = self.validate().unwrap();
         // println!("plan: {:#?}", plan);
 
-        let patch_embed: PatchEmbed<B> = plan.patch_config.init(device);
+        let self1 = &plan.patch_config;
+        let patch_embed: PatchEmbed<B> = self1.try_init(device).ok_or_panic();
 
         // ape: trunc_normal: ([1, num_patches, d_embed], std=0.02)
         // defaults: (mean=0.0, a=-2.0, b=2.0)
@@ -381,20 +387,21 @@ impl SwinTransformerV2Config {
         let grid_transformer_block_sequences: Vec<StochasticDepthTransformerBlockSequence<B>> =
             plan.block_configs
                 .iter()
-                .map(|config| config.init::<B>(device))
+                .map(|config| config.try_init(device).ok_or_panic())
                 .collect();
 
         let grid_merge_layers: Vec<PatchMerging<B>> = (0..grid_transformer_block_sequences.len()
             - 1)
             .map(|layer_i| {
                 let block = &grid_transformer_block_sequences[layer_i];
-                PatchMergingConfig::new(block.input_resolution(), block.d_input()).init(device)
+                let self1 = &PatchMergingConfig::new(block.input_resolution(), block.d_input());
+                self1.try_init(device).ok_or_panic()
             })
             .collect();
 
         let grid_output_features = *plan.layer_dims.last().unwrap();
 
-        SwinTransformerV2 {
+        let module = SwinTransformerV2 {
             patch_embed,
             patch_ape,
             grid_input_dropout: DropoutConfig::new(self.drop_rate).init(),
@@ -407,7 +414,9 @@ impl SwinTransformerV2Config {
             drop_rate: self.drop_rate,
             attn_drop_rate: self.attn_drop_rate,
             drop_path_rate: self.drop_path_rate,
-        }
+        };
+
+        Ok(module)
     }
 }
 
@@ -721,7 +730,7 @@ mod tests {
         );
 
         let device = Default::default();
-        let model = config.init::<B>(&device);
+        let model: SwinTransformerV2<B> = config.try_init(&device).ok_or_panic();
 
         assert_eq!(model.input_resolution(), [224, 224]);
         assert_eq!(model.input_height(), 224);
@@ -794,7 +803,7 @@ mod tests {
 
         let d_embed = (d_input * patch_size * patch_size) / 2;
 
-        let model = SwinTransformerV2Config::new(
+        let self1 = SwinTransformerV2Config::new(
             [h, w],
             patch_size,
             d_input,
@@ -802,8 +811,8 @@ mod tests {
             d_embed,
             layer_configs,
         )
-        .with_window_size(window_size)
-        .init(&device);
+        .with_window_size(window_size);
+        let model: SwinTransformerV2<B> = self1.try_init(&device).ok_or_panic();
 
         let distribution = Distribution::Normal(0.0, 0.02);
         let input = Tensor::<B, 4>::random([b, d_input, h, w], distribution, &device);
@@ -875,7 +884,7 @@ mod tests {
 
         let d_embed = (d_input * patch_size * patch_size) / 2;
 
-        let model = SwinTransformerV2Config::new(
+        let self1 = SwinTransformerV2Config::new(
             [h, w],
             patch_size,
             d_input,
@@ -884,8 +893,8 @@ mod tests {
             layer_configs,
         )
         .with_enable_ape(false)
-        .with_window_size(window_size)
-        .init(&device);
+        .with_window_size(window_size);
+        let model: SwinTransformerV2<B> = self1.try_init(&device).ok_or_panic();
 
         let distribution = Distribution::Normal(0.0, 0.02);
         let input = Tensor::<B, 4>::random([b, d_input, h, w], distribution, &device);

--- a/crates/bunsen/src/kits/bimm/swin/v2/window_attention/attention.rs
+++ b/crates/bunsen/src/kits/bimm/swin/v2/window_attention/attention.rs
@@ -26,14 +26,19 @@ use burn::{
 };
 
 use crate::{
+    burner::module::ModuleInit,
     contracts::{
         assert_shape_contract_periodically,
         unpack_shape_contract,
     },
+    errors::{
+        BunsenResult,
+        WithOkOrPanic,
+    },
     kits::bimm::swin::v2::window_attention::{
         OffsetGridRelativePositionBias,
-        RelativePositionBiasConfig,
-        RelativePositionBiasMeta,
+        OffsetGridRelativePositionBiasConfig,
+        OffsetGridRelativePositionBiasMeta,
         apply_attention_mask,
     },
 };
@@ -358,25 +363,19 @@ impl<B: Backend> WindowAttention<B> {
     }
 }
 
-impl WindowAttentionConfig {
-    /// Create a new `WindowAttentionConfig`.
-    ///
-    /// # Arguments
-    ///
-    /// - `device`: The backend device to use.
-    ///
-    /// # Returns
-    ///
-    /// A new instance of `WindowAttentionConfig`.
-    pub fn init<B: Backend>(
+impl<B: Backend> ModuleInit<B, WindowAttention<B>> for WindowAttentionConfig {
+    fn try_init(
         &self,
         device: &B::Device,
-    ) -> WindowAttention<B> {
+    ) -> BunsenResult<WindowAttention<B>> {
         let d_input = self.d_input();
         let num_heads = self.num_heads();
         let window_size = self.window_shape();
 
-        WindowAttention {
+        let self1 = &OffsetGridRelativePositionBiasConfig::new(num_heads, window_size)
+            .with_mlp_hidden_dim(self.rpb_mlp_hidden_dim)
+            .with_mlp_activation(self.rpb_mlp_activation.clone());
+        let module = WindowAttention {
             d_input,
             num_heads,
             q_linear: LinearConfig::new(d_input, d_input)
@@ -399,10 +398,7 @@ impl WindowAttentionConfig {
                 prob: self.attn_drop,
             }
             .init(),
-            rpb_module: RelativePositionBiasConfig::new(num_heads, window_size)
-                .with_mlp_hidden_dim(self.rpb_mlp_hidden_dim)
-                .with_mlp_activation(self.rpb_mlp_activation.clone())
-                .init_offset_grid_rpb(device),
+            rpb_module: self1.try_init(device).ok_or_panic(),
             proj: LinearConfig::new(d_input, d_input)
                 .with_bias(false)
                 .init(device),
@@ -410,7 +406,9 @@ impl WindowAttentionConfig {
                 prob: self.proj_drop,
             }
             .init(),
-        }
+        };
+
+        Ok(module)
     }
 }
 
@@ -449,7 +447,7 @@ mod tests {
         assert_eq!(config.window_width(), 4);
 
         let device = Default::default();
-        let attn_mod = config.init::<B>(&device);
+        let attn_mod: WindowAttention<B> = config.try_init(&device).ok_or_panic();
 
         assert_eq!(attn_mod.d_input(), channels);
         assert_eq!(attn_mod.window_shape(), window_shape);
@@ -476,7 +474,7 @@ mod tests {
         let config = WindowAttentionConfig::new(channels, [window_size, window_size], num_heads);
 
         let device = Default::default();
-        let attn_mod = config.init::<B>(&device);
+        let attn_mod: WindowAttention<B> = config.try_init(&device).ok_or_panic();
 
         assert_eq!(attn_mod.d_input(), channels);
         assert_eq!(attn_mod.window_shape(), [window_size, window_size]);

--- a/crates/bunsen/src/kits/bimm/swin/v2/window_attention/pos_bias.rs
+++ b/crates/bunsen/src/kits/bimm/swin/v2/window_attention/pos_bias.rs
@@ -15,7 +15,9 @@ use burn::{
 };
 
 use crate::{
+    burner::module::ModuleInit,
     contracts::assert_shape_contract_periodically,
+    errors::BunsenResult,
     kits::bimm::swin::v2::window_attention::{
         window_attention_relative_position_index,
         window_log1p_relative_offset_grid,
@@ -23,7 +25,7 @@ use crate::{
 };
 
 /// Common introspection interface for relative position bias modules.
-pub trait RelativePositionBiasMeta {
+pub trait OffsetGridRelativePositionBiasMeta {
     /// Returns the number of attention heads.
     fn num_heads(&self) -> usize;
 
@@ -46,7 +48,7 @@ pub trait RelativePositionBiasMeta {
 
 /// Configuration for the relative position bias module.
 #[derive(Config, Debug)]
-pub struct RelativePositionBiasConfig {
+pub struct OffsetGridRelativePositionBiasConfig {
     /// The number of attention heads.
     pub num_heads: usize,
 
@@ -66,7 +68,7 @@ pub struct RelativePositionBiasConfig {
     pub mlp_activation: ActivationConfig,
 }
 
-impl RelativePositionBiasMeta for RelativePositionBiasConfig {
+impl OffsetGridRelativePositionBiasMeta for OffsetGridRelativePositionBiasConfig {
     fn num_heads(&self) -> usize {
         self.num_heads
     }
@@ -80,23 +82,14 @@ impl RelativePositionBiasMeta for RelativePositionBiasConfig {
     }
 }
 
-impl RelativePositionBiasConfig {
-    /// Initializes an `OffsetGridRelativePositionBias` module.
-    ///
-    /// # Arguments
-    ///
-    /// * `device`: The device on which the module will be created.
-    ///
-    /// # Returns
-    ///
-    /// An `OffsetGridRelativePositionBias` module.
-    #[inline(always)]
-    #[must_use]
-    pub fn init_offset_grid_rpb<B: Backend>(
+impl<B: Backend> ModuleInit<B, OffsetGridRelativePositionBias<B>>
+    for OffsetGridRelativePositionBiasConfig
+{
+    fn try_init(
         &self,
         device: &B::Device,
-    ) -> OffsetGridRelativePositionBias<B> {
-        OffsetGridRelativePositionBias {
+    ) -> BunsenResult<OffsetGridRelativePositionBias<B>> {
+        Ok(OffsetGridRelativePositionBias {
             base: self.base,
             num_heads: self.num_heads,
             window_shape: self.window_shape,
@@ -113,7 +106,7 @@ impl RelativePositionBiasConfig {
                 .with_d_hidden(self.mlp_hidden_dim)
                 .with_activation(self.mlp_activation.clone())
                 .init(device),
-        }
+        })
     }
 }
 
@@ -141,7 +134,7 @@ pub struct OffsetGridRelativePositionBias<B: Backend> {
     pub cbp: ContinuousPositionBiasMlp<B>,
 }
 
-impl<B: Backend> RelativePositionBiasMeta for OffsetGridRelativePositionBias<B> {
+impl<B: Backend> OffsetGridRelativePositionBiasMeta for OffsetGridRelativePositionBias<B> {
     fn num_heads(&self) -> usize {
         self.num_heads
     }
@@ -269,13 +262,12 @@ impl<B: Backend> ContinuousPositionBiasMlpMeta for ContinuousPositionBiasMlp<B> 
     }
 }
 
-impl ContinuousPositionBiasMlpConfig {
-    /// Initializes the MLP with the given device.
-    fn init<B: Backend>(
+impl<B: Backend> ModuleInit<B, ContinuousPositionBiasMlp<B>> for ContinuousPositionBiasMlpConfig {
+    fn try_init(
         &self,
         device: &B::Device,
-    ) -> ContinuousPositionBiasMlp<B> {
-        ContinuousPositionBiasMlp {
+    ) -> BunsenResult<ContinuousPositionBiasMlp<B>> {
+        Ok(ContinuousPositionBiasMlp {
             l1: nn::LinearConfig::new(2, self.d_hidden).init(device),
 
             act: self.activation.init(device),
@@ -283,7 +275,7 @@ impl ContinuousPositionBiasMlpConfig {
             l2: nn::LinearConfig::new(self.d_hidden, self.num_heads)
                 .with_bias(false)
                 .init(device),
-        }
+        })
     }
 }
 
@@ -316,6 +308,7 @@ mod tests {
     use super::*;
     use crate::{
         contracts::assert_shape_contract,
+        errors::WithOkOrPanic,
         kits::bimm::swin::v2::window_attention::{
             window_attention_relative_position_index,
             window_log1p_relative_offset_grid,
@@ -330,7 +323,7 @@ mod tests {
     fn test_rpb_meta() {
         type B = CpuBackend;
 
-        let config = RelativePositionBiasConfig::new(12, [3, 2]);
+        let config = OffsetGridRelativePositionBiasConfig::new(12, [3, 2]);
 
         assert_eq!(config.base(), 8.0);
         assert_eq!(config.num_heads(), 12);
@@ -339,7 +332,7 @@ mod tests {
         assert_eq!(config.window_width(), 2);
 
         let device = Default::default();
-        let rpb = config.init_offset_grid_rpb::<B>(&device);
+        let rpb: OffsetGridRelativePositionBias<B> = config.try_init(&device).ok_or_panic();
 
         assert_eq!(rpb.base(), 8.0);
         assert_eq!(rpb.num_heads(), 12);
@@ -357,8 +350,8 @@ mod tests {
         let window_shape = [3, 2];
         let num_heads = 8;
 
-        let config = RelativePositionBiasConfig::new(num_heads, window_shape);
-        let rpb = config.init_offset_grid_rpb::<B>(&device);
+        let config = OffsetGridRelativePositionBiasConfig::new(num_heads, window_shape);
+        let rpb: OffsetGridRelativePositionBias<B> = config.try_init(&device).ok_or_panic();
 
         assert_eq!(rpb.base(), 8.0);
         assert_eq!(rpb.num_heads(), num_heads);
@@ -400,7 +393,7 @@ mod tests {
         assert_eq!(config.num_heads(), 8);
 
         let device = Default::default();
-        let mlp = config.init::<B>(&device);
+        let mlp: ContinuousPositionBiasMlp<B> = config.init(&device);
 
         assert_eq!(mlp.d_hidden(), 512);
         assert_eq!(mlp.num_heads(), 8);

--- a/crates/bunsen/src/kits/gpts/nanochat/block.rs
+++ b/crates/bunsen/src/kits/gpts/nanochat/block.rs
@@ -22,6 +22,12 @@ use crate::{
         },
         embedding::RotaryEmbedding,
     },
+    burner::module::ModuleInit,
+    errors::{
+        BunsenError,
+        BunsenResult,
+        WithOkOrPanic,
+    },
     kits::gpts::nanochat::{
         Mlp,
         MlpConfig,
@@ -58,19 +64,37 @@ impl NanoChatGptBlockMeta for NanoChatGptBlockConfig {
 
 impl NanoChatGptBlockConfig {
     /// Initialize a [`NanoChatGptBlock`].
+    ///
+    /// Panics on errors.
     pub fn init<B: Backend>(
-        self,
+        &self,
         layer_index: usize,
         device: &B::Device,
     ) -> NanoChatGptBlock<B> {
-        assert_eq!(self.attn.n_embed(), self.mlp.n_embed());
-        let n_embed = self.n_embed();
-        NanoChatGptBlock {
-            input_norm: self.norm.clone().with_num_features(n_embed).init(device),
-            attn: self.attn.init(layer_index, device),
-            attn_norm: self.norm.clone().with_num_features(n_embed).init(device),
-            mlp: self.mlp.init(device),
+        self.try_init(layer_index, device).ok_or_panic()
+    }
+
+    /// Initialize a [`NanoChatGptBlock`].
+    pub fn try_init<B: Backend>(
+        &self,
+        layer_index: usize,
+        device: &B::Device,
+    ) -> BunsenResult<NanoChatGptBlock<B>> {
+        if self.attn.n_embed() != self.mlp.n_embed() {
+            return Err(BunsenError::Invalid(format!(
+                "Attn and MLP embed sizes must be equal: {} != {}",
+                self.attn.n_embed(),
+                self.mlp.n_embed()
+            )));
         }
+
+        let n_embed = self.n_embed();
+        Ok(NanoChatGptBlock {
+            input_norm: self.norm.clone().with_num_features(n_embed).init(device),
+            attn: self.attn.try_init(layer_index, device)?,
+            attn_norm: self.norm.clone().with_num_features(n_embed).init(device),
+            mlp: self.mlp.try_init(device)?,
+        })
     }
 }
 

--- a/crates/bunsen/src/kits/gpts/nanochat/model.rs
+++ b/crates/bunsen/src/kits/gpts/nanochat/model.rs
@@ -36,10 +36,12 @@ use crate::{
             RotaryEmbeddingMeta,
         },
     },
+    burner::module::ModuleInit,
     contracts::{
         assert_shape_contract_periodically,
         unpack_shape_contract,
     },
+    errors::BunsenResult,
     kits::gpts::nanochat::{
         MlpConfig,
         NanoChatGptBlock,
@@ -246,27 +248,26 @@ impl NanoChatGptMeta for NanoChatGptStructureConfig {
     }
 }
 
-impl NanoChatGptStructureConfig {
-    /// Initialize a [`NanoChatGpt`].
-    pub fn init<B: Backend>(
-        self,
+impl<B: Backend> ModuleInit<B, NanoChatGpt<B>> for NanoChatGptStructureConfig {
+    fn try_init(
+        &self,
         device: &B::Device,
-    ) -> NanoChatGpt<B> {
+    ) -> BunsenResult<NanoChatGpt<B>> {
         let n_embed = self.n_embed();
-        NanoChatGpt {
+        Ok(NanoChatGpt {
             wte: self.wte.init(device),
             h: self
                 .h
-                .into_iter()
+                .iter()
                 .enumerate()
-                .map(|(layer_idx, c)| c.init(layer_idx, device))
-                .collect(),
+                .map(|(layer_idx, c)| c.try_init(layer_idx, device))
+                .collect::<BunsenResult<Vec<NanoChatGptBlock<B>>>>()?,
             h_norm: self.norm.clone().with_num_features(n_embed).init(device),
             lm_head: self.lm_head.init(device),
-            r_emb: self.r_emb.init(device),
+            r_emb: self.r_emb.try_init(device)?,
             init_seq_len: self.init_seq_len,
             softcap: self.softcap,
-        }
+        })
     }
 }
 

--- a/crates/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs
@@ -27,7 +27,9 @@ use burn::{
 
 use super::WHISPER_DEFAULT_D_MODEL;
 use crate::{
+    burner::module::ModuleInit,
     contracts::unpack_shape_contract,
+    errors::BunsenResult,
     kits::speech::whisper::blocks::{
         ResidualEncoderAttentionBlock,
         ResidualEncoderAttentionBlockConfig,
@@ -105,15 +107,14 @@ impl AudioEncoderMeta for AudioEncoderConfig {
     }
 }
 
-impl AudioEncoderConfig {
-    /// Initialize an `AudioEncoder`.
-    pub fn init<B: Backend>(
+impl<B: Backend> ModuleInit<B, AudioEncoder<B>> for AudioEncoderConfig {
+    fn try_init(
         &self,
         device: &B::Device,
-    ) -> AudioEncoder<B> {
+    ) -> BunsenResult<AudioEncoder<B>> {
         let pos_ctx = self.max_context / 2;
 
-        AudioEncoder {
+        Ok(AudioEncoder {
             conv1: Conv1dConfig::new(self.n_mels, self.d_model, 3)
                 .with_padding(PaddingConfig1d::Explicit(1, 1))
                 .init(device),
@@ -135,12 +136,12 @@ impl AudioEncoderConfig {
                 .map(|_| {
                     ResidualEncoderAttentionBlockConfig::new(self.d_model)
                         .with_d_head(self.d_head)
-                        .init(device)
+                        .try_init(device)
                 })
-                .collect(),
+                .collect::<BunsenResult<Vec<ResidualEncoderAttentionBlock<B>>>>()?,
 
             ln_post: LayerNormConfig::new(self.d_model).init(device),
-        }
+        })
     }
 }
 

--- a/crates/bunsen/src/kits/speech/whisper/blocks/decoder_block.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/decoder_block.rs
@@ -17,16 +17,20 @@ use burn::{
 };
 
 use super::WHISPER_DEFAULT_D_MODEL;
-use crate::blocks::transformers::{
-    attention::{
-        layer_norm_cross_attn,
-        layer_norm_self_attn,
+use crate::{
+    blocks::transformers::{
+        attention::{
+            layer_norm_cross_attn,
+            layer_norm_self_attn,
+        },
+        mlp::{
+            Mlp,
+            MlpConfig,
+            layer_norm_mlp,
+        },
     },
-    mlp::{
-        Mlp,
-        MlpConfig,
-        layer_norm_mlp,
-    },
+    burner::module::ModuleInit,
+    errors::BunsenResult,
 };
 
 /// Common meta for [`ResidualDecoderAttentionBlock`] and
@@ -71,12 +75,13 @@ impl ResidualDecoderAttentionBlockMeta for ResidualDecoderAttentionBlockConfig {
     }
 }
 
-impl ResidualDecoderAttentionBlockConfig {
-    /// Initialize the residual decoder attention block.
-    pub fn init<B: Backend>(
+impl<B: Backend> ModuleInit<B, ResidualDecoderAttentionBlock<B>>
+    for ResidualDecoderAttentionBlockConfig
+{
+    fn try_init(
         &self,
         device: &B::Device,
-    ) -> ResidualDecoderAttentionBlock<B> {
+    ) -> BunsenResult<ResidualDecoderAttentionBlock<B>> {
         let mha_cfg =
             MultiHeadAttentionConfig::new(self.d_model, self.n_heads()).with_dropout(self.dropout);
         let ln_cfg = LayerNormConfig::new(self.d_model);
@@ -88,14 +93,14 @@ impl ResidualDecoderAttentionBlockConfig {
         attn.key.bias = None;
         cross_attn.key.bias = None;
 
-        ResidualDecoderAttentionBlock {
+        Ok(ResidualDecoderAttentionBlock {
             attn_ln: ln_cfg.init(device),
             attn,
             cross_attn_ln: ln_cfg.init(device),
             cross_attn,
             mlp_ln: ln_cfg.init(device),
-            mlp: MlpConfig::new(self.d_model).init(device),
-        }
+            mlp: MlpConfig::new(self.d_model).try_init(device)?,
+        })
     }
 }
 

--- a/crates/bunsen/src/kits/speech/whisper/blocks/encoder_block.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/encoder_block.rs
@@ -14,13 +14,16 @@ use burn::{
 };
 
 use super::WHISPER_DEFAULT_D_MODEL;
-use crate::blocks::transformers::{
-    attention::layer_norm_self_attn,
-    mlp::{
-        Mlp,
-        MlpConfig,
-        layer_norm_mlp,
+use crate::{
+    blocks::transformers::{
+        attention::layer_norm_self_attn,
+        mlp::{
+            Mlp,
+            MlpConfig,
+            layer_norm_mlp,
+        },
     },
+    burner::module::ModuleInit,
 };
 
 /// Common meta for [`ResidualEncoderAttentionBlock`] and
@@ -65,12 +68,13 @@ impl ResidualEncoderAttentionBlockMeta for ResidualEncoderAttentionBlockConfig {
     }
 }
 
-impl ResidualEncoderAttentionBlockConfig {
-    /// Initialize a block.
-    pub fn init<B: Backend>(
+impl<B: Backend> ModuleInit<B, ResidualEncoderAttentionBlock<B>>
+    for ResidualEncoderAttentionBlockConfig
+{
+    fn try_init(
         &self,
         device: &B::Device,
-    ) -> ResidualEncoderAttentionBlock<B> {
+    ) -> crate::errors::BunsenResult<ResidualEncoderAttentionBlock<B>> {
         let mha_cfg =
             MultiHeadAttentionConfig::new(self.d_model, self.n_heads()).with_dropout(self.dropout);
         let ln_cfg = LayerNormConfig::new(self.d_model);
@@ -80,12 +84,12 @@ impl ResidualEncoderAttentionBlockConfig {
         let mut attn = mha_cfg.init(device);
         attn.key.bias = None;
 
-        ResidualEncoderAttentionBlock {
+        Ok(ResidualEncoderAttentionBlock {
             attn_ln: ln_cfg.init(device),
             attn,
             mlp_ln: ln_cfg.init(device),
-            mlp: MlpConfig::new(self.d_model).init(device),
-        }
+            mlp: MlpConfig::new(self.d_model).try_init(device)?,
+        })
     }
 }
 

--- a/crates/bunsen/src/kits/speech/whisper/blocks/text_decoder.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/text_decoder.rs
@@ -25,6 +25,8 @@ use burn::{
 use super::WHISPER_DEFAULT_D_MODEL;
 use crate::{
     blocks::transformers::attention::causal_mask,
+    burner::module::ModuleInit,
+    errors::BunsenResult,
     kits::speech::whisper::blocks::{
         ResidualDecoderAttentionBlock,
         ResidualDecoderAttentionBlockConfig,
@@ -113,13 +115,12 @@ pub fn attn_decoder_mask<B: Backend>(
     mask
 }
 
-impl TextDecoderConfig {
-    /// Initialize text decoder module.
-    pub fn init<B: Backend>(
+impl<B: Backend> ModuleInit<B, TextDecoder<B>> for TextDecoderConfig {
+    fn try_init(
         &self,
         device: &B::Device,
-    ) -> TextDecoder<B> {
-        TextDecoder {
+    ) -> BunsenResult<TextDecoder<B>> {
+        Ok(TextDecoder {
             token_embedding: EmbeddingConfig::new(self.vocab_size, self.d_model).init(device),
 
             positional_embedding: Param::from_tensor(Tensor::<B, 2>::random(
@@ -133,13 +134,13 @@ impl TextDecoderConfig {
                     ResidualDecoderAttentionBlockConfig::new(self.d_model)
                         .with_d_head(self.d_head)
                         .with_dropout(self.block_dropout)
-                        .init(device)
+                        .try_init(device)
                 })
-                .collect(),
+                .collect::<BunsenResult<Vec<ResidualDecoderAttentionBlock<B>>>>()?,
 
             ln: LayerNormConfig::new(self.d_model).init(device),
             // mask: Param::from_tensor(attn_decoder_mask(self.max_text_context, device)),
-        }
+        })
     }
 }
 

--- a/crates/bunsen/src/kits/speech/whisper/blocks/whisper_model.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/whisper_model.rs
@@ -9,13 +9,16 @@ use burn::{
 };
 
 use super::WHISPER_DEFAULT_D_MODEL;
-use crate::kits::speech::whisper::blocks::{
-    AudioEncoder,
-    AudioEncoderConfig,
-    AudioEncoderMeta,
-    TextDecoder,
-    TextDecoderConfig,
-    TextDecoderMeta,
+use crate::{
+    burner::module::ModuleInit,
+    kits::speech::whisper::blocks::{
+        AudioEncoder,
+        AudioEncoderConfig,
+        AudioEncoderMeta,
+        TextDecoder,
+        TextDecoderConfig,
+        TextDecoderMeta,
+    },
 };
 
 /// Whisper API config.
@@ -66,6 +69,15 @@ impl WhisperApiConfig {
             )
             .with_d_head(self.d_head),
         }
+    }
+}
+
+impl<B: Backend> ModuleInit<B, Whisper<B>> for WhisperApiConfig {
+    fn try_init(
+        &self,
+        device: &B::Device,
+    ) -> crate::errors::BunsenResult<Whisper<B>> {
+        self.to_structure().try_init(device)
     }
 }
 
@@ -123,18 +135,17 @@ impl WhisperMeta for WhisperStructuralConfig {
     }
 }
 
-impl WhisperStructuralConfig {
-    /// Initialize the Whisper model with the given configuration and device.
-    pub fn init<B: Backend>(
-        self,
+impl<B: Backend> ModuleInit<B, Whisper<B>> for WhisperStructuralConfig {
+    fn try_init(
+        &self,
         device: &B::Device,
-    ) -> Whisper<B> {
+    ) -> crate::errors::BunsenResult<Whisper<B>> {
         let encoder = self.encoder.init(device);
         let decoder = self.decoder.init(device);
 
         assert_eq!(encoder.d_model(), decoder.d_model());
 
-        Whisper { encoder, decoder }
+        Ok(Whisper { encoder, decoder })
     }
 }
 
@@ -265,7 +276,7 @@ mod tests {
         assert_eq!(structural.decoder().n_heads(), n_text_heads);
         assert_eq!(structural.decoder().n_layers(), n_text_layers);
 
-        let model: Whisper<B> = structural.init(&device);
+        let model: Whisper<B> = structural.try_init(&device).unwrap();
 
         assert_eq!(model.n_mels(), n_mels);
         assert_eq!(model.vocab_size(), vocab_size);

--- a/examples/resnet_finetune/src/main.rs
+++ b/examples/resnet_finetune/src/main.rs
@@ -10,7 +10,10 @@ use std::time::Instant;
 
 use anyhow::Context;
 use bunsen::{
-    burner::module::DTypeMapper,
+    burner::module::{
+        DTypeMapper,
+        ModuleInit,
+    },
     data::cache::BunsenDiskCache,
     kits::bimm::resnet::{
         PREFAB_RESNET_MAP,
@@ -344,7 +347,7 @@ pub fn train<B: AutodiffBackend>(args: &Args) -> anyhow::Result<()> {
         }
     }
 
-    let model: ResNet<B> = resnet_config.clone().to_structure().init(&device);
+    let model: ResNet<B> = resnet_config.clone().try_init(&device)?;
 
     let old_float_type = model.output_fc.weight.dtype();
 

--- a/examples/resnet_tiny/src/main.rs
+++ b/examples/resnet_tiny/src/main.rs
@@ -10,7 +10,10 @@ use core::{
 use std::sync::Arc;
 
 use bunsen::{
-    burner::module::DTypeMapper,
+    burner::module::{
+        DTypeMapper,
+        ModuleInit,
+    },
     data::cache::BunsenDiskCache,
     kits::bimm::resnet::{
         PREFAB_RESNET_MAP,
@@ -229,7 +232,7 @@ pub fn backend_main<B: AutodiffBackend>(args: &Args) -> anyhow::Result<()> {
         .with_activation(ActivationConfig::Gelu)
         .to_structure();
 
-    let resnet: ResNet<B> = resnet_config.init(&device);
+    let resnet: ResNet<B> = resnet_config.try_init(&device)?;
 
     let resnet: ResNet<B> = match &args.resnet_pretrained {
         Some(pretrained) => {

--- a/examples/swin_tiny/src/main.rs
+++ b/examples/swin_tiny/src/main.rs
@@ -9,6 +9,11 @@ use bunsen::{
         DropBlock2dConfig,
         DropBlockOptions,
     },
+    burner::module::ModuleInit,
+    errors::{
+        BunsenResult,
+        WithOkOrPanic,
+    },
     kits::bimm::swin::v2::swin_model::{
         LayerConfig,
         SwinTransformerV2,
@@ -389,7 +394,7 @@ pub fn backend_main<B: AutodiffBackend>(args: &Args) -> anyhow::Result<()> {
     .summary();
 
     let result = training.launch(Learner::new(
-        training_config.model.init::<B>(&device),
+        training_config.model.try_init(&device)?,
         training_config.optimizer.init(),
         lr_scheduler,
     ));
@@ -408,15 +413,15 @@ pub struct ModelConfig {
     pub swin: SwinTransformerV2Config,
 }
 
-impl ModelConfig {
-    pub fn init<B: Backend>(
-        self,
+impl<B: Backend> ModuleInit<B, Model<B>> for ModelConfig {
+    fn try_init(
+        &self,
         device: &B::Device,
-    ) -> Model<B> {
-        Model {
+    ) -> BunsenResult<Model<B>> {
+        Ok(Model {
             drop_block: self.drop_block.init(),
-            swin: self.swin.init::<B>(device),
-        }
+            swin: self.swin.try_init(device).ok_or_panic(),
+        })
     }
 }
 

--- a/examples/whisper-dev/src/main.rs
+++ b/examples/whisper-dev/src/main.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use bunsen::{
+    burner::module::ModuleInit,
     errors::WithOkOrPanic,
     kits::speech::whisper::{
         blocks::Whisper,
@@ -57,8 +58,7 @@ fn run<B: Backend>(args: Args) -> Result<(), Box<dyn std::error::Error>> {
 
     let device = Default::default();
 
-    let mut whisper: Whisper<B> = cfg.to_structure().init(&device);
-
+    let mut whisper: Whisper<B> = cfg.try_init(&device)?;
     whisper.load_from(&mut store).ok_or_panic();
 
     Ok(())


### PR DESCRIPTION


This pull request introduces a new `ModuleInit` trait to standardize module initialization across the library. Key updates include:

- Addition of the `ModuleInit` trait with `try_init` and `init` methods for consistent error handling.
- Refactoring of modules like `Whisper`, ResNet blocks, and SwinTransformer to utilize the new trait.
- Updates to tests and examples to align with the new initialization approach.
