### PR TITLE
Refactor and optimize DropBlock, Whisper, and SwinTransformer modules

### DIFF
--- a/crates/bunsen/src/blocks/images/drop/drop_block.rs
+++ b/crates/bunsen/src/blocks/images/drop/drop_block.rs
@@ -12,10 +12,9 @@ use burn::{
     },
 };
 
-use crate::ops::drop::{
-    DropBlockOptions,
-    drop_block_2d,
-};
+#[doc(inline)]
+pub use crate::ops::drop::DropBlockOptions;
+use crate::ops::drop::drop_block_2d;
 
 /// Config for [`DropBlock2dConfig`] module.
 #[derive(Config, Debug)]

--- a/crates/bunsen/src/errors/mod.rs
+++ b/crates/bunsen/src/errors/mod.rs
@@ -28,7 +28,7 @@ impl BunsenError {
     /// Map an error to an External string error.
     pub fn external<E>(e: E) -> Self
     where
-        E: std::error::Error + Send + Sync + 'static,
+        E: std::error::Error,
     {
         BunsenError::External(e.to_string())
     }

--- a/crates/bunsen/src/kits/bimm/swin/v2/mod.rs
+++ b/crates/bunsen/src/kits/bimm/swin/v2/mod.rs
@@ -43,3 +43,6 @@ pub mod swin_block;
 pub mod swin_model;
 pub mod window_attention;
 pub mod windowing;
+
+#[doc(inline)]
+pub use swin_model::*;

--- a/crates/bunsen/src/kits/speech/whisper/pretrained/pytorch_utils.rs
+++ b/crates/bunsen/src/kits/speech/whisper/pretrained/pytorch_utils.rs
@@ -3,15 +3,27 @@ use std::path::{
     PathBuf,
 };
 
-use burn::config::Config;
+use burn::{
+    config::Config,
+    prelude::Backend,
+};
 use burn_store::{
+    ModuleSnapshot,
     ModuleStore,
     PytorchStore,
 };
 
-use crate::kits::speech::whisper::blocks::{
-    WHISPER_DEFAULT_D_MODEL,
-    WhisperApiConfig,
+use crate::{
+    burner::module::ModuleInit,
+    errors::{
+        BunsenError,
+        BunsenResult,
+    },
+    kits::speech::whisper::blocks::{
+        WHISPER_DEFAULT_D_MODEL,
+        Whisper,
+        WhisperApiConfig,
+    },
 };
 
 fn block_layers_from_keys<S: AsRef<str>>(
@@ -45,7 +57,7 @@ impl PytorchWhisperScanner {
     pub fn scan_cfg<P: AsRef<Path>>(
         &self,
         path: P,
-    ) -> Result<(PytorchStore, WhisperApiConfig), Box<dyn std::error::Error>> {
+    ) -> BunsenResult<(PytorchStore, WhisperApiConfig)> {
         let path = path.as_ref();
         let path: PathBuf = path.to_path_buf();
 
@@ -63,29 +75,33 @@ impl PytorchWhisperScanner {
 
         let mut store = store;
 
-        let keys = store.keys()?;
+        let keys = store.keys().map_err(BunsenError::external)?;
 
         let [d_model, n_mels] = store
-            .get_snapshot("encoder.conv1.weight")?
+            .get_snapshot("encoder.conv1.weight")
+            .map_err(BunsenError::external)?
             .unwrap()
             .shape
             .dims();
 
         let [vocab_size, _] = store
-            .get_snapshot("decoder.token_embedding.weight")?
+            .get_snapshot("decoder.token_embedding.weight")
+            .map_err(BunsenError::external)?
             .unwrap()
             .shape
             .dims();
 
         let [k, _] = store
-            .get_snapshot("encoder.positional_embedding")?
+            .get_snapshot("encoder.positional_embedding")
+            .map_err(BunsenError::external)?
             .unwrap()
             .shape
             .dims();
         let max_audio_ctx = k * 2;
 
         let [max_text_ctx, _] = store
-            .get_snapshot("decoder.positional_embedding")?
+            .get_snapshot("decoder.positional_embedding")
+            .map_err(BunsenError::external)?
             .unwrap()
             .shape
             .dims();
@@ -106,5 +122,21 @@ impl PytorchWhisperScanner {
             )
             .with_d_head(self.d_head),
         ))
+    }
+
+    /// Load a pytorch whisper model from a checkpoint.
+    pub fn load<B: Backend, P: AsRef<Path>>(
+        &self,
+        path: P,
+        device: &B::Device,
+    ) -> BunsenResult<(Whisper<B>, WhisperApiConfig)> {
+        let (mut store, cfg) = self.scan_cfg(path)?;
+
+        let mut module = cfg.try_init(device)?;
+        module
+            .load_from(&mut store)
+            .map_err(BunsenError::external)?;
+
+        Ok((module, cfg))
     }
 }

--- a/examples/swin_tiny/src/main.rs
+++ b/examples/swin_tiny/src/main.rs
@@ -7,18 +7,18 @@ use bunsen::{
     blocks::images::drop::drop_block::{
         DropBlock2d,
         DropBlock2dConfig,
+        DropBlockOptions,
     },
     burner::module::ModuleInit,
     errors::{
         BunsenResult,
         WithOkOrPanic,
     },
-    kits::bimm::swin::v2::swin_model::{
+    kits::bimm::swin::v2::{
         LayerConfig,
         SwinTransformerV2,
         SwinTransformerV2Config,
     },
-    ops::drop::DropBlockOptions,
 };
 use bunsen_firehose::{
     burn::{

--- a/examples/whisper-dev/src/main.rs
+++ b/examples/whisper-dev/src/main.rs
@@ -1,9 +1,6 @@
 use std::path::PathBuf;
 
-use bunsen::kits::speech::whisper::{
-    blocks::Whisper,
-    pretrained::PytorchWhisperScanner,
-};
+use bunsen::kits::speech::whisper::pretrained::PytorchWhisperScanner;
 use burn::prelude::Backend;
 use clap::Parser;
 
@@ -46,9 +43,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn run<B: Backend>(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     let device = B::Device::default();
 
-    let (module, cfg): (Whisper<B>, _) = PytorchWhisperScanner::new()
+    let (module, cfg) = PytorchWhisperScanner::new()
         .with_top_level_key(args.top_level_key.clone())
-        .load(PathBuf::from(args.source.clone()), &device)?;
+        .load::<B, _>(PathBuf::from(args.source.clone()), &device)?;
 
     println!("{:#?}", cfg);
 

--- a/examples/whisper-dev/src/main.rs
+++ b/examples/whisper-dev/src/main.rs
@@ -1,22 +1,17 @@
 use std::path::PathBuf;
 
-use bunsen::{
-    burner::module::ModuleInit,
-    errors::WithOkOrPanic,
-    kits::speech::whisper::{
-        blocks::Whisper,
-        pretrained::PytorchWhisperScanner,
-    },
+use bunsen::kits::speech::whisper::{
+    blocks::Whisper,
+    pretrained::PytorchWhisperScanner,
 };
 use burn::prelude::Backend;
-use burn_store::ModuleSnapshot;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
     /// Path to the source model.
-    #[arg(long, default_value = "/media/Data/models/whisper/base.en.pt")]
+    #[arg(long)]
     pub source: String,
 
     /// Path to the source model.
@@ -49,17 +44,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 #[allow(unused)]
 fn run<B: Backend>(args: Args) -> Result<(), Box<dyn std::error::Error>> {
-    let (mut store, cfg) = PytorchWhisperScanner::new()
+    let device = B::Device::default();
+
+    let (module, cfg): (Whisper<B>, _) = PytorchWhisperScanner::new()
         .with_top_level_key(args.top_level_key.clone())
-        .scan_cfg(PathBuf::from(args.source.clone()))?;
+        .load(PathBuf::from(args.source.clone()), &device)?;
 
     println!("{:#?}", cfg);
-    // println!("keys: {:#?}", store.keys());
-
-    let device = Default::default();
-
-    let mut whisper: Whisper<B> = cfg.try_init(&device)?;
-    whisper.load_from(&mut store).ok_or_panic();
 
     Ok(())
 }


### PR DESCRIPTION
- Refactors the `DropBlock`, `Whisper`, and `SwinTransformer` modules to enhance modularity and maintainability.
- Inlines `DropBlockOptions` and reorganizes imports for better code clarity.
- Simplifies the `external` error type in `BunsenError` by removing redundant bounds.
- Refines error handling in Whisper's `scan_cfg` by consistently using `BunsenResult`.
- Adds a `load` method to the `PytorchWhisperScanner` to enable model loading from checkpoints.
- Optimizes module exports for SwinTransformer, including the addition of inline documentation.
- Updates example configurations (e.g., `whisper-dev`, `swin_tiny`) to reflect the improved module structure.
