### PR TITLE
ci: let release-plz use RELEASE_PLZ_TOKEN so the release PR triggers CI

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -14,9 +14,13 @@ name: release-plz
 #     to create and approve pull requests.
 #
 # Note: PRs opened with the default GITHUB_TOKEN do not trigger other workflows
-# (so ci.yml won't run on the release PR). To get CI on the release PR, replace
-# GITHUB_TOKEN below with a Personal Access Token or GitHub App token. See
-# https://release-plz.dev/docs/github/token
+# (so ci.yml won't run on the release PR). To get CI on the release PR, set a
+# repository secret RELEASE_PLZ_TOKEN to a Personal Access Token or GitHub App
+# token; the jobs below prefer it and fall back to GITHUB_TOKEN when it is unset.
+# See https://release-plz.dev/docs/github/token
+#
+# Fine-grained PAT scope: Contents (read/write) + Pull requests (read/write).
+# Classic PAT scope: repo. A GitHub App token is preferred (no expiry, scoped).
 
 on:
   push:
@@ -43,7 +47,7 @@ jobs:
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   # Keep the release PR up to date on every push to main.
@@ -65,5 +69,5 @@ jobs:
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Problem

The release-plz PR (#64) gets no CI checks and no "re-run" button. This is GitHub's intentional behavior: **workflow runs triggered by the default `GITHUB_TOKEN` cannot trigger other workflow runs.** release-plz opens the PR with `GITHUB_TOKEN`, so `ci.yml`'s `pull_request` trigger is suppressed. With no check runs ever created, GitHub shows no re-run button either, and branch protection leaves the PR `BLOCKED`.

## Fix

Both release-plz jobs now use `${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}`. Once a `RELEASE_PLZ_TOKEN` secret (a PAT or GitHub App token) is added, release PRs are pushed under a real identity and trigger CI normally. Until then, it falls back to `GITHUB_TOKEN` so nothing breaks.

## Required follow-up (manual)

Add a repo secret **`RELEASE_PLZ_TOKEN`**:
- **GitHub App (preferred):** no expiry, scoped. See https://release-plz.dev/docs/github/token
- **Fine-grained PAT:** Contents (read/write) + Pull requests (read/write)
- **Classic PAT:** `repo` scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)