### PR TITLE
ci: gate releases on release-PR merge; ready preview crate for publish

### DIFF
--- a/crates/bunsen-preview-chat-dataloader/Cargo.toml
+++ b/crates/bunsen-preview-chat-dataloader/Cargo.toml
@@ -5,6 +5,10 @@ version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
 
+repository.workspace = true
+license.workspace = true
+description = "bunsen preview: Arrow-backed chat dataloader with tokenization for training"
+
 
 [lints]
 workspace = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -26,6 +26,14 @@ semver_check = true
 # Cut a GitHub release (and git tag) for each published crate.
 git_release_enable = true
 
+# Only release when the release PR is merged — not on every push to `main`.
+# Without this, the `release` job publishes any crate whose manifest version
+# isn't on crates.io yet the moment it lands on `main`. That's what caused
+# `bunsen-preview-chat-dataloader` (manifest 0.21.3, never published) to attempt
+# a 0.21.3 back-publish. With releases gated on the release PR, a newly-added
+# crate first publishes at the *next* bumped version, alongside the others.
+release_always = false
+
 
 # --- Published crates -------------------------------------------------------
 # All four crates share a single version (lockstep) via `version_group`, which


### PR DESCRIPTION
Fixes the unexpected `0.21.3` back-publish attempt of `bunsen-preview-chat-dataloader`.

## What happened
The continuous `release` job publishes any releasable crate whose manifest version isn't on crates.io yet. `bunsen-preview-chat-dataloader` inherits `version.workspace = true` (currently `0.21.3`) but was never published, so adding it to the release list made release-plz try to **back-publish `0.21.3`**. That also failed on missing `description`/`license` metadata.

## Fix
- **`release_always = false`** — releases now happen only when the release PR merges, not on every push to `main`. A newly-onboarded crate first publishes at the **next bumped version** (alongside the others), instead of back-filling the current `0.21.3`. This matches the intended workflow: *merge the release PR to release.*
- **Metadata** — added `description`, `license` (workspace), and `repository` (workspace) to `bunsen-preview-chat-dataloader` so it's actually publishable.

## Effect after merge
- The failing continuous back-publish stops immediately.
- release-plz updates the open release PR **#64 (`chore: release v0.22.0`)** to include `bunsen-preview-chat-dataloader` bumped to `0.22.0`.
- Merging #64 publishes everything at `0.22.0`, including the preview crate's **first** release at `0.22.0` — no `0.21.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)