### PR TITLE
[fix]: Add STYLE.md and standardize tensor shape documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       #     cargo tarpaulin --features=wgpu --coveralls=${{ secrets.COVERALLS_REPO_TOKEN }}
 
       - name: Docs
-        run: cargo doc --no-deps
+        run: cargo doc --no-deps --all-features
 
       - name: Build and Test
         run: cargo test --features=flex

--- a/STYLE.md
+++ b/STYLE.md
@@ -1,0 +1,68 @@
+# Bunsen Style Guide
+
+Conventions for code and documentation in the `bunsen` crate. This file is the
+source of truth; assertions added under each chapter are applied across the code
+base.
+
+> See also [`book/src/contributing/style.md`](book/src/contributing/style.md)
+> for prose/Book conventions. This file governs in-source `rustdoc`.
+
+## rustdoc
+
+### Base Style
+
+The base style for rustdoc is [rfc1574].
+
+[rfc1574]: https://github.com/rust-lang/rfcs/blob/master/text/1574-more-api-documentation-conventions.md
+
+### Coverage
+
+* Every public interface requires rustdoc.
+* Objects in a lifecycle ('Config'>'Module') require a short situational relationship description with cross-links.
+
+Every public item needs rustdoc. This chapter defines the structure we expect,
+the cross-links between paired types, and how tensor shapes are written.
+
+### Tensor shape notation
+
+A tensor shape is written as a **single** backtick code span wrapping the whole
+shape in **square brackets**. Dimension expressions and inline annotations live
+*inside* the brackets:
+
+```text
+`[batch, time, embed]`
+`[batch, in_channels, height, width]`
+`[batch, height/2 * width/2, 2 * channels]`
+`[batch, out=planes*expansion, h, w]`
+`[VY=3, VX=3, (VY, VX)=2]`
+```
+
+Do **not** use any of these forms for a tensor shape:
+
+```text
+``[batch, time, embed]``              (double backticks)
+[`batch`, `time`, `embed`]            (per-element backticks)
+(`b_nw`, `num_heads`, ws*ws)          (parentheses + per-element backticks)
+(batch, time, embed)                  (parentheses)
+```
+
+Prefer **shape-first** phrasing — put the shape *before* the object it
+describes (`SHAPE object`) rather than trailing it (`object of shape SHAPE`).
+Articles (`a`/`an`/`the`) stay first; other modifiers follow the shape:
+
+```text
+prefer:  a `[batch, time, embed]` input tensor
+         a `[2*h-1, 2*w-1, 2]` 3D tensor containing the offsets
+not:     an input tensor of shape `[batch, time, embed]`
+         a 3D tensor of shape `[2*h-1, 2*w-1, 2]` containing the offsets
+```
+
+These are **not** tensor shapes — leave them as written:
+
+- Coordinate / value tuples and pairs: `(y, x)`, `(k, v)`,
+  `(density, velocity)`, `(height, width)` tuples.
+- Rust type code spans: `&[usize; D]`, `Param<Tensor<B, R, K>>`.
+- Half-open ranges and indexing: `[start, end)`, `env[$VAR]`.
+- Intra-doc link syntax: `[text](url)`.
+
+<!-- Assertions go here. -->

--- a/crates/bunsen/src/blocks/images/conv/cna.rs
+++ b/crates/bunsen/src/blocks/images/conv/cna.rs
@@ -58,7 +58,7 @@ pub struct AbstractCNA2dConfig {
 }
 
 impl AbstractCNA2dConfig {
-    /// Merge with a [`Conv2dConfig`] to construct a [`CNA2dConfig`].
+    /// Merges with a [`Conv2dConfig`] to construct a [`CNA2dConfig`].
     ///
     /// The abstract [`NormalizationConfig`] will be feature matched
     /// with the target [`Conv2dConfig`], resulting in a normalization
@@ -87,7 +87,7 @@ pub trait CNA2dMeta {
     /// Number of groups.
     fn groups(&self) -> usize;
 
-    /// Get the stride.
+    /// Returns the stride.
     fn stride(&self) -> [usize; 2];
 }
 
@@ -170,6 +170,8 @@ impl<B: Backend> ModuleInit<B, CNA2d<B>> for CNA2dConfig {
 /// to run code between the norm and application images.
 ///
 /// Implements [`CNA2dMeta`].
+///
+/// Built by [`CNA2dConfig`].
 #[derive(Module, Debug)]
 pub struct CNA2d<B: Backend> {
     /// Internal Conv2d layer.
@@ -214,12 +216,12 @@ impl<B: Backend> CNA2d<B> {
     ///
     /// # Arguments
     ///
-    /// - `input`: ``[batch, in_channels, in_height=out_height*stride,
-    ///   in_width=out_width*stride]``.
+    /// - `input`: `[batch, in_channels, in_height=out_height*stride,
+    ///   in_width=out_width*stride]`.
     ///
     /// # Returns
     ///
-    /// ``[batch, out_channels, out_height, out_width]``
+    /// `[batch, out_channels, out_height, out_width]`
     pub fn forward(
         &self,
         input: Tensor<B, 4>,
@@ -241,14 +243,14 @@ impl<B: Backend> CNA2d<B> {
     ///
     /// # Arguments
     ///
-    /// - `input`: \ ``[batch, in_channels, in_height=out_height*stride,
-    ///   in_width=out_width*stride]``.
-    /// - `f`: a callback endofunction, from/to ``[batch, in_channels,
-    ///   out_height, out_width]``.
+    /// - `input`: \ `[batch, in_channels, in_height=out_height*stride,
+    ///   in_width=out_width*stride]`.
+    /// - `f`: a callback endofunction, from/to `[batch, in_channels,
+    ///   out_height, out_width]`.
     ///
     /// # Returns
     ///
-    /// ``[batch, out_channels, out_height, out_width]``
+    /// `[batch, out_channels, out_height, out_width]`
     pub fn map_forward<F>(
         &self,
         input: Tensor<B, 4>,

--- a/crates/bunsen/src/blocks/images/conv/conv_norm.rs
+++ b/crates/bunsen/src/blocks/images/conv/conv_norm.rs
@@ -40,7 +40,7 @@ pub trait ConvNorm2dMeta {
     /// Number of output channels.
     fn out_channels(&self) -> usize;
 
-    /// Get the stride.
+    /// Returns the stride.
     fn stride(&self) -> &[usize; 2];
 }
 
@@ -76,7 +76,7 @@ impl From<Conv2dConfig> for ConvNorm2dConfig {
 }
 
 impl ConvNorm2dConfig {
-    /// Set the initializer.
+    /// Sets the initializer.
     pub fn with_initializer(
         self,
         initializer: Initializer,
@@ -101,6 +101,12 @@ impl<B: Backend> ModuleInit<B, ConvNorm2d<B>> for ConvNorm2dConfig {
 }
 
 /// Grouped [`Conv2d`] and [`BatchNorm`] layer.
+///
+/// Constructs via [`ConvNorm2dConfig`] and `.init(device)`, then call
+/// [`Self::forward`] on a `[batch, in_channels, height, width]` tensor to
+/// apply the convolution followed by batch normalization.
+///
+/// Built by [`ConvNorm2dConfig`].
 #[derive(Module, Debug)]
 pub struct ConvNorm2d<B: Backend> {
     /// Internal Conv2d layer.

--- a/crates/bunsen/src/blocks/images/drop/drop_block.rs
+++ b/crates/bunsen/src/blocks/images/drop/drop_block.rs
@@ -16,7 +16,7 @@ use burn::{
 pub use crate::ops::drop::DropBlockOptions;
 use crate::ops::drop::drop_block_2d;
 
-/// Config for [`DropBlock2dConfig`] module.
+/// Config for [`DropBlock2d`].
 #[derive(Config, Debug)]
 pub struct DropBlock2dConfig {
     /// The options for the drop block algorithm.
@@ -31,7 +31,7 @@ impl From<DropBlockOptions> for DropBlock2dConfig {
 }
 
 impl DropBlock2dConfig {
-    /// Initialize a [`DropBlock2d`] module.
+    /// Initializes a [`DropBlock2d`] module.
     pub fn init(&self) -> DropBlock2d {
         DropBlock2d {
             options: self.options.clone(),
@@ -45,6 +45,8 @@ impl DropBlock2dConfig {
 ///
 /// Based upon [DropBlock (Ghiasi et al., 2018)](https://arxiv.org/pdf/1810.12890.pdf);
 /// inspired also by the `python-image-models` implementation.
+///
+/// Built by [`DropBlock2dConfig`].
 #[derive(Module, Clone, Debug)]
 pub struct DropBlock2d {
     /// The options for the drop block algorithm.

--- a/crates/bunsen/src/blocks/images/drop/drop_path.rs
+++ b/crates/bunsen/src/blocks/images/drop/drop_path.rs
@@ -111,7 +111,7 @@ pub trait DropPathMeta {
     fn scale_by_keep(&self) -> bool;
 }
 
-/// Configuration for the `DropPath` module.
+/// Configuration for the [`DropPath`] module.
 #[derive(Config, Debug)]
 pub struct DropPathConfig {
     /// Probability of dropping a path.
@@ -149,6 +149,8 @@ impl DropPathConfig {
 ///
 /// Burn Module that implements the `DropPath` (Stochastic Depth)
 /// regularization.
+///
+/// Built by [`DropPathConfig`].
 #[derive(Module, Clone, Debug)]
 pub struct DropPath {
     /// Probability of dropping a path.
@@ -184,9 +186,9 @@ impl DropPath {
     ///
     /// This is used for stochastic depth in the transformer block.
     ///
-    /// # Parameters
+    /// # Arguments
     ///
-    /// * `x` - Input tensor of shape (B, D).
+    /// * `x` - `[B, D]` input tensor.
     /// * `f` - Function to apply on the input tensor.
     ///
     /// # Returns

--- a/crates/bunsen/src/blocks/images/drop/size_config.rs
+++ b/crates/bunsen/src/blocks/images/drop/size_config.rs
@@ -25,18 +25,18 @@ pub enum SizeConfig {
 }
 
 impl SizeConfig {
-    /// Construct a source which will have the same size as the source dataset.
+    /// Constructs a source which will have the same size as the source dataset.
     pub fn source() -> Self {
         Self::Default
     }
 
     /// Resolve the effective size.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `source_size`: the size of the source dataset.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// The resolved size of the wrapper dataset.
     pub fn resolve(

--- a/crates/bunsen/src/blocks/images/patching/patch_embed.rs
+++ b/crates/bunsen/src/blocks/images/patching/patch_embed.rs
@@ -70,7 +70,7 @@ pub trait PatchEmbedMeta {
     fn enable_patch_norm(&self) -> bool;
 }
 
-/// Configuration for `PatchEmbed`.
+/// Configuration for [`PatchEmbed`].
 #[derive(Config, Debug, Copy)]
 pub struct PatchEmbedConfig {
     /// Input resolution (height, width).
@@ -143,6 +143,8 @@ impl<B: Backend> ModuleInit<B, PatchEmbed<B>> for PatchEmbedConfig {
 }
 
 /// SWIN-Transformer v2 `PatchEmbed` module.
+///
+/// Built by [`PatchEmbedConfig`].
 #[derive(Module, Debug)]
 pub struct PatchEmbed<B: Backend> {
     /// Input resolution (height, width).
@@ -181,15 +183,15 @@ impl<B: Backend> PatchEmbedMeta for PatchEmbed<B> {
 }
 
 impl<B: Backend> PatchEmbed<B> {
-    /// Apply the `PatchEmbed` module to an input tensor.
+    /// Applies the `PatchEmbed` module to an input tensor.
     ///
     /// # Arguments
     ///
-    /// * `x` - Input tensor of shape ``[B, C, H, W]``.
+    /// * `x` - `[B, C, H, W]` input tensor.
     ///
     /// # Returns
     ///
-    /// * Output tensor of shape ``[B, H/patch_size * W/patch_size, d_output]``.
+    /// * `[B, H/patch_size * W/patch_size, d_output]` output tensor.
     #[must_use]
     pub fn forward(
         &self,

--- a/crates/bunsen/src/blocks/images/pool/avg_pool_2d_same.rs
+++ b/crates/bunsen/src/blocks/images/pool/avg_pool_2d_same.rs
@@ -118,7 +118,7 @@ pub struct AvgPool2dSameConfig {
 }
 
 impl AvgPool2dSameConfig {
-    /// Initialize [`AvgPool2dSame`].
+    /// Initializes [`AvgPool2dSame`].
     pub fn init(self) -> AvgPool2dSame {
         AvgPool2dSame {
             pool: self.pool.init(),
@@ -126,7 +126,14 @@ impl AvgPool2dSameConfig {
     }
 }
 
-/// `AvgPool2dSame` Layer.
+/// 2D average pooling with TensorFlow-style "SAME" padding.
+///
+/// Constructs via [`AvgPool2dSameConfig`] and `.init()`. The [`Self::forward`]
+/// pass dynamically pads the input with [`pad_same`] so the output spatial size
+/// matches TensorFlow's "SAME" convention, then applies the wrapped
+/// [`AvgPool2d`].
+///
+/// Built by [`AvgPool2dSameConfig`].
 #[derive(Module, Clone, Debug)]
 pub struct AvgPool2dSame {
     pool: AvgPool2d,

--- a/crates/bunsen/src/blocks/transformers/attention/csa.rs
+++ b/crates/bunsen/src/blocks/transformers/attention/csa.rs
@@ -44,16 +44,16 @@ use crate::{
 
 /// Common meta for [`CausalSelfAttention`] and [`CausalSelfAttentionConfig`].
 pub trait CausalSelfAttentionMeta {
-    /// Return the size of the input and output.
+    /// Returns the size of the input and output.
     fn n_embed(&self) -> usize;
 
-    /// Return the number of heads.
+    /// Returns the number of heads.
     fn n_head(&self) -> usize;
 
-    /// Return the number of KV heads.
+    /// Returns the number of KV heads.
     fn n_kv_head(&self) -> usize;
 
-    /// Return the size of each head.
+    /// Returns the size of each head.
     fn head_dim(&self) -> usize {
         self.n_embed() / self.n_head()
     }
@@ -138,7 +138,7 @@ impl CausalSelfAttentionConfig {
 }
 
 impl CausalSelfAttentionConfig {
-    /// Initialize the module.
+    /// Initializes the module.
     pub fn try_init<B: Backend>(
         &self,
         layer_index: usize,
@@ -175,7 +175,7 @@ impl CausalSelfAttentionConfig {
         })
     }
 
-    /// Initialize the module, or panic.
+    /// Initializes the module, or panic.
     pub fn init<B: Backend>(
         &self,
         layer_index: usize,
@@ -186,6 +186,15 @@ impl CausalSelfAttentionConfig {
 }
 
 /// Causal Self-Attention Module
+///
+/// Multi-head causal self-attention with rotary positional embeddings,
+/// optional Group Query Attention (fewer KV heads than query heads), and
+/// per-head query/key normalization. Construct via
+/// [`CausalSelfAttentionConfig`] and `.init(layer_index, device)`, then call
+/// [`forward`](CausalSelfAttention::forward) with an input sequence, a
+/// [`RotaryEmbedding`], and an optional [`KVCache`].
+///
+/// Built by [`CausalSelfAttentionConfig`].
 #[derive(Module, Debug)]
 pub struct CausalSelfAttention<B: Backend> {
     /// Layer Index.
@@ -235,12 +244,12 @@ impl<B: Backend> CausalSelfAttention<B> {
     /// Forward Pass.
     ///
     /// # Arguments
-    /// - `input`: a ``[B, T, D]`` sequence.
+    /// - `input`: a `[B, T, D]` sequence.
     /// - `r_emb`: a rotary embedding with len ``T``.
     /// - `kv_cache`: optional KV cache.
     ///
     /// # Returns
-    /// - ``[B, T, D]`` attention.
+    /// - `[B, T, D]` attention.
     pub fn forward(
         &self,
         input: Tensor<B, 3>,

--- a/crates/bunsen/src/blocks/transformers/attention/kvcache.rs
+++ b/crates/bunsen/src/blocks/transformers/attention/kvcache.rs
@@ -54,7 +54,7 @@ pub struct KVCacheConfig {
 }
 
 impl KVCacheConfig {
-    /// Set the `batch_size`.
+    /// Sets the `batch_size`.
     pub fn with_batch_size(
         self,
         batch_size: usize,
@@ -86,7 +86,7 @@ impl KVCacheMeta for KVCacheConfig {
 }
 
 impl KVCacheConfig {
-    /// Initialize a [`KVCache`].
+    /// Initializes a [`KVCache`].
     pub fn init<B: Backend>(self) -> KVCache<B> {
         KVCache {
             batch_size: self.batch_size,
@@ -103,6 +103,19 @@ impl KVCacheConfig {
 }
 
 /// KV Cache
+///
+/// A growable key/value cache for incremental (autoregressive) attention
+/// decoding. It stores per-layer key and value tensors across decoding steps
+/// so each new token only attends over freshly computed keys/values plus the
+/// cached history. Use [`insert_kv`](KVCache::insert_kv) to append a step's
+/// `(k, v)` and obtain the full cached slices, [`pos`](KVCache::pos) /
+/// [`reset`](KVCache::reset) to query or rewind the position, and
+/// [`prefill`](KVCache::prefill) to seed it from another cache. The backing
+/// storage grows in chunks as the sequence length increases.
+///
+/// Constructs via [`KVCacheConfig`] and `.init()`.
+///
+/// Built by [`KVCacheConfig`].
 #[derive(Module, Debug)]
 pub struct KVCache<B: Backend> {
     batch_size: usize,
@@ -141,14 +154,14 @@ impl<B: Backend> KVCacheMeta for KVCache<B> {
 }
 
 impl<B: Backend> KVCache<B> {
-    /// Reset the current position.
+    /// Resets the current position.
     ///
     /// Does not drop/re-allocate the cache.
     pub fn reset(&mut self) {
         self.pos = 0;
     }
 
-    /// Get the current position.
+    /// Returns the current position.
     pub fn pos(&self) -> usize {
         self.pos
     }
@@ -196,15 +209,15 @@ impl<B: Backend> KVCache<B> {
         self.pos = other.pos;
     }
 
-    /// Insert and extend a (k, v) pair.
+    /// Inserts and extends a `(k, v)` pair.
     ///
     /// # Arguments
     /// - `layer_idx`: the block layer index.
-    /// - `k`: the ``[B, H_kv, T, D]`` key tensor.
-    /// - `v`: the ``[B, H_kv, T, D]`` value tensor.
+    /// - `k`: the `[B, H_kv, T, D]` key tensor.
+    /// - `v`: the `[B, H_kv, T, D]` value tensor.
     ///
     /// # Returns
-    /// - the extended (k, v) ``[B, H_kv, T, D]`` pair.
+    /// - the extended (k, v) `[B, H_kv, T, D]` pair.
     pub fn insert_kv(
         &mut self,
         layer_idx: usize,
@@ -302,7 +315,7 @@ impl<B: Backend> KVCache<B> {
         .cast(dtype)
     }
 
-    /// Compute the target allocation size for a given required size.
+    /// Computes the target allocation size for a given required size.
     pub fn allocation_size(
         &self,
         required_size: usize,

--- a/crates/bunsen/src/blocks/transformers/attention/masks.rs
+++ b/crates/bunsen/src/blocks/transformers/attention/masks.rs
@@ -6,7 +6,7 @@ use burn::{
     },
 };
 
-/// Generate a Bool causal mask [1, `seq_len`, `n_past` + `seq_len`].
+/// Generates a Bool causal mask `[1, seq_len, n_past + seq_len]`.
 /// `true` = masked (future positions blocked), `false` = attend.
 pub fn causal_mask<B: Backend>(
     seq_len: usize,

--- a/crates/bunsen/src/blocks/transformers/attention/multihead_utils.rs
+++ b/crates/bunsen/src/blocks/transformers/attention/multihead_utils.rs
@@ -14,18 +14,18 @@ use burn::{
     },
 };
 
-/// Compute layer normalized self-attn.
+/// Computes layer normalized self-attn.
 ///
-/// ## Arguments
+/// # Arguments
 /// * `layer_norm` - `LayerNorm`.
 /// * `mh_attn` - `MultiHeadAttention`.
-/// * `x` - ``[batch, seq_len, d_model]`` input.
-/// * `mask` - Optional ``[batch, seq_len, seq_len]`` attention mask.
+/// * `x` - `[batch, seq_len, d_model]` input.
+/// * `mask` - Optional `[batch, seq_len, seq_len]` attention mask.
 ///
-/// ## Returns
+/// # Returns
 /// `RdabForwardRecord` - forward record.
-/// * `fr.output` : ``[batch, seq_len, d_model]``.
-/// * `fr.ca_weights` : ``[batch, n_heads, seq_len, seq_len]``.
+/// * `fr.output` : `[batch, seq_len, d_model]`.
+/// * `fr.ca_weights` : `[batch, n_heads, seq_len, seq_len]`.
 pub fn layer_norm_self_attn<B: Backend>(
     layer_norm: &LayerNorm<B>,
     mh_attn: &MultiHeadAttention<B>,
@@ -76,18 +76,18 @@ pub fn layer_norm_self_attn<B: Backend>(
     mh_attn.forward(input)
 }
 
-/// Compute layer normalized cross-attn.
+/// Computes layer normalized cross-attn.
 ///
-/// ## Arguments
+/// # Arguments
 /// * `layer_norm` - `LayerNorm`.
 /// * `mh_attn` - `MultiHeadAttention`.
-/// * `x` - ``[batch, seq_len, d_model]`` input.
-/// * `xa` - ``[batch, seq_len, d_model]`` cross-attention input.
+/// * `x` - `[batch, seq_len, d_model]` input.
+/// * `xa` - `[batch, seq_len, d_model]` cross-attention input.
 ///
-/// ## Returns
+/// # Returns
 /// `RdabForwardRecord` - forward record.
-/// * `fr.output` : ``[batch, seq_len, d_model]``.
-/// * `fr.ca_weights` : ``[batch, n_heads, seq_len, seq_len]``.
+/// * `fr.output` : `[batch, seq_len, d_model]`.
+/// * `fr.ca_weights` : `[batch, n_heads, seq_len, seq_len]`.
 pub fn layer_norm_cross_attn<B: Backend>(
     layer_norm: &LayerNorm<B>,
     mh_attn: &MultiHeadAttention<B>,

--- a/crates/bunsen/src/blocks/transformers/attention/sdpa.rs
+++ b/crates/bunsen/src/blocks/transformers/attention/sdpa.rs
@@ -55,11 +55,11 @@ pub struct ScaledDotProductAttentionConfig {
 /// - [pytorch scaled_dot_product_attention](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html)
 ///
 /// # Arguments
-/// - `q`: the query tensor, as ``[B, H_q, T_q, D]``.
-/// - `k`: the key tensor, as ``[B, H_k, T_kv, D]``.
-/// - `v`: the value tensor, as ``[B, H_v, T_kv, D]``.
-/// - `bias`: optional additive bias, as ``[T_q, T_kv]``.
-/// - `mask`: optional bias mask, as ``[T_q, T_kv]``.
+/// - `q`: the query tensor, as `[B, H_q, T_q, D]`.
+/// - `k`: the key tensor, as `[B, H_k, T_kv, D]`.
+/// - `v`: the value tensor, as `[B, H_v, T_kv, D]`.
+/// - `bias`: optional additive bias, as `[T_q, T_kv]`.
+/// - `mask`: optional bias mask, as `[T_q, T_kv]`.
 /// - `config`: attention config.
 ///
 /// # Returns
@@ -96,13 +96,13 @@ pub fn scaled_dot_product_attention<B: Backend>(
     attn_weight.matmul(v)
 }
 
-/// Build the Attention Weight for [`scaled_dot_product_attention`].
+/// Builds the Attention Weight for [`scaled_dot_product_attention`].
 ///
 /// # Arguments
-/// - `q`: the query tensor, as ``[B, H_q, T_q, D]``.
-/// - `k`: the key tensor, as ``[B, H_k, T_k, D]``.
-/// - `bias`: optional additive bias, as ``[T_q, T_k]``.
-/// - `mask`: optional bias mask, as ``[T_q, T_k]``.
+/// - `q`: the query tensor, as `[B, H_q, T_q, D]`.
+/// - `k`: the key tensor, as `[B, H_k, T_k, D]`.
+/// - `bias`: optional additive bias, as `[T_q, T_k]`.
+/// - `mask`: optional bias mask, as `[T_q, T_k]`.
 /// - `config`: attention config.
 pub fn sdpa_attn_weight<B: Backend>(
     q: Tensor<B, 4>,
@@ -144,7 +144,7 @@ pub fn sdpa_attn_weight<B: Backend>(
     softmax(attn_weight, 3)
 }
 
-/// Build the Attention Bias for [`scaled_dot_product_attention`].
+/// Builds the Attention Bias for [`scaled_dot_product_attention`].
 ///
 /// # Arguments
 /// - `l`: the query time dimension.
@@ -156,7 +156,7 @@ pub fn sdpa_attn_weight<B: Backend>(
 /// - `device`: the target device of the bias.
 ///
 /// # Returns
-/// - a ``[l, s]`` attention bias tensor.
+/// - a `[l, s]` attention bias tensor.
 pub fn sdpa_bias<B: Backend>(
     l: usize,
     s: usize,

--- a/crates/bunsen/src/blocks/transformers/embedding/rotary.rs
+++ b/crates/bunsen/src/blocks/transformers/embedding/rotary.rs
@@ -101,7 +101,7 @@ impl<B: Backend> ModuleInit<B, RotaryEmbedding<B>> for RotaryEmbeddingConfig {
 
 /// Rotary Embedding Module
 ///
-/// Precomputed rotary positional embedding (RoPE). It holds per-position
+/// Precomputed rotary positional embedding (`RoPE`). It holds per-position
 /// `cos`/`sin` tables and applies position-dependent rotations to the
 /// query/key head dimensions via [`apply`](RotaryEmbedding::apply); use
 /// [`clip_range`](RotaryEmbedding::clip_range) to restrict it to a

--- a/crates/bunsen/src/blocks/transformers/embedding/rotary.rs
+++ b/crates/bunsen/src/blocks/transformers/embedding/rotary.rs
@@ -26,10 +26,10 @@ use crate::{
 
 /// Common meta for [`RotaryEmbedding`] and [`RotaryEmbeddingConfig`].
 pub trait RotaryEmbeddingMeta {
-    /// Return the sequence length.
+    /// Returns the sequence length.
     fn seq_len(&self) -> usize;
 
-    /// Return the head dimension.
+    /// Returns the head dimension.
     fn head_dim(&self) -> usize;
 }
 
@@ -100,15 +100,25 @@ impl<B: Backend> ModuleInit<B, RotaryEmbedding<B>> for RotaryEmbeddingConfig {
 }
 
 /// Rotary Embedding Module
+///
+/// Precomputed rotary positional embedding (RoPE). It holds per-position
+/// `cos`/`sin` tables and applies position-dependent rotations to the
+/// query/key head dimensions via [`apply`](RotaryEmbedding::apply); use
+/// [`clip_range`](RotaryEmbedding::clip_range) to restrict it to a
+/// sub-range of positions. Construct via [`RotaryEmbeddingConfig`] and
+/// `.init(device)`, then call [`apply`](RotaryEmbedding::apply) on a
+/// `[B, T, H, D]` tensor.
+///
+/// Built by [`RotaryEmbeddingConfig`].
 #[derive(Module, Debug)]
 pub struct RotaryEmbedding<B: Backend> {
     /// Head Dimension, D
     pub head_dim: usize,
 
-    /// a ``[1, T, 1, D/2]`` tensor.
+    /// a `[1, T, 1, D/2]` tensor.
     pub cos: Tensor<B, 4>,
 
-    /// a ``[1, T, 1, D/2]`` tensor.
+    /// a `[1, T, 1, D/2]` tensor.
     pub sin: Tensor<B, 4>,
 }
 
@@ -123,7 +133,7 @@ impl<B: Backend> RotaryEmbeddingMeta for RotaryEmbedding<B> {
 }
 
 impl<B: Backend> RotaryEmbedding<B> {
-    /// Cast the embedding to a different dtype.
+    /// Casts the embedding to a different dtype.
     pub fn cast(
         self,
         dtype: DType,
@@ -153,13 +163,13 @@ impl<B: Backend> RotaryEmbedding<B> {
         }
     }
 
-    /// Apply the rotary embedding to the input.
+    /// Applies the rotary embedding to the input.
     ///
     /// # Arguments
-    /// - `input`: a ``[B, T, H, D]`` tensor.
+    /// - `input`: a `[B, T, H, D]` tensor.
     ///
     /// # Returns
-    /// - a ``[B, T, H, D]`` tensor.
+    /// - a `[B, T, H, D]` tensor.
     pub fn apply(
         &self,
         input: Tensor<B, 4>,
@@ -197,7 +207,7 @@ impl<B: Backend> RotaryEmbedding<B> {
     }
 }
 
-/// Compute the rotary embedding inverse frequency table.
+/// Computes the rotary embedding inverse frequency table.
 ///
 /// # Arguments
 /// - `base`: the base.
@@ -205,7 +215,7 @@ impl<B: Backend> RotaryEmbedding<B> {
 /// - `device`: the target device.
 ///
 /// # Returns
-/// - ``[(1.0 / (base**(d / head_dim))) for d in 0:head_dim:2]``
+/// - `[(1.0 / (base**(d / head_dim))) for d in 0:head_dim:2]`
 pub fn inverse_frequency_table<B: Backend>(
     base: usize,
     head_dim: usize,
@@ -218,7 +228,7 @@ pub fn inverse_frequency_table<B: Backend>(
     )
 }
 
-/// Compute the positionally shifted frequency table.
+/// Computes the positionally shifted frequency table.
 ///
 /// # Arguments
 /// - `seq_len`: the sequence length.
@@ -227,7 +237,7 @@ pub fn inverse_frequency_table<B: Backend>(
 /// - `device`: the target device.
 ///
 /// # Returns
-/// - ``[T, F=D/2]`` sequence x inverse frequency table.
+/// - `[T, F=D/2]` sequence x inverse frequency table.
 pub fn positional_frequency_table<B: Backend>(
     seq_len: usize,
     base: usize,

--- a/crates/bunsen/src/blocks/transformers/mlp.rs
+++ b/crates/bunsen/src/blocks/transformers/mlp.rs
@@ -23,15 +23,15 @@ use crate::{
     errors::BunsenResult,
 };
 
-/// Compute layer normalized mlp.
+/// Computes layer normalized mlp.
 ///
-/// ## Arguments
+/// # Arguments
 /// * `layer_norm` - `LayerNorm`.
 /// * `mlp` - `Mlp`.
-/// * `x` - ``[batch, seq_len, n_states]`` input.
+/// * `x` - `[batch, seq_len, n_states]` input.
 ///
-/// ## Returns
-/// ``[batch, seq_len, n_states]``
+/// # Returns
+/// `[batch, seq_len, n_states]`
 pub fn layer_norm_mlp<B: Backend>(
     layer_norm: &LayerNorm<B>,
     mlp: &Mlp<B>,
@@ -42,10 +42,10 @@ pub fn layer_norm_mlp<B: Backend>(
 
 /// Common meta for [`Mlp`] and [`MlpConfig`].
 pub trait MlpMeta {
-    /// Return the size of the input and output.
+    /// Returns the size of the input and output.
     fn n_embed(&self) -> usize;
 
-    /// Return the post-activation exponent.
+    /// Returns the post-activation exponent.
     fn act_exponent(&self) -> Option<f64>;
 }
 
@@ -79,7 +79,7 @@ impl MlpMeta for MlpConfig {
 }
 
 impl MlpConfig {
-    /// Return the size of the hidden layer.
+    /// Returns the size of the hidden layer.
     pub fn hidden_size(&self) -> usize {
         self.n_embed * self.expansion_factor
     }
@@ -104,6 +104,14 @@ impl<B: Backend> ModuleInit<B, Mlp<B>> for MlpConfig {
 }
 
 /// GPT Block MLP Module
+///
+/// The position-wise feed-forward block of a transformer: an up-projection to
+/// an expanded hidden size, an activation (optionally raised to a configured
+/// exponent), and a down-projection back to the embedding size. Construct via
+/// [`MlpConfig`] and `.init(device)`, then call [`forward`](Mlp::forward) on a
+/// `[batch, time, embed]` input.
+///
+/// Built by [`MlpConfig`].
 #[derive(Module, Debug)]
 pub struct Mlp<B: Backend> {
     /// Feed Forward Layer.
@@ -133,10 +141,10 @@ impl<B: Backend> Mlp<B> {
     /// MLP Forward Pass.
     ///
     /// # Arguments
-    /// - `x`: a ``[batch, time, embed]`` input.
+    /// - `x`: a `[batch, time, embed]` input.
     ///
     /// # Returns
-    /// a ``[batch, time, embed]`` result.
+    /// a `[batch, time, embed]` result.
     pub fn forward(
         &self,
         x: Tensor<B, 3>,

--- a/crates/bunsen/src/burner/descriptors/param_desc.rs
+++ b/crates/bunsen/src/burner/descriptors/param_desc.rs
@@ -47,7 +47,7 @@ impl<T> ParamDesc<T>
 where
     T: Debug + Clone + Send + PartialEq,
 {
-    /// Create a new [`ParamDesc`].
+    /// Creates a new [`ParamDesc`].
     pub fn new(
         param_id: ParamId,
         param: T,
@@ -58,7 +58,7 @@ where
         }
     }
 
-    /// Get the [`ParamId`].
+    /// Returns the [`ParamId`].
     pub fn param_id(&self) -> ParamId {
         self.param_id
     }

--- a/crates/bunsen/src/burner/descriptors/tensor_desc.rs
+++ b/crates/bunsen/src/burner/descriptors/tensor_desc.rs
@@ -47,7 +47,7 @@ where
     }
 }
 
-/// Convert a string to a [`DType`].
+/// Converts a string to a [`DType`].
 pub fn dtype_from_str(dtype: &str) -> BunsenResult<DType> {
     Ok(match dtype {
         "F64" => DType::F64,
@@ -68,7 +68,7 @@ pub fn dtype_from_str(dtype: &str) -> BunsenResult<DType> {
 }
 
 impl TensorDesc {
-    /// Create a new `TensorDesc`.
+    /// Creates a new `TensorDesc`.
     pub fn new(
         kind: TensorKindDesc,
         dtype: DType,

--- a/crates/bunsen/src/burner/descriptors/tensor_kinds.rs
+++ b/crates/bunsen/src/burner/descriptors/tensor_kinds.rs
@@ -21,7 +21,7 @@ pub enum TensorKindDesc {
 }
 
 impl TensorKindDesc {
-    /// Get the [`TensorKindDesc`] for a `burner`
+    /// Returns the [`TensorKindDesc`] for a `burner`
     /// [`burn::tensor::TensorKind`].
     pub const fn for_kind<K: ParamKindBinding>() -> Self {
         K::KIND

--- a/crates/bunsen/src/burner/distribution.rs
+++ b/crates/bunsen/src/burner/distribution.rs
@@ -13,7 +13,7 @@ use burn::{
 pub struct DistributionDisplayAdapter(Distribution);
 
 impl DistributionDisplayAdapter {
-    /// Create a new [`DistributionDisplayAdapter`].
+    /// Creates a new [`DistributionDisplayAdapter`].
     pub fn new(distribution: Distribution) -> Self {
         Self(distribution)
     }

--- a/crates/bunsen/src/burner/module/module_init.rs
+++ b/crates/bunsen/src/burner/module/module_init.rs
@@ -10,13 +10,13 @@ use crate::errors::{
 
 /// Trait for initializing a Module.
 pub trait ModuleInit<B: Backend, M: Module<B>> {
-    /// Initialize a Module.
+    /// Initializes a Module.
     fn try_init(
         &self,
         device: &B::Device,
     ) -> BunsenResult<M>;
 
-    /// Initialize a Module, panicking on error.
+    /// Initializes a Module, panicking on error.
     fn init(
         &self,
         device: &B::Device,

--- a/crates/bunsen/src/burner/module/reflection/module_visitors/container_type_util.rs
+++ b/crates/bunsen/src/burner/module/reflection/module_visitors/container_type_util.rs
@@ -7,7 +7,7 @@ pub fn container_type_is_sequence(container_type: &str) -> bool {
     SEQUENCE_TYPES.contains(&container_type)
 }
 
-/// Parse the container type into (class, name).
+/// Parses the container type into (class, name).
 ///
 /// See: [`burn::module::ModuleVisitor::enter_module`].
 ///

--- a/crates/bunsen/src/burner/module/reflection/module_visitors/xml_module_tree_builder.rs
+++ b/crates/bunsen/src/burner/module/reflection/module_visitors/xml_module_tree_builder.rs
@@ -50,7 +50,7 @@ pub struct XmlModuleTreeBuilder<B: Backend> {
 }
 
 impl<B: Backend> XmlModuleTreeBuilder<B> {
-    /// Build a [`XmlModuleTree`] from a [`Module`].
+    /// Builds a [`XmlModuleTree`] from a [`Module`].
     pub fn build<M: Module<B>>(module: &M) -> XmlModuleTree {
         let mut builder = Self::new();
         module.visit(&mut builder);

--- a/crates/bunsen/src/burner/module/reflection/xml_module_tree.rs
+++ b/crates/bunsen/src/burner/module/reflection/xml_module_tree.rs
@@ -79,12 +79,12 @@ impl Debug for XmlModuleTree {
 }
 
 impl XmlModuleTree {
-    /// Build a [`XmlModuleTree`] for a [`Module`].
+    /// Builds a [`XmlModuleTree`] for a [`Module`].
     pub fn build<B: Backend, M: Module<B>>(module: &M) -> Self {
         XmlModuleTreeBuilder::build(module)
     }
 
-    /// Create a new/empty module tree.
+    /// Creates a new/empty module tree.
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         let mut docs = Documents::new();
@@ -100,7 +100,7 @@ impl XmlModuleTree {
         Self { docs, root }
     }
 
-    /// Serialize the module tree to an XML string.
+    /// Serializes the module tree to an XML string.
     pub fn to_xml(
         &self,
         pretty: bool,
@@ -121,7 +121,7 @@ impl XmlModuleTree {
             .unwrap()
     }
 
-    /// Bind (add/lookup) a local (no namespace) name in the [`xot`] arena.
+    /// Binds (add/lookup) a local (no namespace) name in the [`xot`] arena.
     ///
     /// # Arguments
     /// * `name` - a string name.
@@ -136,7 +136,7 @@ impl XmlModuleTree {
         xot.add_name(name)
     }
 
-    /// Bind a list of local names to [`NameId`]s.
+    /// Binds a list of local names to [`NameId`]s.
     ///
     /// See [`Self::bind_local_name`].
     pub fn bind_local_names<const N: usize>(
@@ -173,14 +173,14 @@ impl XmlModuleTree {
         self.docs.xot_mut()
     }
 
-    /// Iterate over [`ParamId`]s for each parameter in the subtree.
+    /// Iterates over [`ParamId`]s for each parameter in the subtree.
     ///
     /// Implicitly calls [`XPathModuleQuery::params`].
     ///
     /// # Returns
     /// `Ok(Vec<ParamId>)` on success, `Err(e)` on errors.
     ///
-    /// ## Example
+    /// # Examples
     /// ```rust,ignore
     /// let param_ids: HashSet<ParamId> = mtree
     ///     .param_ids()?
@@ -198,14 +198,14 @@ impl XmlModuleTree {
         self.query().to_param_ids()
     }
 
-    /// Iterate over [`TensorParamDesc`]s for each parameter in the subtree.
+    /// Iterates over [`TensorParamDesc`]s for each parameter in the subtree.
     ///
     /// Implicitly calls [`XPathModuleQuery::params`].
     ///
     /// # Returns
     /// `Ok(Vec<TensorParamDesc>)` on success, `Err(e)` on errors.
     ///
-    /// ## Example
+    /// # Examples
     /// ```rust,ignore
     /// let descs: Vec<TensorParamDesc> = mtree
     ///     .param_descs()?
@@ -223,7 +223,7 @@ impl XmlModuleTree {
         self.query().to_param_descs()
     }
 
-    /// Create a new default [`XPathModuleQuery`] for this module tree.
+    /// Creates a new default [`XPathModuleQuery`] for this module tree.
     ///
     /// The query builder has a fluent api to incrementally refine a query.
     /// It begins with broad selection over the entire module structure.
@@ -239,7 +239,7 @@ impl XmlModuleTree {
     /// # Panics
     /// On invalid `XPath` expressions.
     ///
-    /// # Example
+    /// # Examples
     /// ```rust,ignore
     /// let q: QueryBuilder<_> = mtree
     ///     .select("GPT/Linear");
@@ -261,7 +261,7 @@ impl XmlModuleTree {
     /// # Returns
     /// `Ok(query)` on success, `Err(e)` on `XPath` errors.
     ///
-    /// # Example
+    /// # Examples
     /// ```rust,ignore
     /// let q: QueryBuilder<_> = mtree
     ///     .select("GPT/Linear");
@@ -283,7 +283,7 @@ impl XmlModuleTree {
     /// # Panics
     /// On invalid `XPath` expressions.
     ///
-    /// # Example
+    /// # Examples
     /// ```rust,ignore
     /// let q: QueryBuilder<_> = mtree
     ///     .select_params("GPT/Linear");
@@ -311,7 +311,7 @@ impl XmlModuleTree {
     /// # Returns
     /// `Ok(query)` on success, `Err(e)` on `XPath` errors.
     ///
-    /// # Example
+    /// # Examples
     /// ```rust,ignore
     /// let q: QueryBuilder<_> = mtree
     ///     .select_params("GPT/Linear");
@@ -334,13 +334,13 @@ impl XmlModuleTree {
         Ok(self.try_select(expr)?.params())
     }
 
-    /// Return an iterator over the parameter [`ParamId`]s of a subtree.
+    /// Returns an iterator over the parameter [`ParamId`]s of a subtree.
     ///
     /// # Returns
     /// `Ok(impl Iterator<Item = ParamId>)` on success, `Err(e)` on `XPath`
     /// errors.
     ///
-    /// # Example
+    /// # Examples
     /// ```rust,ignore
     /// let param_ids : HashSet<ParamId> = mtree
     ///     .select_param_ids("GPT/Linear")?
@@ -405,7 +405,7 @@ impl<'a> XPathModuleQuery<'a> {
         Self { tree, expr }
     }
 
-    /// Get the current `XPath` expression.
+    /// Returns the current `XPath` expression.
     pub fn expr(&self) -> &String {
         &self.expr
     }
@@ -423,7 +423,7 @@ impl<'a> XPathModuleQuery<'a> {
         Ok(Self { expr, ..self })
     }
 
-    /// Execute a [`xee_xpath::Queries::many`] on the current selection.
+    /// Executes a [`xee_xpath::Queries::many`] on the current selection.
     ///
     /// This exposes the `xot`/`xee_xpath` query execution functionality.
     pub fn xee_execute_many<V, F>(
@@ -443,7 +443,7 @@ impl<'a> XPathModuleQuery<'a> {
             .map_err(|e| adapt_xee_error(e, Some(expr)))
     }
 
-    /// Refine the current selection by appending an `XPath` path expression.
+    /// Refines the current selection by appending an `XPath` path expression.
     ///
     /// This is: `{EXPR}` => `{EXPR}/{expr}`
     ///
@@ -456,7 +456,7 @@ impl<'a> XPathModuleQuery<'a> {
         self.try_select(expr).unwrap_or_else(|e| panic!("{}", e))
     }
 
-    /// Refine the current selection by appending an `XPath` path expression.
+    /// Refines the current selection by appending an `XPath` path expression.
     ///
     /// This is: `{EXPR}` => `{EXPR}/{expr}`
     ///
@@ -469,7 +469,7 @@ impl<'a> XPathModuleQuery<'a> {
         self.try_append_expr(format!("/{}", expr.as_ref()).as_str())
     }
 
-    /// Refine the current selection by appending an `XPath` predicate
+    /// Refines the current selection by appending an `XPath` predicate
     /// expression.
     ///
     /// Predicate expressions filter the current node-set, keeping only those
@@ -478,7 +478,7 @@ impl<'a> XPathModuleQuery<'a> {
     ///
     /// This is: `{EXPR}` => `{EXPR}[{expr}]`
     ///
-    /// # Example
+    /// # Examples
     /// * `filter("@name='foo'")` - select only nodes with a "name" attribute
     ///   equal to "foo".
     ///
@@ -491,7 +491,7 @@ impl<'a> XPathModuleQuery<'a> {
         self.try_filter(pred).unwrap_or_else(|e| panic!("{}", e))
     }
 
-    /// Refine the current selection by appending an `XPath` predicate
+    /// Refines the current selection by appending an `XPath` predicate
     /// expression.
     ///
     /// Predicate expressions filter the current node-set, keeping only those
@@ -500,7 +500,7 @@ impl<'a> XPathModuleQuery<'a> {
     ///
     /// This is: `{EXPR}` => `{EXPR}[{expr}]`
     ///
-    /// # Example
+    /// # Examples
     /// * `filter("@name='foo'")` - select only nodes with a "name" attribute
     ///   equal to "foo".
     ///
@@ -513,14 +513,14 @@ impl<'a> XPathModuleQuery<'a> {
         self.try_append_expr(format!("[{}]", pred.as_ref()).as_str())
     }
 
-    /// Select children of the current set.
+    /// Selects children of the current set.
     ///
     /// This is: "{EXPR}" => "{EXPR}/*"
     pub fn children(self) -> XPathModuleQuery<'a> {
         self.select("*")
     }
 
-    /// Select children withh the given `name` attribute.
+    /// Selects children withh the given `name` attribute.
     ///
     /// This is: `{EXPR}` => `{EXPR}/*[@name='{name}']`
     pub fn named_children(
@@ -530,7 +530,7 @@ impl<'a> XPathModuleQuery<'a> {
         self.select(format!("*[@name='{name}']"))
     }
 
-    /// Select children with the given positional index.
+    /// Selects children with the given positional index.
     ///
     /// NOTE: `XPath` indexing is 1-based; so this method adds 1 to the index.
     ///
@@ -542,7 +542,7 @@ impl<'a> XPathModuleQuery<'a> {
         self.select(format!("*[{}]", index + 1))
     }
 
-    /// Recursively select all descedant or self elements with `name`.
+    /// Recursively selects all descedant or self elements with `name`.
     ///
     /// This is: `{EXPR}` => `{EXPR}/descendant-or-self::{name}`
     pub fn subtree_elements(
@@ -552,14 +552,14 @@ impl<'a> XPathModuleQuery<'a> {
         self.select(format!("descendant-or-self::{}", name))
     }
 
-    /// Recursively select all parameter elements in the current context.
+    /// Recursively selects all parameter elements in the current context.
     ///
     /// Equivalent to `.desdendant_or_self_elem(names::PARAM_ELEM)`
     pub fn params(self) -> Self {
         self.subtree_elements(names::PARAM_ELEM)
     }
 
-    /// Filter the selection to nodes where the `rank` attribute has the given
+    /// Filters the selection to nodes where the `rank` attribute has the given
     /// value.
     ///
     /// Equivalent to `.filter(format!("@rank={rank}"))`
@@ -570,7 +570,7 @@ impl<'a> XPathModuleQuery<'a> {
         self.filter(format!("@rank={}", rank))
     }
 
-    /// Iterate over [`TensorParamDesc`]s for each parameter in the subtree.
+    /// Iterates over [`TensorParamDesc`]s for each parameter in the subtree.
     ///
     /// Implicitly calls [`Self::params`].
     ///
@@ -589,14 +589,14 @@ impl<'a> XPathModuleQuery<'a> {
             .collect::<BunsenResult<Vec<TensorParamDesc>>>()
     }
 
-    /// Iterate over [`ParamId`]s for each parameter in the subtree.
+    /// Iterates over [`ParamId`]s for each parameter in the subtree.
     ///
     /// Implicitly calls [`Self::params`].
     ///
     /// # Returns
     /// `Ok(Vec<ParamId>)` on success, `Err(e)` on errors.
     ///
-    /// # Example
+    /// # Examples
     /// ```rust,ignore
     /// let param_ids : HashSet<ParamId> = query
     ///     .to_param_ids()?
@@ -616,7 +616,7 @@ impl<'a> XPathModuleQuery<'a> {
             .collect())
     }
 
-    /// Iterate over string fragments for the current expression matches.
+    /// Iterates over string fragments for the current expression matches.
     ///
     /// # Arguments
     /// * `pretty` - pretty-print/indent the xml fragments.

--- a/crates/bunsen/src/burner/module/reflection/xml_support/xee_util.rs
+++ b/crates/bunsen/src/burner/module/reflection/xml_support/xee_util.rs
@@ -6,7 +6,7 @@ use xee_xpath::error::ErrorValue;
 
 use crate::errors::BunsenError;
 
-/// Construct a long-form error message from an [`ErrorValue`].
+/// Constructs a long-form error message from an [`ErrorValue`].
 pub fn pretty_errorvalue(e: &ErrorValue) -> String {
     format!("XPath Error: {}: {}\n{}", e.code(), e.message(), e.note())
 }
@@ -23,7 +23,7 @@ fn offset_to_location(
     Location { line, column }
 }
 
-/// Adapt an [`xee_xpath::error::Error`] into a [`BunsenError`].
+/// Adapts an [`xee_xpath::error::Error`] into a [`BunsenError`].
 pub fn adapt_xee_error(
     e: xee_xpath::error::Error,
     src: Option<&str>,

--- a/crates/bunsen/src/burner/module/reflection/xml_support/xml_param_desc.rs
+++ b/crates/bunsen/src/burner/module/reflection/xml_support/xml_param_desc.rs
@@ -42,7 +42,7 @@ use crate::{
     },
 };
 
-/// Load a [`TensorParamDesc`] from an xml `<Param/>` node.
+/// Loads a [`TensorParamDesc`] from an xml `<Param/>` node.
 pub fn node_to_tensor_param_desc(
     xot: &xot::Xot,
     node: xot::Node,
@@ -85,7 +85,7 @@ pub fn node_to_tensor_param_desc(
     ))
 }
 
-/// Build an xml `<Param/>` node from a [`TensorParamDesc`].
+/// Builds an xml `<Param/>` node from a [`TensorParamDesc`].
 pub fn tensor_param_desc_to_node(
     xot: &mut xot::Xot,
     param_desc: &TensorParamDesc,
@@ -95,7 +95,7 @@ pub fn tensor_param_desc_to_node(
     tensor_param_desc_to_attributes(xot, node, param_desc)
 }
 
-/// Write a [`TensorParamDesc`] to the attributes of an xml node.
+/// Writes a [`TensorParamDesc`] to the attributes of an xml node.
 pub fn tensor_param_desc_to_attributes(
     xot: &mut xot::Xot,
     node: Node,

--- a/crates/bunsen/src/burner/module/type_mapper.rs
+++ b/crates/bunsen/src/burner/module/type_mapper.rs
@@ -19,7 +19,7 @@ pub struct DTypeMapper<B: Backend> {
 }
 
 impl<B: Backend> DTypeMapper<B> {
-    /// Create a new type mapper with the specified target data type.
+    /// Creates a new type mapper with the specified target data type.
     pub fn new(dt: DType) -> Self {
         Self {
             dt,

--- a/crates/bunsen/src/burner/optim/group_optimizer.rs
+++ b/crates/bunsen/src/burner/optim/group_optimizer.rs
@@ -69,7 +69,7 @@ where
     B: AutodiffBackend,
     O: SimpleOptimizer<B::InnerBackend>,
 {
-    /// Create a new `GroupOptimizer` with the given parameters and optimizer.
+    /// Creates a new `GroupOptimizer` with the given parameters and optimizer.
     pub fn new(
         params: HashSet<ParamId>,
         optim: O,
@@ -82,7 +82,7 @@ where
         }
     }
 
-    /// Build a [`OptimizerGroup`] from an [`OptimizerAdaptor`].
+    /// Builds a [`OptimizerGroup`] from an [`OptimizerAdaptor`].
     pub fn from_adaptor<M, I>(
         params: I,
         adaptor: &OptimizerAdaptor<O, M, B>,
@@ -94,7 +94,7 @@ where
         Self::new(params.into_iter().collect(), adaptor.optim().clone())
     }
 
-    /// Get the learning rate for this group.
+    /// Returns the learning rate for this group.
     pub fn lr(
         &self,
         global: LearningRate,
@@ -106,12 +106,12 @@ where
             .unwrap_or(global)
     }
 
-    /// Get the learning rate mapping function.
+    /// Returns the learning rate mapping function.
     pub fn lr_selector(&self) -> Option<Arc<dyn LrSelector>> {
         self.lr_selector.clone()
     }
 
-    /// Set the learning rate mapping function.
+    /// Sets the learning rate mapping function.
     pub fn with_lr_selector<F>(
         mut self,
         selector: F,
@@ -123,7 +123,7 @@ where
         self
     }
 
-    /// Set a fixed learning rate for this group.
+    /// Sets a fixed learning rate for this group.
     pub fn with_fixed_lr(
         self,
         lr: LearningRate,
@@ -226,7 +226,7 @@ where
 // Macro
 // ---------------------------------------------------------------------------
 
-/// Define a `GroupOptimizerAdaptorN` and its associated mapper for N
+/// Defines a `GroupOptimizerAdaptorN` and its associated mapper for N
 /// `SimpleOptimizer` types.
 ///
 /// # Usage
@@ -268,7 +268,7 @@ macro_rules! define_group_optimizer_adaptor {
                 M: AutodiffModule<B>,
                 B: AutodiffBackend,
             {
-                /// Construct and validate.
+                /// Constructs and validates.
                 ///
                 /// Returns an error if any `ParamId` appears in more than one
                 /// group.

--- a/crates/bunsen/src/burner/optim/lr_selectors.rs
+++ b/crates/bunsen/src/burner/optim/lr_selectors.rs
@@ -3,7 +3,7 @@ use hashbrown::HashMap;
 
 /// Selection function for learning rates.
 pub trait LrSelector: Send + Sync {
-    /// Select the learning rate for this group.
+    /// Selects the learning rate for this group.
     fn select(
         &self,
         lr: LearningRate,
@@ -43,12 +43,12 @@ pub struct FixedLrSelector {
 }
 
 impl FixedLrSelector {
-    /// Create a new selector.
+    /// Creates a new selector.
     pub fn new(lr: LearningRate) -> Self {
         Self { lr }
     }
 
-    /// Get the fixed learning rate.
+    /// Returns the fixed learning rate.
     pub fn lr(&self) -> LearningRate {
         self.lr
     }
@@ -82,12 +82,12 @@ pub struct NamedLrSelector {
 }
 
 impl NamedLrSelector {
-    /// Create a new selector.
+    /// Creates a new selector.
     pub fn new(name: String) -> Self {
         Self { name }
     }
 
-    /// Get the name of the learning rate.
+    /// Returns the name of the learning rate.
     pub fn name(&self) -> &str {
         &self.name
     }

--- a/crates/bunsen/src/burner/tensor/data_view.rs
+++ b/crates/bunsen/src/burner/tensor/data_view.rs
@@ -20,7 +20,7 @@ pub struct TensorDataIndexView<'a, E: Element> {
 }
 
 impl<'a, E: Element> TensorDataIndexView<'a, E> {
-    /// Get an indexed view of the data.
+    /// Returns an indexed view of the data.
     pub fn view(data: &'a TensorData) -> TensorDataIndexView<'a, E> {
         TensorDataIndexView {
             data,

--- a/crates/bunsen/src/contracts/bindings.rs
+++ b/crates/bunsen/src/contracts/bindings.rs
@@ -9,11 +9,11 @@ where
 {
     /// Looks up a value associated with the given key in the stack.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// * `key`: The key to look up.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// An `Option<V>` containing the value if found, or `None` if not found.
     #[must_use]
@@ -24,15 +24,15 @@ where
 
     /// Exports the values for the given keys from the local bindings.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// * `keys`: An array of keys to look up in the local bindings.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// An array of values corresponding to the keys. If a key is not found,
     ///
-    /// ## Panics
+    /// # Panics
     ///
     /// Panics if any key is not found in the local bindings.
     #[must_use]
@@ -83,12 +83,12 @@ where
     /// It is an error to bind a key which is already present;
     /// but this is only checked when `debug_assertions` are on.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// * `key`: The key to insert.
     /// * `value`: The value to associate with the key.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// This method does not return a value,
     /// but modifies the stack by inserting the key-value pair.
@@ -114,11 +114,11 @@ impl<'a> MutableStackEnvironment<'a> {
     /// This is useful when exporting values, as the newly bound values
     /// tend to be the keys being exported.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// * `key`: The key to look up.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// An `Option<usize>` containing the value if found in updates,
     /// or `None` if not found.

--- a/crates/bunsen/src/contracts/expressions.rs
+++ b/crates/bunsen/src/contracts/expressions.rs
@@ -154,13 +154,13 @@ pub enum MatchResult {
 }
 
 impl<'a> DimExpr<'a> {
-    /// Evaluate an expression.
+    /// Evaluates an expression.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `env` - the binding environment.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// A `TryEvalResult`:
     /// * `Value(value)` - the evaluated value of the expression.
@@ -216,14 +216,14 @@ impl<'a> DimExpr<'a> {
         }
     }
 
-    /// Reconcile an expression against a target value.
+    /// Reconciles an expression against a target value.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// * `target`: The target value to match.
     /// * `env`: The environment containing bindings for parameters.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// * `Ok(MatchResult::Match)` if the expression matches the target.
     /// * `Ok(MatchResult::MissMatch)` if the expression does not match the

--- a/crates/bunsen/src/contracts/macros.rs
+++ b/crates/bunsen/src/contracts/macros.rs
@@ -26,7 +26,7 @@ macro_rules! __shape_contract {
 /// of code to every nth call, such as logging, sampling, or throttling
 /// operations.
 ///
-/// ## Arguments:
+/// # Arguments:
 ///
 /// - `$period`: [optional; default=1000] the period.
 /// - `$code`: An expression to be executed every nth time.

--- a/crates/bunsen/src/contracts/mod.rs
+++ b/crates/bunsen/src/contracts/mod.rs
@@ -150,16 +150,16 @@
 //!
 //! /// Window Partition
 //! ///
-//! /// ## Parameters
+//! /// # Arguments
 //! ///
-//! /// - `tensor`: Input tensor of shape (B, h_wins * window_size, w_wins * window_size, C).
+//! /// - `tensor`: `[B, h_wins * window_size, w_wins * window_size, C]` input tensor.
 //! /// - `window_size`: Window size.
 //! ///
-//! /// ## Returns
+//! /// # Returns
 //! ///
-//! /// Output tensor of shape (B * h_windows * w_windows, window_size, window_size, C).
+//! /// `[B * h_windows * w_windows, window_size, window_size, C]` output tensor.
 //! ///
-//! /// ## Panics
+//! /// # Panics
 //! ///
 //! /// Panics if the input tensor does not have 4 dimensions.
 //! pub fn window_partition<B: Backend, K>(

--- a/crates/bunsen/src/contracts/shape_contracts.rs
+++ b/crates/bunsen/src/contracts/shape_contracts.rs
@@ -12,7 +12,7 @@
 //! A [`ShapeContract`] should usually be constructed using the
 //! [`crate::shape_contract`] macro.
 //!
-//! ## Example
+//! # Examples
 //!
 //! ```rust
 //! use bunsen::contracts::{
@@ -93,24 +93,24 @@ pub enum DimMatcher<'a> {
 }
 
 impl<'a> DimMatcher<'a> {
-    /// Create a new `DimMatcher` that matches any dimension size.
+    /// Creates a new `DimMatcher` that matches any dimension size.
     pub const fn any() -> Self {
         DimMatcher::Any { label_id: None }
     }
 
-    /// Create a new `DimMatcher` that matches a variable number of dimensions
+    /// Creates a new `DimMatcher` that matches a variable number of dimensions
     /// (ellipsis).
     pub const fn ellipsis() -> Self {
         DimMatcher::Ellipsis { label_id: None }
     }
 
-    /// Create a new `DimMatcher` from a dimension expression.
+    /// Creates a new `DimMatcher` from a dimension expression.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `expr`: a dimension expression that must match a specific value.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// A new `DimMatcher` that matches the given expression.
     pub const fn expr(expr: DimExpr<'a>) -> Self {
@@ -120,7 +120,7 @@ impl<'a> DimMatcher<'a> {
         }
     }
 
-    /// Get the label of the matcher, if any.
+    /// Returns the label of the matcher, if any.
     pub const fn label_id(&self) -> Option<usize> {
         match self {
             DimMatcher::Any { label_id } => *label_id,
@@ -131,11 +131,11 @@ impl<'a> DimMatcher<'a> {
 
     /// Attach a label to the matcher.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `label_id`: an optional label to attach to the matcher.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// A new `DimMatcher` with the label attached.
     pub const fn with_label_id(
@@ -216,13 +216,13 @@ impl Display for ShapeContract<'_> {
 }
 
 impl<'a> ShapeContract<'a> {
-    /// Create a new shape pattern from a slice of terms.
+    /// Creates a new shape pattern from a slice of terms.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `terms`: a slice of `ShapePatternTerm` that defines the pattern.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// A new `ShapePattern` instance.
     ///
@@ -268,7 +268,7 @@ impl<'a> ShapeContract<'a> {
         }
     }
 
-    /// Convert a key to an index.
+    /// Converts a key to an index.
     pub fn maybe_key_to_index(
         &self,
         key: &str,
@@ -276,19 +276,19 @@ impl<'a> ShapeContract<'a> {
         self.index.iter().position(|&s| s == key)
     }
 
-    /// Assert that the shape matches the pattern.
+    /// Asserts that the shape matches the pattern.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `shape`: the shape to match.
     /// - `env`: the params which are already bound.
     ///
-    /// ## Panics
+    /// # Panics
     ///
     /// If the shape does not match the pattern, or if there is a conflict in
     /// the bindings.
     ///
-    /// ## Example
+    /// # Examples
     ///
     /// ```rust
     /// use bunsen::contracts::{
@@ -331,20 +331,20 @@ impl<'a> ShapeContract<'a> {
         }
     }
 
-    /// Assert that the shape matches the pattern.
+    /// Asserts that the shape matches the pattern.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `shape`: the shape to match.
     /// - `env`: the params which are already bound.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// - `Ok(())`: if the shape matches the pattern.
     /// - `Err(String)`: if the shape does not match the pattern, with an error
     ///   message.
     ///
-    /// ## Example
+    /// # Examples
     ///
     /// ```rust
     /// use bunsen::contracts::{
@@ -407,7 +407,7 @@ impl<'a> ShapeContract<'a> {
         self.format_resolve(shape, scratch.as_mut_slice(), loc)
     }
 
-    /// Match and unpack `K` keys from a shape pattern.
+    /// Matches and unpacks `K` keys from a shape pattern.
     ///
     /// Wraps `try_unpack_shape` and panics if the shape does not match.
     ///
@@ -415,22 +415,22 @@ impl<'a> ShapeContract<'a> {
     ///
     /// - `K`: the length of the `keys` array.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `shape`: the shape to match.
     /// - `keys`: the bound keys to export.
     /// - `env`: the params which are already bound.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// An `[usize; K]` of the unpacked `keys` values.
     ///
-    /// ## Panics
+    /// # Panics
     ///
     /// If the shape does not match the pattern, or if there is a conflict in
     /// the bindings.
     ///
-    /// ## Example
+    /// # Examples
     ///
     /// ```rust
     /// use bunsen::contracts::{
@@ -487,23 +487,23 @@ impl<'a> ShapeContract<'a> {
         }
     }
 
-    /// Try and match and unpack `K` keys from a shape pattern.
+    /// Tries to match and unpack `K` keys from a shape pattern.
     ///
     /// ## Generics
     ///
     /// - `K`: the length of the `keys` array.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `shape`: the shape to match.
     /// - `keys`: the bound keys to export.
     /// - `env`: the params which are already bound.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// A `Result<[usize; K], String>` of the unpacked `keys` values.
     ///
-    /// ## Example
+    /// # Examples
     ///
     /// ```rust
     /// use bunsen::contracts::{
@@ -584,7 +584,7 @@ impl<'a> ShapeContract<'a> {
         Ok(result)
     }
 
-    /// Convert a list of keys to a selection.
+    /// Converts a list of keys to a selection.
     pub fn expect_keys_to_selection<const D: usize>(
         &'a self,
         keys: &[&'a str; D],
@@ -620,13 +620,13 @@ impl<'a> ShapeContract<'a> {
 
     /// Resolve the match for the shape against the pattern.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `shape`: the shape to match.
     /// - `env`: the mutable environment to bind parameters.
     /// - `location`: the location reference from ``#[track_caller]``.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// - `Ok(())`: if the shape matches the pattern; will update the `env`.
     /// - `Err(&str)`: if the shape does not match the pattern, with an error
@@ -727,13 +727,13 @@ impl<'a> ShapeContract<'a> {
         Ok(())
     }
 
-    /// Check if the pattern has an ellipsis.
+    /// Checks if the pattern has an ellipsis.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `rank`: the number of dims of the shape to match.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// - `Ok((usize, usize))`: the position of the ellipsis and the number of
     ///   dimensions it matches.

--- a/crates/bunsen/src/contracts/shape_view.rs
+++ b/crates/bunsen/src/contracts/shape_view.rs
@@ -18,7 +18,7 @@ pub struct ShapeView<'a> {
 }
 
 impl<'a> ShapeView<'a> {
-    /// Build an adaptor from a slice reference.
+    /// Builds an adaptor from a slice reference.
     pub fn from_slice(slice: &'a [usize]) -> Self {
         Self {
             slice: Some(slice),
@@ -26,7 +26,7 @@ impl<'a> ShapeView<'a> {
         }
     }
 
-    /// Build an adaptor from a vector.
+    /// Builds an adaptor from a vector.
     pub fn from_vec(shape: Vec<usize>) -> Self {
         Self {
             slice: None,

--- a/crates/bunsen/src/data/cache/disk_cache.rs
+++ b/crates/bunsen/src/data/cache/disk_cache.rs
@@ -43,7 +43,7 @@ pub struct BunsenDiskCacheOptions {
 }
 
 impl BunsenDiskCacheOptions {
-    /// Set the cache directory.
+    /// Sets the cache directory.
     pub fn with_cache_dir<P: AsRef<Path>>(
         mut self,
         cache_dir: Option<P>,
@@ -52,7 +52,7 @@ impl BunsenDiskCacheOptions {
         self
     }
 
-    /// Set the data directory.
+    /// Sets the data directory.
     pub fn with_data_dir<P: AsRef<Path>>(
         mut self,
         data_dir: Option<P>,
@@ -61,7 +61,7 @@ impl BunsenDiskCacheOptions {
         self
     }
 
-    /// Set the downloader builder.
+    /// Sets the downloader builder.
     pub fn with_downloader(
         mut self,
         downloader: Option<fn() -> Downloader>,
@@ -94,7 +94,7 @@ impl Default for BunsenDiskCache {
 }
 
 impl BunsenDiskCache {
-    /// Construct a new [`BunsenDiskCache`].
+    /// Constructs a new [`BunsenDiskCache`].
     pub fn new(options: BunsenDiskCacheOptions) -> BunsenResult<Self> {
         let cache_dir = BUNSEN_CACHE_CONFIG
             .resolve_cache_dir(options.cache_dir)
@@ -122,17 +122,17 @@ impl BunsenDiskCache {
         })
     }
 
-    /// Get the cache directory.
+    /// Returns the cache directory.
     pub fn cache_dir(&self) -> &Path {
         &self.cache_dir
     }
 
-    /// Get the data directory.
+    /// Returns the data directory.
     pub fn data_dir(&self) -> &Path {
         &self.data_dir
     }
 
-    /// Get the downloader.
+    /// Returns the downloader.
     pub fn downloader(&self) -> &Downloader {
         &self.downloader
     }
@@ -198,7 +198,7 @@ impl BunsenDiskCache {
         Ok(path)
     }
 
-    /// Get the cache path for the given key.
+    /// Returns the cache path for the given key.
     ///
     /// * Does not check that the path exists.
     /// * Does not initialize the containing directories.
@@ -218,7 +218,7 @@ impl BunsenDiskCache {
         path_utils::extend_path(&self.cache_dir, context, file)
     }
 
-    /// Get the data path for the given key.
+    /// Returns the data path for the given key.
     ///
     /// * Does not check that the path exists.
     /// * Does not initialize the containing directories.

--- a/crates/bunsen/src/data/cache/path_resolver.rs
+++ b/crates/bunsen/src/data/cache/path_resolver.rs
@@ -45,12 +45,12 @@ pub struct PathResolver {
 }
 
 impl PathResolver {
-    /// Get the [`ProjectDirs`] for this config.
+    /// Returns the [`ProjectDirs`] for this config.
     pub fn project_dirs(&self) -> Option<ProjectDirs> {
         ProjectDirs::from(self.organization, self.application, self.qualifier)
     }
 
-    /// Resolve the cache directory for this config.
+    /// Resolves the cache directory for this config.
     ///
     /// Resolution Order:
     /// 1. `path`, if present.
@@ -86,7 +86,7 @@ impl PathResolver {
         None
     }
 
-    /// Resolve the data directory for this config.
+    /// Resolves the data directory for this config.
     ///
     /// Resolution Order:
     /// 1. `path`, if present.

--- a/crates/bunsen/src/data/cache/path_utils.rs
+++ b/crates/bunsen/src/data/cache/path_utils.rs
@@ -5,7 +5,7 @@ use std::path::{
     PathBuf,
 };
 
-/// Extend a path with a context and filename.
+/// Extends a path with a context and filename.
 ///
 /// * Does not check that the path exists.
 /// * Does not initialize the containing directories.

--- a/crates/bunsen/src/data/pretrained/prefabs.rs
+++ b/crates/bunsen/src/data/pretrained/prefabs.rs
@@ -45,7 +45,7 @@ impl<C> StaticPreFabConfig<C>
 where
     C: 'static + Config + Debug + Clone,
 {
-    /// Convert to a [`PreFabConfig<C>`].
+    /// Converts to a [`PreFabConfig<C>`].
     pub fn to_prefab(&self) -> PreFabConfig<C> {
         let builder = self.builder;
         PreFabConfig {
@@ -56,7 +56,7 @@ where
         }
     }
 
-    /// Build a new config.
+    /// Builds a new config.
     pub fn to_config(&self) -> C {
         (self.builder)()
     }
@@ -131,12 +131,12 @@ impl<C> PreFabConfig<C>
 where
     C: 'static + Config + Debug + Clone,
 {
-    /// Build a new config.
+    /// Builds a new config.
     pub fn to_config(&self) -> C {
         (self.builder)()
     }
 
-    /// Lookup a descriptor.
+    /// Looks up a descriptor.
     pub fn lookup_pretrained_weights(
         &self,
         name: &str,
@@ -147,7 +147,7 @@ where
         }
     }
 
-    /// Lookup a descriptor.
+    /// Looks up a descriptor.
     pub fn try_lookup_pretrained_weights(
         &self,
         name: &str,
@@ -161,7 +161,7 @@ where
         }
     }
 
-    /// Lookup a descriptor.
+    /// Looks up a descriptor.
     pub fn expect_lookup_pretrained_weights(
         &self,
         name: &str,
@@ -193,7 +193,7 @@ impl<C> StaticPreFabMap<C>
 where
     C: 'static + Config + Debug + Clone,
 {
-    /// Convert to a [`PreFabMap`].
+    /// Converts to a [`PreFabMap`].
     pub fn to_prefab_map(&self) -> PreFabMap<C> {
         PreFabMap {
             name: self.name.to_string(),
@@ -206,7 +206,7 @@ where
         }
     }
 
-    /// Lookup a prefab.
+    /// Looks up a prefab.
     pub fn lookup_prefab(
         &self,
         name: &str,
@@ -217,7 +217,7 @@ where
             .map(|c| c.to_prefab())
     }
 
-    /// Lookup a prefab.
+    /// Looks up a prefab.
     pub fn try_lookup_prefab(
         &self,
         name: &str,
@@ -231,7 +231,7 @@ where
         }
     }
 
-    /// Lookup a prefab.
+    /// Looks up a prefab.
     pub fn expect_lookup_prefab(
         &self,
         name: &str,
@@ -263,7 +263,7 @@ impl<C> PreFabMap<C>
 where
     C: 'static + Config + Debug + Clone,
 {
-    /// Lookup a prefab.
+    /// Looks up a prefab.
     pub fn lookup_prefab(
         &self,
         name: &str,
@@ -271,7 +271,7 @@ where
         self.items.get(name).cloned()
     }
 
-    /// Lookup a prefab.
+    /// Looks up a prefab.
     pub fn try_lookup_prefab(
         &self,
         name: &str,
@@ -285,7 +285,7 @@ where
         }
     }
 
-    /// Lookup a prefab.
+    /// Looks up a prefab.
     pub fn expect_lookup_prefab(
         &self,
         name: &str,

--- a/crates/bunsen/src/data/pretrained/weights.rs
+++ b/crates/bunsen/src/data/pretrained/weights.rs
@@ -27,7 +27,7 @@ use crate::{
 
 const X25: crc::Crc<u16> = crc::Crc::<u16>::new(&crc::CRC_16_IBM_SDLC);
 
-/// Build a cache key (bare cache file name) from a name and URL.
+/// Builds a cache key (bare cache file name) from a name and URL.
 pub fn url_to_cache_key(
     name: Option<&str>,
     url: &str,
@@ -40,7 +40,7 @@ pub fn url_to_cache_key(
     }
 }
 
-/// Get the cache resource key for a pretrained weights file.
+/// Returns the cache resource key for a pretrained weights file.
 ///
 /// # Arguments
 ///
@@ -73,7 +73,7 @@ pub struct StaticPretrainedWeightsDescriptor<'a> {
 }
 
 impl<'a> StaticPretrainedWeightsDescriptor<'a> {
-    /// Convert to a [`PretrainedWeightsDescriptor`].
+    /// Converts to a [`PretrainedWeightsDescriptor`].
     pub fn to_descriptor(&self) -> PretrainedWeightsDescriptor {
         PretrainedWeightsDescriptor {
             name: self.name.to_string(),
@@ -144,7 +144,7 @@ pub struct StaticPretrainedWeightsMap<'a> {
 }
 
 impl<'a> StaticPretrainedWeightsMap<'a> {
-    /// Convert to a [`PretrainedWeightsMap`].
+    /// Converts to a [`PretrainedWeightsMap`].
     pub fn to_directory(&self) -> PretrainedWeightsMap {
         PretrainedWeightsMap {
             items: self
@@ -173,7 +173,7 @@ pub struct PretrainedWeightsMap {
 }
 
 impl PretrainedWeightsMap {
-    /// Lookup a descriptor by name.
+    /// Looks up a descriptor by name.
     pub fn lookup_by_name(
         &self,
         name: &str,
@@ -181,7 +181,7 @@ impl PretrainedWeightsMap {
         self.items.get(name).cloned()
     }
 
-    /// Lookup a descriptor.
+    /// Looks up a descriptor.
     pub fn try_lookup_by_name(
         &self,
         name: &str,
@@ -195,7 +195,7 @@ impl PretrainedWeightsMap {
         }
     }
 
-    /// Lookup a descriptor.
+    /// Looks up a descriptor.
     pub fn expect_lookup_by_name(
         &self,
         name: &str,

--- a/crates/bunsen/src/errors/mod.rs
+++ b/crates/bunsen/src/errors/mod.rs
@@ -25,7 +25,7 @@ pub enum BunsenError {
 }
 
 impl BunsenError {
-    /// Map an error to an External string error.
+    /// Maps an error to an External string error.
     pub fn external<E>(e: E) -> Self
     where
         E: std::error::Error,

--- a/crates/bunsen/src/kits/bimm/resnet/basic_block.rs
+++ b/crates/bunsen/src/kits/bimm/resnet/basic_block.rs
@@ -96,18 +96,18 @@ pub trait BasicBlockMeta {
     /// Affects downsample behavior.
     fn stride(&self) -> usize;
 
-    /// Get the output resolution for a given input resolution.
+    /// Returns the output resolution for a given input resolution.
     ///
     /// The input must be a multiple of the stride.
     ///
     /// # Arguments
     ///
-    /// - `input_resolution`: \ ``[in_height=out_height*stride,
-    ///   in_width=out_width*stride]``.
+    /// - `input_resolution`: \ `[in_height=out_height*stride,
+    ///   in_width=out_width*stride]`.
     ///
     /// # Returns
     ///
-    /// ``[out_height, out_width]``
+    /// `[out_height, out_width]`
     ///
     /// # Panics
     ///
@@ -121,6 +121,10 @@ pub trait BasicBlockMeta {
 }
 
 /// [`BasicBlock`] Config.
+///
+/// Describes the channel sizes, stride, dilation, and regularization for a
+/// [`BasicBlock`]. Call `.init(device)` to build the [`BasicBlock`] module,
+/// then drive it with [`BasicBlock::forward`].
 ///
 /// Implements [`BasicBlockMeta`].
 #[derive(Config, Debug)]
@@ -285,7 +289,14 @@ impl<B: Backend> ModuleInit<B, BasicBlock<B>> for BasicBlockConfig {
 
 /// Basic Block for `ResNet`.
 ///
+/// The standard two-conv `ResNet` residual unit: two `3x3` conv/norm/act
+/// stages plus an optional downsample on the residual identity path.
+/// Configure via [`BasicBlockConfig`], call `.init(device)` to build, then
+/// [`BasicBlock::forward`] to apply.
+///
 /// Implements [`BasicBlockMeta`].
+///
+/// Built by [`BasicBlockConfig`].
 #[derive(Module, Debug)]
 pub struct BasicBlock<B: Backend> {
     /// Reduction factor.
@@ -353,12 +364,12 @@ impl<B: Backend> BasicBlock<B> {
     ///
     /// # Arguments
     ///
-    /// - `input`: ``[batch, in_planes, in_height=out_height*stride,
-    ///   in_width=out_width*stride]``.
+    /// - `input`: `[batch, in_planes, in_height=out_height*stride,
+    ///   in_width=out_width*stride]`.
     ///
     /// # Returns
     ///
-    /// A ``[batch, out_planes=planes*expansion_factor, out_height, out_width]``
+    /// A `[batch, out_planes=planes*expansion_factor, out_height, out_width]`
     /// tensor.
     pub fn forward(
         &self,
@@ -438,7 +449,7 @@ impl<B: Backend> BasicBlock<B> {
         x
     }
 
-    /// Set the drop path probability.
+    /// Sets the drop path probability.
     pub fn with_drop_path_prob(
         self,
         drop_path_prob: f64,
@@ -457,7 +468,7 @@ impl<B: Backend> BasicBlock<B> {
         }
     }
 
-    /// Set the drop block behavior.
+    /// Sets the drop block behavior.
     pub fn with_drop_block(
         self,
         drop_block: Option<DropBlockOptions>,

--- a/crates/bunsen/src/kits/bimm/resnet/bottleneck_block.rs
+++ b/crates/bunsen/src/kits/bimm/resnet/bottleneck_block.rs
@@ -64,6 +64,12 @@ use crate::{
 };
 
 /// Bottleneck Policy.
+///
+/// Carries the bottleneck `pinch_factor` that sets the internal channel
+/// reduction of a [`BottleneckBlock`]. This is a plain settings config; it
+/// builds no module on its own.
+///
+/// Used by [`BottleneckBlockConfig`].
 #[derive(Config, Debug)]
 pub struct BottleneckPolicyConfig {
     /// Input pinch factor.
@@ -112,7 +118,7 @@ pub trait BottleneckBlockMeta {
     /// Control factor for `first_planes()`
     fn reduce_first(&self) -> usize;
 
-    /// Get Width Plane.
+    /// Returns Width Plane.
     ///
     /// ``pinch_planes * (base_width / 64) * cardinality``
     fn width(&self) -> usize {
@@ -124,18 +130,18 @@ pub trait BottleneckBlockMeta {
     /// Affects downsample behavior.
     fn stride(&self) -> usize;
 
-    /// Get the output resolution for a given input resolution.
+    /// Returns the output resolution for a given input resolution.
     ///
     /// The input must be a multiple of the stride.
     ///
     /// # Arguments
     ///
-    /// - `input_resolution`: ``[in_height=out_height*stride,
-    ///   in_width=out_width*stride]``.
+    /// - `input_resolution`: `[in_height=out_height*stride,
+    ///   in_width=out_width*stride]`.
     ///
     /// # Returns
     ///
-    /// ``[out_height, out_width]``
+    /// `[out_height, out_width]`
     ///
     /// # Panics
     ///
@@ -152,6 +158,10 @@ pub trait BottleneckBlockMeta {
 pub const BOTTLENECK_BLOCK_DEFAULT_PINCH_FACTOR: usize = 4;
 
 /// [`BottleneckBlock`] Config.
+///
+/// Describes the channel sizes, cardinality, bottleneck policy, stride, and
+/// regularization for a [`BottleneckBlock`]. Call `.init(device)` to build the
+/// [`BottleneckBlock`] module, then drive it with [`BottleneckBlock::forward`].
 ///
 /// Implements [`BottleneckBlockMeta`].
 #[derive(Config, Debug)]
@@ -357,7 +367,14 @@ impl<B: Backend> ModuleInit<B, BottleneckBlock<B>> for BottleneckBlockConfig {
 
 /// Bottleneck Block for `ResNet`.
 ///
+/// The three-conv bottleneck `ResNet` residual unit: a `1x1` pinch, a `3x3`
+/// (optionally grouped) conv, and a `1x1` expand, plus an optional downsample
+/// on the residual identity path. Configure via [`BottleneckBlockConfig`],
+/// call `.init(device)` to build, then [`BottleneckBlock::forward`] to apply.
+///
 /// Implements [`BottleneckBlockMeta`].
+///
+/// Built by [`BottleneckBlockConfig`].
 #[derive(Module, Debug)]
 pub struct BottleneckBlock<B: Backend> {
     /// Base width.
@@ -452,12 +469,12 @@ impl<B: Backend> BottleneckBlock<B> {
     ///
     /// # Arguments
     ///
-    /// - `input`: ``[batch, in_planes, in_height=out_height*stride,
-    ///   in_width=out_width*stride]``.
+    /// - `input`: `[batch, in_planes, in_height=out_height*stride,
+    ///   in_width=out_width*stride]`.
     ///
     /// # Returns
     ///
-    /// A ``[batch, out_planes=planes*expansion_factor, out_height, out_width]``
+    /// A `[batch, out_planes=planes*expansion_factor, out_height, out_width]`
     /// tensor;
     pub fn forward(
         &self,
@@ -545,7 +562,7 @@ impl<B: Backend> BottleneckBlock<B> {
         })
     }
 
-    /// Set the drop path probability.
+    /// Sets the drop path probability.
     pub fn with_drop_path_prob(
         self,
         drop_path_prob: f64,
@@ -564,7 +581,7 @@ impl<B: Backend> BottleneckBlock<B> {
         }
     }
 
-    /// Set the drop block behavior.
+    /// Sets the drop block behavior.
     pub fn with_drop_block(
         self,
         drop_block: Option<DropBlockOptions>,

--- a/crates/bunsen/src/kits/bimm/resnet/downsample.rs
+++ b/crates/bunsen/src/kits/bimm/resnet/downsample.rs
@@ -61,18 +61,18 @@ pub trait ResNetDownsampleMeta {
     /// The stride of the downsample layer.
     fn stride(&self) -> usize;
 
-    /// Get the output resolution for a given input resolution.
+    /// Returns the output resolution for a given input resolution.
     ///
     /// The input must be a multiple of the stride.
     ///
     /// # Arguments
     ///
-    /// - `input_resolution`: ``[in_height=out_height*stride,
-    ///   in_width=out_width*stride]``.
+    /// - `input_resolution`: `[in_height=out_height*stride,
+    ///   in_width=out_width*stride]`.
     ///
     /// # Returns
     ///
-    /// ``[out_height, out_width]``
+    /// `[out_height, out_width]`
     ///
     /// # Panics
     ///
@@ -96,6 +96,11 @@ pub trait ResNetDownsampleMeta {
 }
 
 /// [`ResNetDownsample`] configuration.
+///
+/// Describes the conv (channels, kernel, stride, dilation) and normalization
+/// used to project a residual identity path onto the block output shape. Call
+/// `.init(device)` to build the [`ResNetDownsample`] module, then drive it with
+/// [`ResNetDownsample::forward`].
 ///
 /// Implements [`ResNetDownsampleMeta`].
 ///
@@ -187,7 +192,14 @@ impl<B: Backend> ModuleInit<B, ResNetDownsample<B>> for ResNetDownsampleConfig {
 
 /// `ResNet` Downsample Layer.
 ///
+/// A conv + norm that reshapes a residual identity tensor (channels and/or
+/// spatial stride) so it can be added to a block output. Configure via
+/// [`ResNetDownsampleConfig`], call `.init(device)` to build, then
+/// [`ResNetDownsample::forward`] to apply.
+///
 /// Implements [`ResNetDownsampleMeta`].
+///
+/// Built by [`ResNetDownsampleConfig`].
 ///
 /// # Missing Features
 ///
@@ -229,12 +241,12 @@ impl<B: Backend> ResNetDownsample<B> {
     ///
     /// # Arguments
     ///
-    /// - `input`: \ ``[batch, in_channels, in_height=out_height*stride,
-    ///   in_width=out_width*stride]``
+    /// - `input`: \ `[batch, in_channels, in_height=out_height*stride,
+    ///   in_width=out_width*stride]`
     ///
     /// # Returns
     ///
-    /// ``[batch_size, out_channels, h_out, w_out]``
+    /// `[batch_size, out_channels, h_out, w_out]`
     pub fn forward(
         &self,
         input: Tensor<B, 4>,

--- a/crates/bunsen/src/kits/bimm/resnet/layer_block.rs
+++ b/crates/bunsen/src/kits/bimm/resnet/layer_block.rs
@@ -56,6 +56,12 @@ use crate::{
 };
 
 /// Abstract [`LayerBlock`] Config.
+///
+/// High-level description of one `ResNet` stage: how many blocks, the channel
+/// sizes, dilation, downsampling, and whether to use bottleneck blocks. Lowers
+/// to a [`LayerBlockStructureConfig`] via
+/// [`LayerBlockContractConfig::to_structure`]; call `.init(device)` to build
+/// the [`LayerBlock`] module, then drive it with [`LayerBlock::forward`].
 #[derive(Config, Debug)]
 pub struct LayerBlockContractConfig {
     /// The number of internal blocks.
@@ -97,7 +103,7 @@ pub struct LayerBlockContractConfig {
 }
 
 impl LayerBlockContractConfig {
-    /// Build the [`ResidualBlockContractConfig`]s for this layer block.
+    /// Builds the [`ResidualBlockContractConfig`]s for this layer block.
     pub fn to_block_contracts(&self) -> Vec<ResidualBlockContractConfig> {
         let mut first_dilation = self.first_dilation;
 
@@ -127,7 +133,7 @@ impl LayerBlockContractConfig {
         blocks
     }
 
-    /// Convert to [`LayerBlockStructureConfig`].
+    /// Converts to [`LayerBlockStructureConfig`].
     pub fn to_structure(&self) -> LayerBlockStructureConfig {
         LayerBlockStructureConfig {
             blocks: self
@@ -159,7 +165,7 @@ pub trait LayerBlockMeta {
     /// The number of blocks.
     fn len(&self) -> usize;
 
-    /// Check if the layer block is empty.
+    /// Checks if the layer block is empty.
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -170,21 +176,21 @@ pub trait LayerBlockMeta {
     /// The number of output feature planes.
     fn out_planes(&self) -> usize;
 
-    /// Get the effective stride of the layers.
+    /// Returns the effective stride of the layers.
     fn stride(&self) -> usize;
 
-    /// Get the output resolution for a given input resolution.
+    /// Returns the output resolution for a given input resolution.
     ///
     /// The input must be a multiple of the stride.
     ///
     /// # Arguments
     ///
-    /// - `input_resolution`: ``[in_height=out_height*stride,
-    ///   in_width=out_width*stride]``.
+    /// - `input_resolution`: `[in_height=out_height*stride,
+    ///   in_width=out_width*stride]`.
     ///
     /// # Returns
     ///
-    /// ``[out_height, out_width]``
+    /// `[out_height, out_width]`
     ///
     /// # Panics
     ///
@@ -198,6 +204,10 @@ pub trait LayerBlockMeta {
 }
 
 /// [`LayerBlock`] Configuration.
+///
+/// The concrete, per-block structure of a `ResNet` stage: an explicit list of
+/// [`ResidualBlockStructureConfig`]s. Call `.init(device)` to build the
+/// [`LayerBlock`] module, then drive it with [`LayerBlock::forward`].
 ///
 /// Implements [`LayerBlockMeta`].
 #[derive(Config, Debug)]
@@ -233,7 +243,7 @@ impl LayerBlockMeta for LayerBlockStructureConfig {
 }
 
 impl LayerBlockStructureConfig {
-    /// Check if the config is valid.
+    /// Checks if the config is valid.
     pub fn try_validate(&self) -> BunsenResult<()> {
         if self.is_empty() {
             return Err(BunsenError::Invalid("blocks is empty".to_string()));
@@ -256,7 +266,7 @@ impl LayerBlockStructureConfig {
         Ok(())
     }
 
-    /// Panic if `try_validate` returns an error.
+    /// Panics if `try_validate` returns an error.
     pub fn expect_valid(&self) {
         match self.try_validate() {
             Ok(_) => (),
@@ -264,7 +274,7 @@ impl LayerBlockStructureConfig {
         }
     }
 
-    /// Apply a mapping over the blocks.
+    /// Applies a mapping over the blocks.
     pub fn map_blocks<F>(
         self,
         f: &mut F,
@@ -282,7 +292,7 @@ impl LayerBlockStructureConfig {
         }
     }
 
-    /// Update the drop block options.
+    /// Updates the drop block options.
     pub fn with_drop_block<O>(
         self,
         options: O,
@@ -320,7 +330,15 @@ impl<B: Backend> ModuleInit<B, LayerBlock<B>> for LayerBlockStructureConfig {
 
 /// Layer block; stack of [`ResidualBlock`]s.
 ///
+/// One `ResNet` stage: a sequential run of [`ResidualBlock`]s applied in order,
+/// where the first block typically handles channel/stride changes. Configure
+/// via [`LayerBlockContractConfig`], call `.init(device)` to build, then
+/// [`LayerBlock::forward`] to apply.
+///
 /// Implements [`LayerBlockMeta`].
+///
+/// Built by [`LayerBlockContractConfig`] (high-level) or
+/// [`LayerBlockStructureConfig`].
 #[derive(Module, Debug)]
 pub struct LayerBlock<B: Backend> {
     /// Internal blocks.
@@ -358,7 +376,7 @@ impl<B: Backend> LayerBlock<B> {
         }
     }
 
-    /// Apply the layer block.
+    /// Applies the layer block.
     pub fn forward(
         &self,
         input: Tensor<B, 4>,
@@ -394,7 +412,7 @@ impl<B: Backend> LayerBlock<B> {
         x
     }
 
-    /// Apply a mapping over the blocks.
+    /// Applies a mapping over the blocks.
     pub fn map_blocks<F>(
         self,
         f: &mut F,
@@ -412,7 +430,7 @@ impl<B: Backend> LayerBlock<B> {
         }
     }
 
-    /// Update the drop path probability.
+    /// Updates the drop path probability.
     pub fn with_drop_path_prob(
         self,
         prob: f64,
@@ -421,7 +439,7 @@ impl<B: Backend> LayerBlock<B> {
         self.map_blocks(&mut |_, block| block.with_drop_path_prob(prob))
     }
 
-    /// Update the drop block options.
+    /// Updates the drop block options.
     pub fn with_drop_block<O>(
         self,
         options: O,

--- a/crates/bunsen/src/kits/bimm/resnet/mod.rs
+++ b/crates/bunsen/src/kits/bimm/resnet/mod.rs
@@ -3,7 +3,7 @@
 //! Implementation of the *`ResNet`* family of models for image recognition.
 //! See: [arXiv:1512.03385v1 [cs.CV]](<https://arxiv.org/abs/1512.03385>)
 //!
-//! ## Example
+//! # Examples
 //!
 //! Examples of loading pretrained model:
 //!

--- a/crates/bunsen/src/kits/bimm/resnet/residual_block.rs
+++ b/crates/bunsen/src/kits/bimm/resnet/residual_block.rs
@@ -53,6 +53,12 @@ use crate::{
 };
 
 /// Abstract [`ResidualBlock`] Config.
+///
+/// High-level description of a single residual unit: channel sizes, dilation,
+/// downsampling, and whether to select a [`BasicBlock`] or [`BottleneckBlock`].
+/// Lowers to a [`ResidualBlockStructureConfig`] via
+/// [`ResidualBlockContractConfig::to_structure`]; call `.init(device)` to build
+/// the [`ResidualBlock`] module, then drive it with [`ResidualBlock::forward`].
 #[derive(Config, Debug)]
 pub struct ResidualBlockContractConfig {
     /// The number of input feature planes.
@@ -90,7 +96,7 @@ pub struct ResidualBlockContractConfig {
 }
 
 impl ResidualBlockContractConfig {
-    /// Convert to [`ResidualBlockStructureConfig`].
+    /// Converts to [`ResidualBlockStructureConfig`].
     pub fn to_structure(&self) -> ResidualBlockStructureConfig {
         let stride = if self.downsample_input { 2 } else { 1 };
 
@@ -145,18 +151,18 @@ pub trait ResidualBlockMeta {
     /// Affects downsample behavior.
     fn stride(&self) -> usize;
 
-    /// Get the output resolution for a given input resolution.
+    /// Returns the output resolution for a given input resolution.
     ///
     /// The input must be a multiple of the stride.
     ///
     /// # Arguments
     ///
-    /// - `input_resolution`: \ ``[in_height=out_height*stride,
-    ///   in_width=out_width*stride]``.
+    /// - `input_resolution`: \ `[in_height=out_height*stride,
+    ///   in_width=out_width*stride]`.
     ///
     /// # Returns
     ///
-    /// ``[out_height, out_width]``
+    /// `[out_height, out_width]`
     ///
     /// # Panics
     ///
@@ -170,6 +176,11 @@ pub trait ResidualBlockMeta {
 }
 
 /// [`ResidualBlock`] Config.
+///
+/// The concrete, resolved choice of inner block ([`BasicBlockConfig`] or
+/// [`BottleneckBlockConfig`]) for one residual unit. Call `.init(device)` to
+/// build the [`ResidualBlock`] module, then drive it with
+/// [`ResidualBlock::forward`].
 ///
 /// Implements [`ResidualBlockMeta`].
 #[derive(Config, Debug)]
@@ -227,7 +238,7 @@ impl From<BottleneckBlockConfig> for ResidualBlockStructureConfig {
 }
 
 impl ResidualBlockStructureConfig {
-    /// Set drop block options.
+    /// Sets drop block options.
     pub fn with_drop_block(
         self,
         options: Option<DropBlockOptions>,
@@ -238,7 +249,7 @@ impl ResidualBlockStructureConfig {
         }
     }
 
-    /// Set the drop path probability.
+    /// Sets the drop path probability.
     pub fn with_drop_path_prob(
         self,
         drop_path_prob: f64,
@@ -265,7 +276,15 @@ impl<B: Backend> ModuleInit<B, ResidualBlock<B>> for ResidualBlockStructureConfi
 
 /// A `ResNet` [`BasicBlock`] or [`BottleneckBlock`] wrapper.
 ///
+/// A uniform residual-unit module that dispatches to either a [`BasicBlock`] or
+/// a [`BottleneckBlock`], letting a stage hold a homogeneous list of blocks.
+/// Configure via [`ResidualBlockContractConfig`], call `.init(device)` to
+/// build, then [`ResidualBlock::forward`] to apply.
+///
 /// Implements [`ResidualBlockMeta`].
+///
+/// Built by [`ResidualBlockContractConfig`] (high-level) or
+/// [`ResidualBlockStructureConfig`].
 #[derive(Module, Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum ResidualBlock<B: Backend> {
@@ -320,16 +339,16 @@ impl<B: Backend> ResidualBlock<B> {
         }
     }
 
-    /// Apply the wrapped block to the input.
+    /// Applies the wrapped block to the input.
     ///
     /// # Arguments
     ///
-    /// - `input`: ``[batch, in_planes, in_height=out_height*stride,
-    ///   in_width=out_width*stride]``.
+    /// - `input`: `[batch, in_planes, in_height=out_height*stride,
+    ///   in_width=out_width*stride]`.
     ///
     /// # Returns
     ///
-    /// A ``[batch, out_planes, out_height, out_width]`` tensor;
+    /// A `[batch, out_planes, out_height, out_width]` tensor;
     pub fn forward(
         &self,
         input: Tensor<B, 4>,
@@ -340,7 +359,7 @@ impl<B: Backend> ResidualBlock<B> {
         }
     }
 
-    /// Set the drop path probability.
+    /// Sets the drop path probability.
     pub fn with_drop_path_prob(
         self,
         drop_path_prob: f64,
@@ -352,7 +371,7 @@ impl<B: Backend> ResidualBlock<B> {
         }
     }
 
-    /// Set drop block options.
+    /// Sets drop block options.
     pub fn with_drop_block(
         self,
         options: Option<DropBlockOptions>,

--- a/crates/bunsen/src/kits/bimm/resnet/resnet_model.rs
+++ b/crates/bunsen/src/kits/bimm/resnet/resnet_model.rs
@@ -84,6 +84,12 @@ pub const RESNET101_BLOCKS: [usize; 4] = [3, 4, 23, 3];
 pub const RESNET152_BLOCKS: [usize; 4] = [3, 8, 36, 3];
 
 /// High-level [`ResNet`] model configuration.
+///
+/// The user-facing entry point for building a [`ResNet`]: stage depths, class
+/// count, stem width, output stride, and bottleneck policy. Lowers to a
+/// [`ResNetStructureConfig`] via [`ResNetContractConfig::to_structure`]; call
+/// `.init(device)` to build the [`ResNet`] module, then drive it with
+/// [`ResNet::forward`].
 #[derive(Config, Debug)]
 pub struct ResNetContractConfig {
     /// Layer block depths.
@@ -120,7 +126,7 @@ pub struct ResNetContractConfig {
 }
 
 impl ResNetContractConfig {
-    /// Enable default bottleneck policy.
+    /// Enables default bottleneck policy.
     pub fn with_bottleneck(
         self,
         enable: bool,
@@ -133,7 +139,7 @@ impl ResNetContractConfig {
         self.with_bottleneck_policy(policy)
     }
 
-    /// Build the [`LayerBlockContractConfig`] stack.
+    /// Builds the [`LayerBlockContractConfig`] stack.
     #[allow(unused)]
     pub fn to_layer_contracts(&self) -> Vec<LayerBlockContractConfig> {
         let mut net_stride = 4;
@@ -181,7 +187,7 @@ impl ResNetContractConfig {
         layers
     }
 
-    /// Convert to a [`ResNetStructureConfig`].
+    /// Converts to a [`ResNetStructureConfig`].
     pub fn to_structure(&self) -> ResNetStructureConfig {
         ResNetStructureConfig::new(
             ConvNorm2dConfig::from(
@@ -202,7 +208,7 @@ impl ResNetContractConfig {
         )
     }
 
-    /// Create a ResNet-18 model.
+    /// Creates a ResNet-18 model.
     pub fn resnet18(num_classes: usize) -> Self {
         Self::new(RESNET18_BLOCKS.to_vec(), num_classes) // .with_bottleneck(true)
     }
@@ -229,6 +235,10 @@ impl From<ResNetContractConfig> for ResNetStructureConfig {
 /// This config defines the structure of a converted [`ResNet`] model.
 /// It is not a semantic configuration and does not check the validity
 /// of the internal sizes before or during construction.
+///
+/// Holds the explicit stem, per-stage [`LayerBlockStructureConfig`]s, and head.
+/// Call `.init(device)` to build the [`ResNet`] module, then drive it with
+/// [`ResNet::forward`].
 #[derive(Config, Debug)]
 pub struct ResNetStructureConfig {
     /// The input Conv/Norm block configuration.
@@ -250,7 +260,7 @@ pub struct ResNetStructureConfig {
 }
 
 impl ResNetStructureConfig {
-    /// Apply the given standard drop block probability scheme.
+    /// Applies the given standard drop block probability scheme.
     pub fn with_standard_drop_block_prob(
         self,
         drop_prob: f64,
@@ -273,7 +283,7 @@ impl ResNetStructureConfig {
         self.with_drop_block_options(blocks)
     }
 
-    /// Update the config with stochastic depth.
+    /// Updates the config with stochastic depth.
     pub fn with_stochastic_depth_drop_path_rate(
         self,
         drop_path_rate: f64,
@@ -303,7 +313,7 @@ impl ResNetStructureConfig {
         }
     }
 
-    /// Update the config with the given drop block options.
+    /// Updates the config with the given drop block options.
     ///
     /// # Arguments
     ///
@@ -363,6 +373,14 @@ impl<B: Backend> ModuleInit<B, ResNet<B>> for ResNetStructureConfig {
 }
 
 /// `ResNet` model.
+///
+/// The full image classification network: stem conv/norm/act + max-pool, a
+/// sequence of [`LayerBlock`] stages, then adaptive-average-pool and a linear
+/// classifier head. Configure via [`ResNetContractConfig`], call
+/// `.init(device)` to build, then [`ResNet::forward`] to map a `[batch, 3, h,
+/// w]` image batch to `[batch, num_classes]` logits.
+///
+/// Built by [`ResNetContractConfig`] (high-level) or [`ResNetStructureConfig`].
 #[derive(Module, Debug)]
 pub struct ResNet<B: Backend> {
     /// Input conv/norm.
@@ -419,7 +437,7 @@ impl<B: Backend> ResNet<B> {
         self.output_fc.forward(x)
     }
 
-    /// Load weights from a `PyTorch` weights path.
+    /// Loads weights from a `PyTorch` weights path.
     #[cfg(feature = "store")]
     pub fn load_pytorch_weights(
         mut self,
@@ -448,7 +466,7 @@ impl<B: Backend> ResNet<B> {
         Ok(self)
     }
 
-    /// Re-initialize the last layer with the specified number of output
+    /// Re-initializes the last layer with the specified number of output
     /// classes.
     pub fn with_classes(
         mut self,
@@ -460,7 +478,7 @@ impl<B: Backend> ResNet<B> {
         self
     }
 
-    /// Update the config with stochastic depth.
+    /// Updates the config with stochastic depth.
     pub fn with_stochastic_path_depth(
         self,
         drop_path_rate: f64,
@@ -490,7 +508,7 @@ impl<B: Backend> ResNet<B> {
         }
     }
 
-    /// Update the config with the given drop block options.
+    /// Updates the config with the given drop block options.
     ///
     /// # Arguments
     ///
@@ -511,7 +529,7 @@ impl<B: Backend> ResNet<B> {
         }
     }
 
-    /// Apply the given standard drop block probability scheme.
+    /// Applies the given standard drop block probability scheme.
     pub fn with_stochastic_drop_block(
         self,
         drop_prob: f64,
@@ -534,7 +552,7 @@ impl<B: Backend> ResNet<B> {
         self.with_drop_block_options(blocks)
     }
 
-    /// Apply a mapping over layers.
+    /// Applies a mapping over layers.
     pub fn map_layers<F>(
         self,
         f: F,
@@ -548,7 +566,7 @@ impl<B: Backend> ResNet<B> {
         }
     }
 
-    /// Freeze the layers.
+    /// Freezes the layers.
     pub fn freeze_layers(self) -> Self {
         self.map_layers(|layers| layers.into_iter().map(|layer| layer.no_grad()).collect())
     }

--- a/crates/bunsen/src/kits/bimm/resnet/stems.rs
+++ b/crates/bunsen/src/kits/bimm/resnet/stems.rs
@@ -85,7 +85,13 @@ use crate::blocks::images::conv::cna::{
     CNA2dConfig,
 };
 
-/// stem contract configuration.
+/// `ResNet` input stem contract configuration.
+///
+/// High-level choice of stem variant (default single `7x7` conv, or the deep
+/// three-`3x3`-conv variants). Lowers to a [`ResNetStemStructureConfig`] via
+/// [`ResNetStemContractConfig::to_structure`], which in turn describes the
+/// [`ResNetStem`] input module that downsamples and lifts an image batch into
+/// the network's feature space.
 #[derive(Debug, Clone, Default)]
 pub enum ResNetStemContractConfig {
     /// Default; single 7x7 convolution with stride 2.
@@ -112,7 +118,7 @@ pub enum ResNetStemContractConfig {
 }
 
 impl ResNetStemContractConfig {
-    /// Convert to a [`ResNetStemStructureConfig`].
+    /// Converts to a [`ResNetStemStructureConfig`].
     pub fn to_structure(
         &self,
         in_channels: usize,
@@ -154,7 +160,11 @@ impl ResNetStemContractConfig {
     }
 }
 
-/// stem contract configuration.
+/// `ResNet` input stem structure configuration.
+///
+/// The concrete layer layout of a [`ResNetStem`]: one to three conv/norm/act
+/// stages plus an optional pooling layer. Produced by
+/// [`ResNetStemContractConfig::to_structure`].
 #[derive(Debug, Clone)]
 pub struct ResNetStemStructureConfig {
     /// The first convolution.
@@ -170,7 +180,16 @@ pub struct ResNetStemStructureConfig {
     pub pool: Option<MaxPool2dConfig>,
 }
 
-/// stem impl.
+/// `ResNet` input stem module.
+///
+/// The first stage of a `ResNet`: it applies one to three conv/norm/act blocks
+/// followed by an optional max-pool, downsampling the input image and lifting
+/// it into the network's initial feature space before the residual stages.
+/// [`ResNetStem::forward`] maps a `[batch, in_channels, h, w]` image batch to a
+/// `[batch, planes, h', w']` feature tensor.
+///
+/// Its structure is described by [`ResNetStemStructureConfig`], selected via
+/// the high-level [`ResNetStemContractConfig`].
 #[derive(Module, Debug)]
 pub struct ResNetStem<B: Backend> {
     /// The first convolution.

--- a/crates/bunsen/src/kits/bimm/swin/v2/block_sequence.rs
+++ b/crates/bunsen/src/kits/bimm/swin/v2/block_sequence.rs
@@ -75,7 +75,11 @@ pub trait StochasticDepthTransformerBlockSequenceMeta {
     // TODO: norm_layer config, use_checkpoint, pretrained_window_size.
 }
 
-/// Config for `BasicLayer`.
+/// Config for [`StochasticDepthTransformerBlockSequence`].
+///
+/// Describes a stack of `depth` shift-window-alternating transformer blocks.
+/// Construct it, then call `.init(device)` to build the module and `forward` a
+/// `[batch, height * width, channels]` tensor through it.
 #[derive(Config, Debug)]
 pub struct StochasticDepthTransformerBlockSequenceConfig {
     /// Number of input channels.
@@ -234,6 +238,8 @@ impl<B: Backend> ModuleInit<B, StochasticDepthTransformerBlockSequence<B>>
 ///
 /// Applies a sequence of shift-window-alternating ``SwinTransformerBlock``
 /// modules.
+///
+/// Built by [`StochasticDepthTransformerBlockSequenceConfig`].
 #[derive(Module, Debug)]
 pub struct StochasticDepthTransformerBlockSequence<B: Backend> {
     blocks: Vec<ShiftedWindowTransformerBlock<B>>,
@@ -288,11 +294,11 @@ impl<B: Backend> StochasticDepthTransformerBlockSequence<B> {
     ///
     /// # Arguments
     ///
-    /// - `x`: Input tensor of shape: ``[batch, height * width, channels]``.
+    /// - `x`: `[batch, height * width, channels]` input tensor.
     ///
     /// # Returns
     ///
-    /// Output tensor of shape ``[batch, height * width, channels``.
+    /// `[batch, height * width, channels]` output tensor.
     ///
     /// # Panics
     ///

--- a/crates/bunsen/src/kits/bimm/swin/v2/mod.rs
+++ b/crates/bunsen/src/kits/bimm/swin/v2/mod.rs
@@ -1,7 +1,7 @@
 //! # Implementation of the Swin Transformer V2 model.
 //! See: [SWIN-V2](https://github.com/microsoft/Swin-Transformer/blob/main/models/swin_transformer_v2.py)
 //!
-//! ## Example
+//! # Examples
 //!
 //! ```rust,no_run
 //! use bunsen::{

--- a/crates/bunsen/src/kits/bimm/swin/v2/patch_merge.rs
+++ b/crates/bunsen/src/kits/bimm/swin/v2/patch_merge.rs
@@ -70,7 +70,12 @@ pub trait PatchMergingMeta {
     }
 }
 
-/// Configuration for `PatchMerging`.
+/// Configuration for [`PatchMerging`].
+///
+/// Specifies the input resolution and feature dimension for a patch-merging
+/// downsample step. Build the module with `.init(device)`, then `forward` a
+/// `[batch, height * width, channels]` tensor to halve the spatial resolution
+/// and double the channels.
 #[derive(Config, Debug)]
 pub struct PatchMergingConfig {
     /// Input resolution (height, width).
@@ -115,15 +120,17 @@ impl<B: Backend> ModuleInit<B, PatchMerging<B>> for PatchMergingConfig {
 
 /// SWIN-Transformer v2 `PatchMerging` module.
 ///
-/// This module accepts ``[batch, height * width, channels]`` inputs, and then:
-/// - Collates interleaved patches of size ``[height/2, width/2]`` into
-///   ``[batch, height/2 * width/2, 4 * channels]``.
+/// This module accepts `[batch, height * width, channels]` inputs, and then:
+/// - Collates interleaved patches of size `[height/2, width/2]` into `[batch,
+///   height/2 * width/2, 4 * channels]`.
 /// - Applies a linear layer to reduce the feature dimension to ``2 *
 ///   channels``.
 /// - Applies layer normalization.
-/// - Yields output of shape ``[batch, height/2 * width/2, 2 * channels]``.
+/// - Yields `[batch, height/2 * width/2, 2 * channels]` output.
 ///
 /// See: <https://github.com/microsoft/Swin-Transformer/blob/main/models/swin_transformer_v2.py>
+///
+/// Built by [`PatchMergingConfig`].
 #[derive(Module, Debug)]
 pub struct PatchMerging<B: Backend> {
     /// Input resolution (height, width).
@@ -151,11 +158,11 @@ impl<B: Backend> PatchMerging<B> {
     ///
     /// # Arguments
     ///
-    /// - `x` - Input tensor of shape ``[batch, height * width, channels]``.
+    /// - `x` - `[batch, height * width, channels]` input tensor.
     ///
     /// # Returns
     ///
-    /// A tensor of shape ``[batch, height/2 * width/2, 2 * channels]``.
+    /// A `[batch, height/2 * width/2, 2 * channels]` tensor.
     ///
     /// # Panics
     ///
@@ -195,20 +202,20 @@ impl<B: Backend> PatchMerging<B> {
     }
 }
 
-/// Collate patches from a tensor.
+/// Collates patches from a tensor.
 ///
-/// This splits the input into 4 interleaved patches, each ``[height/2,
-/// width/2]``; and then concatenates them along the last dimension.
+/// This splits the input into 4 interleaved patches, each `[height/2,
+/// width/2]`; and then concatenates them along the last dimension.
 ///
 /// # Arguments
 ///
-/// * `x` - Input tensor of shape ``[batch, height * width, channels]``.
+/// * `x` - `[batch, height * width, channels]` input tensor.
 /// * `h` - Height of the input tensor.
 /// * `w` - Width of the input tensor.
 ///
 /// # Returns
 ///
-/// * A tensor of shape ``[batch, height/2 * width/2, 4 * channels]``.
+/// * A `[batch, height/2 * width/2, 4 * channels]` tensor.
 ///
 /// # Panics
 ///
@@ -241,22 +248,22 @@ where
     x.reshape([b, h2w2, 4 * c])
 }
 
-/// Decollate patches from a tensor.
+/// Decollates patches from a tensor.
 ///
-/// This splits the input into 4 patches, each ``[height/2, width/2]``;
+/// This splits the input into 4 patches, each `[height/2, width/2]`;
 /// and interleaves them along the height and width dimensions.
 ///
 /// The inverse operation of `collate_patches`.
 ///
 /// # Arguments
 ///
-/// * `x` - Input tensor of shape ``[batch, height/2 * width/2, 4 * channels]``.
+/// * `x` - `[batch, height/2 * width/2, 4 * channels]` input tensor.
 /// * `height` - Height of the input tensor.
 /// * `width` - Width of the input tensor.
 ///
 /// # Returns
 ///
-/// * A tensor of shape ``[batch, height * width, channels]``.
+/// * A `[batch, height * width, channels]` tensor.
 ///
 /// # Panics
 ///

--- a/crates/bunsen/src/kits/bimm/swin/v2/swin_block.rs
+++ b/crates/bunsen/src/kits/bimm/swin/v2/swin_block.rs
@@ -52,20 +52,24 @@ use crate::{
 
 /// Common meta-interface for `BlockMlp` config.
 pub trait BlockMlpMeta {
-    /// Get the input dimension size.
+    /// Returns the input dimension size.
     fn d_input(&self) -> usize;
 
-    /// Get the hidden dimension size.
+    /// Returns the hidden dimension size.
     fn d_hidden(&self) -> usize;
 
-    /// Get the output dimension size.
+    /// Returns the output dimension size.
     fn d_output(&self) -> usize;
 
-    /// Get the dropout rate.
+    /// Returns the dropout rate.
     fn drop(&self) -> f64;
 }
 
-/// Configuration for `BlockMlp`.
+/// Configuration for [`BlockMlp`].
+///
+/// Describes the two-layer feed-forward MLP used inside a Swin transformer
+/// block. Build it with `.init(device)`, then `forward` a tensor whose last
+/// dimension is `d_input`.
 #[derive(Config, Debug)]
 pub struct BlockMlpConfig {
     d_input: usize,
@@ -120,7 +124,12 @@ impl<B: Backend> ModuleInit<B, BlockMlp<B>> for BlockMlpConfig {
     }
 }
 
-/// Swin MLP Module
+/// Swin MLP Module.
+///
+/// A two linear-layer MLP with activation and dropout, applied to the trailing
+/// feature dimension of an input tensor.
+///
+/// Built by [`BlockMlpConfig`].
 #[derive(Module, Debug)]
 pub struct BlockMlp<B: Backend> {
     /// First linear layer.
@@ -155,15 +164,15 @@ impl<B: Backend> BlockMlpMeta for BlockMlp<B> {
 }
 
 impl<B: Backend> BlockMlp<B> {
-    /// Apply the MLP to the input tensor.
+    /// Applies the MLP to the input tensor.
     ///
     /// # Arguments
     ///
-    /// - `x`: a tensor of ``[batch = ..., in]``.
+    /// - `x`: a tensor of `[batch = ..., in]`.
     ///
     /// # Returns
     ///
-    /// A tensor of ``[batch = ... out]``
+    /// A tensor of `[batch = ... out]`
     #[must_use]
     pub fn forward<const D: usize>(
         &self,
@@ -208,7 +217,7 @@ impl<B: Backend> BlockMlp<B> {
 ///
 /// # Arguments
 ///
-/// * `x` - Input tensor of ``[batch, height, width, channels]``.
+/// * `x` - Input tensor of `[batch, height, width, channels]`.
 /// * `f` - Function to apply on the shifted tensor.
 ///
 /// # Returns
@@ -247,43 +256,43 @@ where
 
 /// Common introspection interface for `TransformerBlock`.
 pub trait ShiftedWindowTransformerBlockMeta {
-    /// Get the input dimension size.
+    /// Returns the input dimension size.
     fn d_input(&self) -> usize;
 
-    /// Get the input resolution.
+    /// Returns the input resolution.
     fn input_resolution(&self) -> [usize; 2];
 
-    /// Get the input height.
+    /// Returns the input height.
     fn input_height(&self) -> usize {
         self.input_resolution()[0]
     }
 
-    /// Get the input width.
+    /// Returns the input width.
     fn input_width(&self) -> usize {
         self.input_resolution()[1]
     }
 
-    /// Get the output dimension size.
+    /// Returns the output dimension size.
     fn d_output(&self) -> usize {
         self.d_input()
     }
 
-    /// Get the output resolution.
+    /// Returns the output resolution.
     fn output_resolution(&self) -> [usize; 2] {
         self.input_resolution()
     }
 
-    /// Get the output height.
+    /// Returns the output height.
     fn output_height(&self) -> usize {
         self.input_height()
     }
 
-    /// Get the output width.
+    /// Returns the output width.
     fn output_width(&self) -> usize {
         self.input_width()
     }
 
-    /// Get the number of attention heads.
+    /// Returns the number of attention heads.
     fn num_heads(&self) -> usize;
 
     /// Window size for window attention.
@@ -313,13 +322,19 @@ pub trait ShiftedWindowTransformerBlockMeta {
     fn drop_path_rate(&self) -> f64;
 }
 
-/// Configuration for `TransformerBlock`.
+/// Configuration for `TransformerBlock` (the python name); builds a
+/// [`ShiftedWindowTransformerBlock`].
+///
+/// Specifies a single Swin transformer block: window attention (optionally
+/// shifted) plus an MLP, with residual/drop-path connections. Build it with
+/// `.init(device)`, then `forward` a `[batch, height * width, channels]`
+/// tensor.
 #[derive(Config, Debug)]
 pub struct ShiftedWindowTransformerBlockConfig {
     /// Input dimension size.
     pub d_input: usize,
 
-    /// Input resolution as ``[height, width]``.
+    /// Input resolution as `[height, width]`.
     pub input_resolution: [usize; 2],
 
     /// Number of attention heads.
@@ -495,9 +510,11 @@ impl<B: Backend> ModuleInit<B, ShiftedWindowTransformerBlock<B>>
 /// Equivalent to the ``SwinTransformerBlock`` in the python source.
 ///
 /// Applies one layer of Swin Transformer block with window attention and MLP.
+///
+/// Built by [`ShiftedWindowTransformerBlockConfig`].
 #[derive(Module, Debug)]
 pub struct ShiftedWindowTransformerBlock<B: Backend> {
-    /// Input resolution of the block, as ``[H, W]``.
+    /// Input resolution of the block, as `[H, W]`.
     pub input_resolution: [usize; 2],
 
     /// Window size for window attention.
@@ -572,11 +589,11 @@ impl<B: Backend> ShiftedWindowTransformerBlock<B> {
     ///
     /// # Arguments
     ///
-    /// * `x` - Input tensor of ``[batch, height * width, channels]``.
+    /// * `x` - Input tensor of `[batch, height * width, channels]`.
     ///
     /// # Returns
     ///
-    /// A new tensor of ``[batch, height * width, channels]``.
+    /// A new tensor of `[batch, height * width, channels]`.
     ///
     /// # Panics
     ///
@@ -634,12 +651,12 @@ impl<B: Backend> ShiftedWindowTransformerBlock<B> {
     ///
     /// # Arguments
     ///
-    /// * `x` - Input tensor of ``[batch, height, width, channels]``.
+    /// * `x` - Input tensor of `[batch, height, width, channels]`.
     /// * `c` - Number of channels in the input tensor.
     ///
     /// # Returns
     ///
-    /// A new tensor of ``[batch, height, width, channels]`` with window
+    /// A new tensor of `[batch, height, width, channels]` with window
     /// attention applied.
     #[must_use]
     #[inline(always)]

--- a/crates/bunsen/src/kits/bimm/swin/v2/swin_model.rs
+++ b/crates/bunsen/src/kits/bimm/swin/v2/swin_model.rs
@@ -65,6 +65,11 @@ use crate::{
 };
 
 /// Configuration for a single layer in the Swin Transformer V2 model.
+///
+/// One entry per stage in a [`SwinTransformerV2Config`]'s `layer_configs`
+/// vector. Records the per-stage block `depth` and attention head count;
+/// stage-level resolution, channels and drop-path rates are derived by the
+/// parent config during [`SwinTransformerV2Config::validate`].
 #[derive(Config, Debug, PartialEq, Eq)]
 pub struct LayerConfig {
     /// The depth of the layer, i.e., the number of transformer blocks in this
@@ -130,7 +135,13 @@ pub trait SwinTransformerV2Meta {
     fn enable_patch_norm(&self) -> bool;
 }
 
-/// Configuration for `SwinTransformerV2` model.
+/// Configuration for the [`SwinTransformerV2`] model.
+///
+/// Top-level config describing the patch embedding, per-stage
+/// [`LayerConfig`]s, window size and training options. Build the model with
+/// `.init(device)` (or validate first via
+/// [`SwinTransformerV2Config::validate`]), then `forward` a `[batch,
+/// channels, height, width]` image tensor to get classification logits.
 #[derive(Config, Debug)]
 pub struct SwinTransformerV2Config {
     /// The input image resolution as [height, width].
@@ -259,7 +270,7 @@ pub struct SwinTransformerV2Plan {
 }
 
 impl SwinTransformerV2Config {
-    /// Check config validity and return a plan for the Swin Transformer V2
+    /// Checks config validity and returns a plan for the Swin Transformer V2
     /// model.
     ///
     /// Performs model constraint validation tests without initializing a model.
@@ -421,6 +432,8 @@ impl<B: Backend> ModuleInit<B, SwinTransformerV2<B>> for SwinTransformerV2Config
 }
 
 /// High-level SWIN Transformer V2 model.
+///
+/// Built by [`SwinTransformerV2Config`].
 #[derive(Module, Debug)]
 pub struct SwinTransformerV2<B: Backend> {
     /// The patch embedding layer that converts the input image into patches.
@@ -526,7 +539,7 @@ impl<B: Backend> SwinTransformerV2Meta for SwinTransformerV2<B> {
 }
 
 impl<B: Backend> SwinTransformerV2<B> {
-    /// Apply patch embedding and absolute positional encoding (APE) to the
+    /// Applies patch embedding and absolute positional encoding (APE) to the
     /// input image tensor.
     #[inline(always)]
     #[must_use]
@@ -594,11 +607,11 @@ impl<B: Backend> SwinTransformerV2<B> {
     ///
     /// # Arguments
     ///
-    /// * `input`: A tensor of ``[batch, channels, height, width]``,
+    /// * `input`: A tensor of `[batch, channels, height, width]`,
     ///
     /// # Returns
     ///
-    /// A 2D tensor of ``[batch, num_classes]`` of the classification logits.
+    /// A 2D tensor of `[batch, num_classes]` of the classification logits.
     ///
     /// # Panics
     ///

--- a/crates/bunsen/src/kits/bimm/swin/v2/window_attention/attention.rs
+++ b/crates/bunsen/src/kits/bimm/swin/v2/window_attention/attention.rs
@@ -48,29 +48,29 @@ pub const EPS: f64 = 1e-12;
 
 /// Common introspection interface for `WindowAttention`.
 pub trait WindowAttentionMeta {
-    /// Get the input/channel dimension size.
+    /// Returns the input/channel dimension size.
     fn d_input(&self) -> usize;
 
-    /// Get the window shape ``[height, width]``.
+    /// Returns the window shape `[height, width]`.
     fn window_shape(&self) -> [usize; 2];
 
-    /// Get the height of the window.
+    /// Returns the height of the window.
     fn window_height(&self) -> usize {
         self.window_shape()[0]
     }
 
-    /// Get the width of the window.
+    /// Returns the width of the window.
     fn window_width(&self) -> usize {
         self.window_shape()[1]
     }
 
-    /// Get the number of attention heads.
+    /// Returns the number of attention heads.
     fn num_heads(&self) -> usize;
 
-    /// Get the drop rate for attention.
+    /// Returns the drop rate for attention.
     fn attn_drop(&self) -> f64;
 
-    /// Get the drop rate for projection.
+    /// Returns the drop rate for projection.
     fn proj_drop(&self) -> f64;
 
     /// Is the QKV bias enabled?
@@ -78,32 +78,32 @@ pub trait WindowAttentionMeta {
 }
 
 impl WindowAttentionMeta for WindowAttentionConfig {
-    /// Get the input/channel dimension size.
+    /// Returns the input/channel dimension size.
     fn d_input(&self) -> usize {
         self.d_input
     }
 
-    /// Get the window shape.
+    /// Returns the window shape.
     fn window_shape(&self) -> [usize; 2] {
         self.window_shape
     }
 
-    /// Get the number of heads.
+    /// Returns the number of heads.
     fn num_heads(&self) -> usize {
         self.num_heads
     }
 
-    /// Get the drop rate for attention.
+    /// Returns the drop rate for attention.
     fn attn_drop(&self) -> f64 {
         self.attn_drop
     }
 
-    /// Get the drop rate for projection.
+    /// Returns the drop rate for projection.
     fn proj_drop(&self) -> f64 {
         self.proj_drop
     }
 
-    /// Check if QKV bias is enabled.
+    /// Checks if QKV bias is enabled.
     fn enable_qkv_bias(&self) -> bool {
         self.enable_qkv_bias
     }
@@ -135,7 +135,7 @@ impl<B: Backend> WindowAttentionMeta for WindowAttention<B> {
     }
 }
 
-/// Configuration for the `WindowAttention` module.
+/// Configuration for SWIN's [`WindowAttention`] module.
 #[derive(Config, Debug)]
 pub struct WindowAttentionConfig {
     /// Input dimension size.
@@ -169,6 +169,13 @@ pub struct WindowAttentionConfig {
 }
 
 /// The `WindowAttention` module.
+///
+/// Windowed multi-head self-attention for Swin Transformer v2: applies cosine
+/// attention with a learnable logit scale and continuous relative position
+/// bias over each window, with an optional shift mask for shifted-window
+/// attention.
+///
+/// Built by [`WindowAttentionConfig`].
 #[derive(Module, Debug)]
 pub struct WindowAttention<B: Backend> {
     /// Input dimension size.
@@ -207,12 +214,12 @@ impl<B: Backend> WindowAttention<B> {
     ///
     /// # Arguments
     ///
-    /// - `x`: Input tensor of shape ``[batch * num_windows, Wh*Ww, channels]``.
-    /// - `mask`: Optional mask tensor of shape ``[num_windows, Wh*Ww, Wh*Ww]``.
+    /// - `x`: `[batch * num_windows, Wh*Ww, channels]` input.
+    /// - `mask`: Optional `[num_windows, Wh*Ww, Wh*Ww]` mask.
     ///
     /// # Returns
     ///
-    /// Output tensor of shape ``[batch * num_windows, Wh*Ww, channels]``.
+    /// Output `[batch * num_windows, Wh*Ww, channels]`.
     ///
     /// # Panics
     ///
@@ -260,19 +267,19 @@ impl<B: Backend> WindowAttention<B> {
         // (b_nw, ws*ws, c)
     }
 
-    /// Compute the attention.
+    /// Computes the attention.
     ///
     /// # Arguments
     ///
     /// - `b_nw`: Batch size times number of windows.
     /// - `n`: Number of elements in the input tensor.
-    /// - `q`: Query tensor of shape (`b_nw`, `num_heads`, ws*ws, `c_per_head`).
-    /// - `k`: Key tensor of shape (`b_nw`, `num_heads`, ws*ws, `c_per_head`).
-    /// - `mask`: Optional mask tensor of shape (`num_windows`, ws*ws, ws*ws).
+    /// - `q`: `[b_nw, num_heads, ws*ws, c_per_head]` query tensor.
+    /// - `k`: `[b_nw, num_heads, ws*ws, c_per_head]` key tensor.
+    /// - `mask`: Optional `[num_windows, ws*ws, ws*ws]` mask tensor.
     ///
     /// # Returns
     ///
-    /// - Output attention tensor of shape (`b_nw`, `num_heads`, ws*ws, ws*ws).
+    /// - `[b_nw, num_heads, ws*ws, ws*ws]` output attention tensor.
     #[must_use]
     fn attention(
         &self,
@@ -318,11 +325,10 @@ impl<B: Backend> WindowAttention<B> {
         attn
     }
 
-    /// Get the learnable logit scale.
+    /// Returns the learnable logit scale.
     ///
     /// # Returns
-    ///
-    /// - Output tensor of shape (`num_heads`, 1, 1).
+    /// * `[num_heads, 1, 1]`
     #[must_use]
     fn logit_scale(&self) -> Tensor<B, 3> {
         // TODO(crutcher): I suspect this is a bug in the original code.
@@ -331,29 +337,23 @@ impl<B: Backend> WindowAttention<B> {
         self.logit_scale.val().clamp_max((1.0f64 / 0.01).ln()).exp()
     }
 
-    /// Get the learnable relative position bias.
+    /// Returns the learnable relative position bias.
     ///
     /// # Returns
-    ///
-    /// - Output tensor of shape (`num_heads`, Wh*Ww, Wh*Ww).
-    #[inline(always)]
+    /// * `[num_heads, Wh*Ww, Wh*Ww]`
     #[must_use]
     fn relative_pos_bias(&self) -> Tensor<B, 3> {
         self.rpb_module.forward()
     }
 
-    /// Encode the attention logits with the logit scale and relative position
+    /// Encodes the attention logits with the logit scale and relative position
     /// bias.
     ///
     /// # Arguments
-    ///
-    /// - `attn`: Attention logits tensor of shape (`b_nw`, `num_heads`, Wh*Ww,
-    ///   Wh*Ww).
+    /// * `attn`: `[b_nw, num_heads, Wh*Ww, Wh*Ww]` logits.
     ///
     /// # Returns
-    ///
-    /// - Output tensor of shape (`b_nw`, `num_heads`, Wh*Ww, Wh*Ww).
-    #[inline(always)]
+    /// * `[b_nw, num_heads, Wh*Ww, Wh*Ww]`.
     #[must_use]
     fn encode_attention(
         &self,

--- a/crates/bunsen/src/kits/bimm/swin/v2/window_attention/attention_mask.rs
+++ b/crates/bunsen/src/kits/bimm/swin/v2/window_attention/attention_mask.rs
@@ -7,20 +7,19 @@ use burn::prelude::{
 
 use crate::kits::bimm::swin::v2::windowing::window_partition;
 
-/// Apply an attention mask.
+/// Applies an attention mask.
 ///
 /// # Arguments
 ///
 /// - `b_nw`: Batch size times number of windows.
 /// - `n`: Number of elements in the input tensor, Wh*Ww.
 /// - `num_heads`: Number of attention heads.
-/// - `attn`: Attention logits tensor of shape (`b_nw`, `num_heads`, Wh*Ww,
-///   Wh*Ww).
-/// - `mask`: Mask tensor of shape (`num_windows`, Wh*Ww, Wh*Ww).
+/// - `attn`: `[b_nw, num_heads, Wh*Ww, Wh*Ww]` attention logits tensor.
+/// - `mask`: `[num_windows, Wh*Ww, Wh*Ww]` mask tensor.
 ///
 /// # Returns
 ///
-/// - Output tensor of shape (`b_nw`, `num_heads`, Wh*Ww, Wh*Ww).
+/// - `[b_nw, num_heads, Wh*Ww, Wh*Ww]` output tensor.
 #[inline(always)]
 #[must_use]
 pub fn apply_attention_mask<B: Backend>(
@@ -115,7 +114,7 @@ fn sw_img_mask<B: Backend>(
     img_mask
 }
 
-/// Create a shifted window attention mask.
+/// Creates a shifted window attention mask.
 ///
 /// This function generates a mask for the shifted window attention mechanism.
 ///

--- a/crates/bunsen/src/kits/bimm/swin/v2/window_attention/pos_bias.rs
+++ b/crates/bunsen/src/kits/bimm/swin/v2/window_attention/pos_bias.rs
@@ -46,13 +46,17 @@ pub trait OffsetGridRelativePositionBiasMeta {
     fn base(&self) -> f64;
 }
 
-/// Configuration for the relative position bias module.
+/// Configuration for the [`OffsetGridRelativePositionBias`] module.
+///
+/// Specifies the head count, window shape and base scale for the continuous
+/// relative position bias. Build it with `.init(device)`, then call `forward`
+/// to produce the per-head bias table.
 #[derive(Config, Debug)]
 pub struct OffsetGridRelativePositionBiasConfig {
     /// The number of attention heads.
     pub num_heads: usize,
 
-    /// The shape of the window ``[height, width]``.
+    /// The shape of the window `[height, width]`.
     pub window_shape: [usize; 2],
 
     /// The base value for the relative position bias.
@@ -113,6 +117,8 @@ impl<B: Backend> ModuleInit<B, OffsetGridRelativePositionBias<B>>
 /// An offset grid relative position bias module.
 ///
 /// Published/Used in SWIN-Transformer v2.
+///
+/// Built by [`OffsetGridRelativePositionBiasConfig`].
 #[derive(Module, Debug)]
 pub struct OffsetGridRelativePositionBias<B: Backend> {
     /// The base value for the relative position bias.
@@ -157,7 +163,7 @@ impl<B: Backend> OffsetGridRelativePositionBias<B> {
     ///
     /// # Returns
     ///
-    /// A 3D tensor of shape (`num_heads`, height * width, height * width)
+    /// A `[num_heads, height * width, height * width]` 3D tensor
     /// containing the relative position bias for each head and position
     /// pair.
     #[must_use]
@@ -219,7 +225,11 @@ pub trait ContinuousPositionBiasMlpMeta {
     fn num_heads(&self) -> usize;
 }
 
-/// Configuration for `ContinuousPositionBiasMlp`.
+/// Configuration for [`ContinuousPositionBiasMlp`].
+///
+/// Specifies the head count, hidden width and activation for the small MLP that
+/// maps relative-offset coordinates to per-head bias values. Build it with
+/// `.init(device)`, then `forward` a `[..., 2]` coordinate tensor.
 #[derive(Config, Debug)]
 pub struct ContinuousPositionBiasMlpConfig {
     /// The number of heads.
@@ -245,6 +255,8 @@ impl ContinuousPositionBiasMlpMeta for ContinuousPositionBiasMlpConfig {
 }
 
 /// A multi-layer perceptron (MLP) for continuous position bias.
+///
+/// Built by [`ContinuousPositionBiasMlpConfig`].
 #[derive(Module, Debug)]
 pub struct ContinuousPositionBiasMlp<B: Backend> {
     l1: nn::Linear<B>,
@@ -284,12 +296,12 @@ impl<B: Backend> ContinuousPositionBiasMlp<B> {
     ///
     /// # Arguments
     ///
-    /// * `x`: A tensor of ``[..., 2]`` of the relative log-offset coordinates
+    /// * `x`: A tensor of `[..., 2]` of the relative log-offset coordinates
     ///   table.
     ///
     /// # Returns
     ///
-    /// A tensor of ``[..., num_heads]`` of the learned bias table.
+    /// A tensor of `[..., num_heads]` of the learned bias table.
     #[must_use]
     pub fn forward<const D: usize>(
         &self,

--- a/crates/bunsen/src/kits/bimm/swin/v2/window_attention/pos_grid.rs
+++ b/crates/bunsen/src/kits/bimm/swin/v2/window_attention/pos_grid.rs
@@ -19,7 +19,7 @@ use burn::{
 ///
 /// # Returns
 ///
-/// A 3D tensor of shape (2*height-1, 2*width-1, 2) containing the offset
+/// A `[2*height-1, 2*width-1, 2]` 3D tensor containing the offset
 /// indices.
 ///
 /// The first dimension represents the height offsets, the second dimension
@@ -59,7 +59,7 @@ pub fn window_index_offset_grid<B: Backend>(
 ///
 /// # Returns
 ///
-/// A 3D tensor of shape (2*height-1, 2*width-1, 2) containing the relative
+/// A `[2*height-1, 2*width-1, 2]` 3D tensor containing the relative
 /// offsets.
 #[inline(always)]
 #[must_use]
@@ -87,7 +87,7 @@ pub fn window_relative_offset_grid<B: Backend>(
 ///
 /// # Returns
 ///
-/// A 3D tensor of shape (2*height-1, 2*width-1, 2) containing the log-scaled
+/// A `[2*height-1, 2*width-1, 2]` 3D tensor containing the log-scaled
 /// relative offsets.
 #[inline(always)]
 #[must_use]
@@ -104,7 +104,8 @@ pub fn window_log1p_relative_offset_grid<B: Backend>(
     sign * x.abs().log1p() / base.ln()
 }
 
-/// Create a 2D attention bias relative position index for a given window shape.
+/// Creates a 2D attention bias relative position index for a given window
+/// shape.
 ///
 /// # Arguments
 ///
@@ -113,7 +114,7 @@ pub fn window_log1p_relative_offset_grid<B: Backend>(
 ///
 /// # Returns
 ///
-/// A 2D tensor of shape (height * width, height * width) containing the
+/// A `[height * width, height * width]` 2D tensor containing the
 /// relative position indices.
 ///
 /// This has a translation-invariant property, meaning that the relative
@@ -124,7 +125,7 @@ pub fn window_log1p_relative_offset_grid<B: Backend>(
 /// \forall i, j \in [0, h * w), \text{rel}[i, j] = \text{rel}[i + \Delta_i, j + \Delta_j]
 /// ```
 ///
-/// # Example
+/// # Examples
 ///
 /// ```rust.notest
 /// window_attention_relative_position_index([2, 3], device);

--- a/crates/bunsen/src/kits/bimm/swin/v2/windowing.rs
+++ b/crates/bunsen/src/kits/bimm/swin/v2/windowing.rs
@@ -14,13 +14,13 @@ use crate::contracts::unpack_shape_contract;
 ///
 /// # Arguments
 ///
-/// - `tensor`: Input tensor of ``[batch, height, width, channels]``.
+/// - `tensor`: Input tensor of `[batch, height, width, channels]`.
 /// - `window_size`: Window size.
 ///
 /// # Returns
 ///
-/// Output tensor of ``[batch * h_windows * w_windows, window_size, window_size,
-/// channels]``.
+/// Output tensor of `[batch * h_windows * w_windows, window_size, window_size,
+/// channels]`.
 ///
 /// # Panics
 ///
@@ -56,15 +56,15 @@ where
 ///
 /// # Arguments
 ///
-/// - `windows`: Input tensor of ``[batch * h_windows * w_windows, window_size,
-///   window_size, channels]``.
+/// - `windows`: Input tensor of `[batch * h_windows * w_windows, window_size,
+///   window_size, channels]`.
 /// - `window_size`: Window size.
 /// - `height`: Height of the original image.
 /// - `width`: Width of the original image.
 ///
 /// # Returns
 ///
-/// Output tensor of shape ``[batch, height, width, channels]``.
+/// `[batch, height, width, channels]` output tensor.
 ///
 /// # Panics
 ///

--- a/crates/bunsen/src/kits/gpts/nanochat/block.rs
+++ b/crates/bunsen/src/kits/gpts/nanochat/block.rs
@@ -37,7 +37,7 @@ use crate::{
 
 /// Common meta for [`NanoChatGptBlock`] and [`NanoChatGptBlockConfig`].
 pub trait NanoChatGptBlockMeta {
-    /// Return the size of the input and output.
+    /// Returns the size of the input and output.
     fn n_embed(&self) -> usize;
 }
 
@@ -63,7 +63,7 @@ impl NanoChatGptBlockMeta for NanoChatGptBlockConfig {
 }
 
 impl NanoChatGptBlockConfig {
-    /// Initialize a [`NanoChatGptBlock`].
+    /// Initializes a [`NanoChatGptBlock`].
     ///
     /// Panics on errors.
     pub fn init<B: Backend>(
@@ -74,7 +74,7 @@ impl NanoChatGptBlockConfig {
         self.try_init(layer_index, device).ok_or_panic()
     }
 
-    /// Initialize a [`NanoChatGptBlock`].
+    /// Initializes a [`NanoChatGptBlock`].
     pub fn try_init<B: Backend>(
         &self,
         layer_index: usize,
@@ -98,7 +98,14 @@ impl NanoChatGptBlockConfig {
     }
 }
 
-/// GPT Block
+/// A single nanoChat GPT transformer block.
+///
+/// Applies input normalization, causal self-attention, post-attention
+/// normalization, and an MLP, with residual connections handled by the
+/// surrounding model. Used as the repeated unit inside
+/// [`NanoChatGpt`](super::NanoChatGpt).
+///
+/// Built by [`NanoChatGptBlockConfig`].
 #[derive(Module, Debug)]
 pub struct NanoChatGptBlock<B: Backend> {
     /// Input Normalization.
@@ -128,12 +135,12 @@ impl<B: Backend> NanoChatGptBlock<B> {
     /// - this block does not norm on output.
     ///
     /// # Arguments
-    /// - `input`: a ``[B, T, D]`` input.
-    /// - `r_emb`: a ``[1, T, 1, D/2]`` embedding.
+    /// - `input`: a `[B, T, D]` input.
+    /// - `r_emb`: a `[1, T, 1, D/2]` embedding.
     /// - `kv_cache`: optional KV cache.
     ///
     /// # Returns
-    /// - the ``[B, T, D]`` block output.
+    /// - the `[B, T, D]` block output.
     pub fn forward(
         &self,
         input: Tensor<B, 3>,

--- a/crates/bunsen/src/kits/gpts/nanochat/model.rs
+++ b/crates/bunsen/src/kits/gpts/nanochat/model.rs
@@ -51,31 +51,36 @@ use crate::{
 
 /// Common meta for [`NanoChatGpt`] and [`NanoChatGptConfig`].
 pub trait NanoChatGptMeta {
-    /// Return the size of the input and output.
+    /// Returns the size of the input and output.
     fn n_embed(&self) -> usize;
 
-    /// Return the number of heads.
+    /// Returns the number of heads.
     fn n_head(&self) -> usize;
 
-    /// Return the number of KV heads.
+    /// Returns the number of KV heads.
     fn n_kv_head(&self) -> usize;
 
-    /// Return the size of each head.
+    /// Returns the size of each head.
     fn head_dim(&self) -> usize {
         self.n_embed() / self.n_head()
     }
 
-    /// Return the initial sequence length.
+    /// Returns the initial sequence length.
     fn init_seq_len(&self) -> usize;
 
-    /// Return the maximum sequence length.
+    /// Returns the maximum sequence length.
     fn max_seq_len(&self) -> usize;
 
-    /// Return the number of layers.
+    /// Returns the number of layers.
     fn n_layer(&self) -> usize;
 }
 
 /// High-level GPT Config.
+///
+/// User-facing configuration for the nanoChat GPT model, exposing the common
+/// hyperparameters (sizes, layer/head counts, vocabulary, softcap). Expands via
+/// [`into_structure`](NanoChatGptConfig::into_structure) into a
+/// [`NanoChatGptStructureConfig`], which builds the [`NanoChatGpt`] module.
 #[derive(Config, Debug)]
 pub struct NanoChatGptConfig {
     /// Initial sequence Length.
@@ -151,7 +156,7 @@ impl NanoChatGptMeta for NanoChatGptConfig {
 }
 
 impl NanoChatGptConfig {
-    /// Initialize a [`NanoChatGpt`].
+    /// Initializes a [`NanoChatGpt`].
     pub fn init<B: Backend>(
         self,
         device: &B::Device,
@@ -159,7 +164,7 @@ impl NanoChatGptConfig {
         self.into_structure().init(device)
     }
 
-    /// Convert this config into a [`NanoChatGptStructureConfig`].
+    /// Converts this config into a [`NanoChatGptStructureConfig`].
     pub fn into_structure(self) -> NanoChatGptStructureConfig {
         let block_config = self.block_config();
         NanoChatGptStructureConfig {
@@ -173,7 +178,7 @@ impl NanoChatGptConfig {
         }
     }
 
-    /// Build the [`NanoChatGptBlockConfig`] for this config.
+    /// Builds the [`NanoChatGptBlockConfig`] for this config.
     pub fn block_config(&self) -> NanoChatGptBlockConfig {
         NanoChatGptBlockConfig::new(
             CausalSelfAttentionConfig::new(self.n_head, self.n_kv_head, self.n_embed)
@@ -188,6 +193,10 @@ impl NanoChatGptConfig {
 }
 
 /// Low-level GPT Structure Config.
+///
+/// The fully-expanded structural configuration for the [`NanoChatGpt`] module,
+/// holding the explicit sub-configs (embedding, per-layer blocks, head, rotary
+/// embedding). Directly builds the [`NanoChatGpt`] module via [`ModuleInit`].
 ///
 /// This config has a lot of duplicate information.
 #[derive(Config, Debug)]
@@ -271,7 +280,14 @@ impl<B: Backend> ModuleInit<B, NanoChatGpt<B>> for NanoChatGptStructureConfig {
     }
 }
 
-/// GPT Module
+/// nanoChat GPT language model.
+///
+/// A decoder-only transformer: token embedding, a stack of
+/// [`NanoChatGptBlock`] layers, a final normalization, and a tied/linear head
+/// producing softcapped vocabulary logits. Supports incremental decoding via a
+/// [`KVCache`].
+///
+/// Built by [`NanoChatGptConfig`].
 #[derive(Module, Debug)]
 pub struct NanoChatGpt<B: Backend> {
     wte: Embedding<B>,
@@ -318,7 +334,7 @@ impl<B: Backend> NanoChatGpt<B> {
     /// Forward Pass.
     ///
     /// # Arguments
-    /// - `idx`: a ``[B, T]`` input.
+    /// - `idx`: a `[B, T]` input.
     /// - `kv_cache`: a `KVCache`.
     pub fn forward(
         &self,
@@ -382,7 +398,7 @@ impl<B: Backend> NanoChatGpt<B> {
         .init()
     }
 
-    /// Calculate the estimated FLOPs per token for the model.
+    /// Calculates the estimated FLOPs per token for the model.
     ///
     /// Ref: <https://arxiv.org/abs/2204.02311>
     pub fn estimate_flops_per_token(&self) -> usize {

--- a/crates/bunsen/src/kits/sims/conway/life2d.rs
+++ b/crates/bunsen/src/kits/sims/conway/life2d.rs
@@ -17,17 +17,17 @@ use burn::{
     },
 };
 
-/// Fuzz the state.
+/// Fuzzes the state.
 ///
 /// Flips bits with probability `density`.
 ///
 /// # Arguments
 ///
-/// - `state`: the ``[H, W]`` input state.
+/// - `state`: the `[H, W]` input state.
 /// - `density`: the probability of flipping a given bit.
 ///
 /// # Returns
-/// - the fuzzed ``[H, W]`` state.
+/// - the fuzzed `[H, W]` state.
 pub fn fuzz_state_2d<B: Backend>(
     state: Tensor<B, 2, Bool>,
     density: f64,
@@ -46,7 +46,7 @@ pub fn fuzz_state_2d<B: Backend>(
     state.bool_xor(noise)
 }
 
-/// Wrap the board state.
+/// Wraps the board state.
 ///
 /// This simulates a toroidal space by copying the penultimate rows and columns
 /// to the edges of the opposite sides.
@@ -63,7 +63,7 @@ pub fn wrap_state_2d<B: Backend>(state: Tensor<B, 2, Bool>) -> Tensor<B, 2, Bool
         .slice_assign(s![.., -1], left)
 }
 
-/// Expand a tensor by copying the wrap compliment edges.
+/// Expands a tensor by copying the wrap compliment edges.
 pub fn wrap_pad_2d<B: Backend>(state: Tensor<B, 2, Bool>) -> Tensor<B, 2, Bool> {
     let top = state.clone().slice(s![0, ..]);
     let bottom = state.clone().slice(s![-1, ..]);
@@ -129,14 +129,14 @@ where
     result
 }
 
-/// Return the next board.
+/// Returns the next board.
 ///
 /// # Arguments
 ///
-/// - `state`: a ``[H, W]`` game state.
+/// - `state`: a `[H, W]` game state.
 ///
 /// # Returns
-/// - the ``[H, W]`` evolved interior state, with wrapped edges.
+/// - the `[H, W]` evolved interior state, with wrapped edges.
 pub fn next_state_wrapped_2d<B: Backend>(state: Tensor<B, 2, Bool>) -> Tensor<B, 2, Bool> {
     let update = next_interior_2d(state.clone());
 
@@ -148,13 +148,13 @@ pub fn next_state_wrapped_2d<B: Backend>(state: Tensor<B, 2, Bool>) -> Tensor<B,
     wrap_state_2d(state)
 }
 
-/// Return the interior board next-state.
+/// Returns the interior board next-state.
 ///
 /// # Arguments
-/// - `state`: a ``[H, W]`` game state.
+/// - `state`: a `[H, W]` game state.
 ///
 /// # Returns
-/// - the ``[H-2, W-2]`` evolved interior state.
+/// - the `[H-2, W-2]` evolved interior state.
 pub fn next_interior_2d<B: Backend>(state: Tensor<B, 2, Bool>) -> Tensor<B, 2, Bool> {
     #[cfg(debug_assertions)]
     let [h, w] = crate::contracts::unpack_shape_contract!(["h", "w"], &state.dims(),);
@@ -193,6 +193,9 @@ pub fn next_interior_2d<B: Backend>(state: Tensor<B, 2, Bool>) -> Tensor<B, 2, B
 }
 
 /// Config for [`ConwayLife2DState`]
+///
+/// Specifies the `[H, W]` board shape. Call `.init(device)` to build a
+/// zeroed [`ConwayLife2DState`] module, which can then be seeded and stepped.
 #[derive(Config, Debug)]
 pub struct ConwayLife2DConfig {
     /// The shape of the board.
@@ -200,7 +203,7 @@ pub struct ConwayLife2DConfig {
 }
 
 impl ConwayLife2DConfig {
-    /// Initialize a [`ConwayLife2DState`] module.
+    /// Initializes a [`ConwayLife2DState`] module.
     pub fn init<B: Backend>(
         self,
         device: &B::Device,
@@ -212,23 +215,30 @@ impl ConwayLife2DConfig {
 }
 
 /// State module for Conway's Game of Life.
+///
+/// Holds the toroidal `[H, W]` boolean board. Construct it from a
+/// [`ConwayLife2DConfig`] via `.init(device)`, optionally seed it with
+/// [`ConwayLife2DState::fuzz`], then call [`ConwayLife2DState::step`] to
+/// advance the simulation one wrapped generation at a time.
+///
+/// Built by [`ConwayLife2DConfig`].
 pub struct ConwayLife2DState<B: Backend> {
     /// The current state of the board.
     pub state: Tensor<B, 2, Bool>,
 }
 
 impl<B: Backend> ConwayLife2DState<B> {
-    /// Get the device the module is on.
+    /// Returns the device the module is on.
     pub fn device(&self) -> B::Device {
         self.state.device()
     }
 
-    /// Get the board shape.
+    /// Returns the board shape.
     pub fn shape(&self) -> [usize; 2] {
         self.state.shape().dims()
     }
 
-    /// Add uniform positive noise to the board.
+    /// Adds uniform positive noise to the board.
     pub fn fuzz(
         &mut self,
         density: f64,
@@ -236,7 +246,7 @@ impl<B: Backend> ConwayLife2DState<B> {
         self.state = fuzz_state_2d(self.state.clone(), density);
     }
 
-    /// Advance one step.
+    /// Advances one step.
     ///
     /// Wraps edges.
     pub fn step(&mut self) {
@@ -245,7 +255,7 @@ impl<B: Backend> ConwayLife2DState<B> {
         B::sync(&self.device()).unwrap();
     }
 
-    /// Read a slice of the current board state.
+    /// Reads a slice of the current board state.
     pub fn read_slice<R>(
         &self,
         ranges: R,
@@ -256,7 +266,7 @@ impl<B: Backend> ConwayLife2DState<B> {
         read_2d_slice(self.state.clone(), ranges)
     }
 
-    /// Write a slice to the current board state.
+    /// Writes a slice to the current board state.
     pub fn write_slice<R>(
         &mut self,
         ranges: R,

--- a/crates/bunsen/src/kits/sims/conway/life3d.rs
+++ b/crates/bunsen/src/kits/sims/conway/life3d.rs
@@ -18,17 +18,17 @@ use serde::{
     Serialize,
 };
 
-/// Fuzz the state.
+/// Fuzzes the state.
 ///
 /// Flips bits with probability `density`.
 ///
 /// # Arguments
 ///
-/// - `state`: the ``[H, W, Z]`` input state.
+/// - `state`: the `[H, W, Z]` input state.
 /// - `density`: the probability of flipping a given bit.
 ///
 /// # Returns
-/// - the fuzzed ``[H, W, Z]`` state.
+/// - the fuzzed `[H, W, Z]` state.
 pub fn fuzz_state_3d<B: Backend>(
     state: Tensor<B, 3, Bool>,
     density: f64,
@@ -47,7 +47,7 @@ pub fn fuzz_state_3d<B: Backend>(
     state.bool_xor(noise)
 }
 
-/// Wrap the board state.
+/// Wraps the board state.
 ///
 /// This simulates a toroidal space by copying the penultimate rows and columns
 /// to the edges of the opposite sides.
@@ -68,15 +68,15 @@ pub fn wrap_state_3d<B: Backend>(state: Tensor<B, 3, Bool>) -> Tensor<B, 3, Bool
         .slice_assign(s![.., .., -1], front)
 }
 
-/// Return the next board.
+/// Returns the next board.
 ///
 /// # Arguments
 ///
-/// - `state`: a ``[H, W, Z]`` game state.
+/// - `state`: a `[H, W, Z]` game state.
 /// - `rules`: a ruleset.
 ///
 /// # Returns
-/// - the ``[H, W, Z]`` evolved interior state, with wrapped edges.
+/// - the `[H, W, Z]` evolved interior state, with wrapped edges.
 pub fn next_state_wrapped_3d<B: Backend>(
     state: Tensor<B, 3, Bool>,
     rules: &LifeRules,
@@ -91,15 +91,15 @@ pub fn next_state_wrapped_3d<B: Backend>(
     wrap_state_3d(state)
 }
 
-/// Return the interior board next-state.
+/// Returns the interior board next-state.
 ///
 /// # Arguments
 ///
-/// - `state`: a ``[H, W, Z]`` game state.
+/// - `state`: a `[H, W, Z]` game state.
 /// - `rules`: the ruleset to use.
 ///
 /// # Returns
-/// - the ``[H-2, W-2, Z-2]`` evolved interior state.
+/// - the `[H-2, W-2, Z-2]` evolved interior state.
 pub fn next_interior_3d<B: Backend>(
     state: Tensor<B, 3, Bool>,
     rules: &LifeRules,
@@ -173,6 +173,10 @@ impl Default for LifeRules {
 }
 
 /// Config for [`ConwayLife3DState`]
+///
+/// Specifies the `[H, W, Z]` board shape and the [`LifeRules`] ruleset. Call
+/// `.init(device)` to build a zeroed [`ConwayLife3DState`] module, which can
+/// then be seeded and stepped.
 #[derive(Config, Debug)]
 pub struct ConwayLife3DConfig {
     /// The shape of the board.
@@ -183,7 +187,7 @@ pub struct ConwayLife3DConfig {
 }
 
 impl ConwayLife3DConfig {
-    /// Initialize a [`ConwayLife3DState`] module.
+    /// Initializes a [`ConwayLife3DState`] module.
     pub fn init<B: Backend>(
         self,
         device: &B::Device,
@@ -196,6 +200,14 @@ impl ConwayLife3DConfig {
 }
 
 /// State module for Conway's Game of Life.
+///
+/// Holds the toroidal `[H, W, Z]` boolean board together with its
+/// [`LifeRules`]. Construct it from a [`ConwayLife3DConfig`] via
+/// `.init(device)`, optionally seed it with [`ConwayLife3DState::fuzz`], then
+/// call [`ConwayLife3DState::step`] to advance the simulation one wrapped
+/// generation at a time.
+///
+/// Built by [`ConwayLife3DConfig`].
 pub struct ConwayLife3DState<B: Backend> {
     /// The current state of the board.
     pub state: Tensor<B, 3, Bool>,
@@ -205,17 +217,17 @@ pub struct ConwayLife3DState<B: Backend> {
 }
 
 impl<B: Backend> ConwayLife3DState<B> {
-    /// Get the device the module is on.
+    /// Returns the device the module is on.
     pub fn device(&self) -> B::Device {
         self.state.device()
     }
 
-    /// Get the board shape.
+    /// Returns the board shape.
     pub fn shape(&self) -> [usize; 3] {
         self.state.shape().dims()
     }
 
-    /// Add uniform positive noise to the board.
+    /// Adds uniform positive noise to the board.
     pub fn fuzz(
         &mut self,
         density: f64,
@@ -234,7 +246,7 @@ impl<B: Backend> ConwayLife3DState<B> {
         self.state = self.state.clone().bool_or(noise);
     }
 
-    /// Advance the game state.
+    /// Advances the game state.
     pub fn step(&mut self) {
         self.state = next_state_wrapped_3d(self.state.clone(), &self.rules);
 

--- a/crates/bunsen/src/kits/sims/lbm/d2q9/collision.rs
+++ b/crates/bunsen/src/kits/sims/lbm/d2q9/collision.rs
@@ -30,7 +30,7 @@ use crate::kits::sims::lbm::d2q9::{
 /// and will default to `1.0` for `None`.
 ///
 /// # Arguments
-/// - `dist`: ``[H, W, VY=3, VX=3]`` current distribution
+/// - `dist`: `[H, W, VY=3, VX=3]` current distribution
 /// - `relaxation`: relaxation parameter.
 /// - `correction`: fused correction factor for the relaxation operator;
 ///   defaults to 1.0.
@@ -56,14 +56,14 @@ pub fn bgk_collision<B: Backend, S: Into<OmegaSource<B>>>(
 /// - [`with_spherical_reflection`]
 ///
 /// # Arguments
-/// - `dist`: ``[H, W, VY=3, VX=3]`` pre-collision distribution
-/// - `solid_mask`: ``[H, W]`` mask of solid locations.
+/// - `dist`: `[H, W, VY=3, VX=3]` pre-collision distribution
+/// - `solid_mask`: `[H, W]` mask of solid locations.
 /// - `correction`: fused correction factor for the relaxation operator;
 ///   defaults to 1.0.
 /// - `lbm_tables`: LBM Reference Tables.
 ///
 /// # Returns
-/// - ``[H, W, VY=3, VX=3]`` distribution.
+/// - `[H, W, VY=3, VX=3]` distribution.
 pub fn bgk_collision_with_spherical_reflection<B: Backend>(
     dist: Tensor<B, 4>,
     solid_mask: Tensor<B, 2, Bool>,

--- a/crates/bunsen/src/kits/sims/lbm/d2q9/mod.rs
+++ b/crates/bunsen/src/kits/sims/lbm/d2q9/mod.rs
@@ -9,16 +9,16 @@
 //!
 //! This is a "D2Q9" LBM Grid; "D2" for 2-dimension, "Q9" for 9-direction.
 //!
-//! This library uses a ``[H, W, VY=3, VX=3]`` layout.
+//! This library uses a `[H, W, VY=3, VX=3]` layout.
 //! * ``(H, W)`` determines a cell's spatial location.
-//! * at a given ``(H, W)`` point, the 3x3 ``[VY=3, VX=3]`` grid describes the
+//! * at a given ``(H, W)`` point, the 3x3 `[VY=3, VX=3]` grid describes the
 //!   local moving particle population.
 //!
-//! The ``[VY=3, VX=3]`` populations are each moving away from the center
+//! The `[VY=3, VX=3]` populations are each moving away from the center
 //! at ``(1, 1)``, which is stationary.
 //!
 //! The ``(y, x)`` directions correspond with the direction vectors ``(y-1,
-//! x-1)``; so ``[H, W, 0, 0]`` is the population at ``(H, W)`` which is moving
+//! x-1)``; so `[H, W, 0, 0]` is the population at ``(H, W)`` which is moving
 //! in the ``(-1, -1)`` direction.
 //!
 //! This direction is also available in the `direction_vectors()` interface.

--- a/crates/bunsen/src/kits/sims/lbm/d2q9/reflection.rs
+++ b/crates/bunsen/src/kits/sims/lbm/d2q9/reflection.rs
@@ -13,10 +13,10 @@ use burn::{
 /// This point as a sphere, normal to all directions.
 ///
 /// # Arguments
-/// - `dist`: ``[H, W, VY=3, VX=3]`` pre-collision distribution
+/// - `dist`: `[H, W, VY=3, VX=3]` pre-collision distribution
 ///
 /// # Returns
-/// - ``[H, W, VY=3, VX=3]`` distribution.
+/// - `[H, W, VY=3, VX=3]` distribution.
 pub fn spherical_reflection<B: Backend>(dist: Tensor<B, 4>) -> Tensor<B, 4> {
     dist.flip([2, 3])
 }
@@ -27,12 +27,12 @@ pub fn spherical_reflection<B: Backend>(dist: Tensor<B, 4>) -> Tensor<B, 4> {
 /// This models every solid point as a sphere, normal to all directions.
 ///
 /// # Arguments
-/// - `pre_dist`: ``[H, W, VY=3, VX=3]`` pre-collision distribution
-/// - `naive_dist`: ``[H, W, VY=3, VX=3]`` post-collision distribution
-/// - `solid_mask`: ``[H, W]`` mask of solid locations.
+/// - `pre_dist`: `[H, W, VY=3, VX=3]` pre-collision distribution
+/// - `naive_dist`: `[H, W, VY=3, VX=3]` post-collision distribution
+/// - `solid_mask`: `[H, W]` mask of solid locations.
 ///
 /// # Returns
-/// - ``[H, W, VY=3, VX=3]`` distribution.
+/// - `[H, W, VY=3, VX=3]` distribution.
 pub fn with_spherical_reflection<B: Backend>(
     pre_dist: Tensor<B, 4>,
     naive_dist: Tensor<B, 4>,

--- a/crates/bunsen/src/kits/sims/lbm/d2q9/relaxation.rs
+++ b/crates/bunsen/src/kits/sims/lbm/d2q9/relaxation.rs
@@ -21,8 +21,8 @@ use serde::{
 /// and will default to `1.0` for `None`.
 ///
 /// # Arguments
-/// - `dist_a`: a ``[H, W, VY=3, VX=3]`` distribution.
-/// - `dist_b`: a ``[H, W, VY=3, VX=3]`` distribution.
+/// - `dist_a`: a `[H, W, VY=3, VX=3]` distribution.
+/// - `dist_b`: a `[H, W, VY=3, VX=3]` distribution.
 /// - `relaxation`: relaxation parameter.
 /// - `correction`: fused correction factor for the relaxation operator;
 ///   defaults to 1.0.
@@ -55,7 +55,7 @@ pub enum OmegaSource<B: Backend> {
 }
 
 impl<B: Backend> OmegaSource<B> {
-    /// Get the omega tensor.
+    /// Returns the omega tensor.
     pub fn omega(
         &self,
         device: &B::Device,
@@ -94,7 +94,7 @@ pub enum RelaxationParam {
 }
 
 impl RelaxationParam {
-    /// Validate the relaxation; or panic.
+    /// Validates the relaxation; or panic.
     pub fn validate(&self) {
         match self {
             RelaxationParam::Omega(omega) => {
@@ -109,7 +109,7 @@ impl RelaxationParam {
         }
     }
 
-    /// Get the relaxation frequency (1/tau), typically in (0, 2)
+    /// Returns the relaxation frequency (1/tau), typically in (0, 2).
     pub fn as_omega_value(&self) -> f64 {
         match self {
             RelaxationParam::Omega(omega) => *omega,
@@ -117,7 +117,7 @@ impl RelaxationParam {
         }
     }
 
-    /// Get the relaxation time (1/omega), typically > 0.5
+    /// Returns the relaxation time (1/omega), typically > 0.5.
     pub fn as_tau_value(&self) -> f64 {
         match self {
             RelaxationParam::Omega(omega) => 1.0 / *omega,

--- a/crates/bunsen/src/kits/sims/lbm/d2q9/simulation.rs
+++ b/crates/bunsen/src/kits/sims/lbm/d2q9/simulation.rs
@@ -24,15 +24,15 @@ use super::{
 
 /// Introspection trait for [`LBMD2Q9State`]
 pub trait LBMMeta {
-    /// Get the shape of the simulation: `[HEIGHT, WIDTH]`
+    /// Returns the shape of the simulation: `[HEIGHT, WIDTH]`.
     fn shape(&self) -> [usize; 2];
 
-    /// Get the height of the simulation.
+    /// Returns the height of the simulation.
     fn height(&self) -> usize {
         self.shape()[0]
     }
 
-    /// Get the width of the simulation.
+    /// Returns the width of the simulation.
     fn width(&self) -> usize {
         self.shape()[1]
     }
@@ -40,7 +40,9 @@ pub trait LBMMeta {
 
 /// Config for [`LBMD2Q9State`]
 ///
-/// Implements [`LBMMeta`].
+/// Specifies the `[HEIGHT, WIDTH]` grid shape and the [`RelaxationParam`]. Call
+/// `.init(device, rho)` to build a relaxed [`LBMD2Q9State`] module ready to be
+/// advanced step by step. Implements [`LBMMeta`].
 #[derive(Config, Debug)]
 pub struct LBMD2Q9Config {
     /// The shape of the simulation: `[HEIGHT, WIDTH]`
@@ -58,7 +60,7 @@ impl LBMMeta for LBMD2Q9Config {
 }
 
 impl LBMD2Q9Config {
-    /// Initialize a [`LBMD2Q9State`] module.
+    /// Initializes a [`LBMD2Q9State`] module.
     pub fn init<B: Backend>(
         self,
         device: &B::Device,
@@ -98,6 +100,14 @@ impl LBMD2Q9Config {
 }
 
 /// Lattice-Boltzmann Fluid Simulation State Module
+///
+/// Holds the D2Q9 population distribution `[H, W, 3, 3]`, the relaxation field,
+/// solid mask, and [`LbmTables`] lattice constants. Construct it from a
+/// [`LBMD2Q9Config`] via `.init(device, rho)`, then call
+/// [`LBMD2Q9State::advance_step`] to stream, collide, and reflect the fluid one
+/// step at a time. Implements [`LBMMeta`].
+///
+/// Built by [`LBMD2Q9Config`].
 #[derive(Module, Debug)]
 pub struct LBMD2Q9State<B: Backend> {
     /// The current simulation step.
@@ -106,12 +116,12 @@ pub struct LBMD2Q9State<B: Backend> {
     /// Total Mass.
     pub correct_total_mass: f64,
 
-    /// The grid velocity: ``[H, W, UY=3, UX=3]``
+    /// The grid velocity: `[H, W, UY=3, UX=3]`
     /// Here the 0-9 velocity terms are unfolded
     /// into the ``UY`` and ``UX`` dims.
     pub dist: Tensor<B, 4>,
 
-    /// The solid mask: ``[H, W]``
+    /// The solid mask: `[H, W]`
     pub solid_mask: Tensor<B, 2, Bool>,
 
     /// The relaxation field.
@@ -129,17 +139,17 @@ impl<B: Backend> LBMMeta for LBMD2Q9State<B> {
 }
 
 impl<B: Backend> LBMD2Q9State<B> {
-    /// Get the device the module is on.
+    /// Returns the device the module is on.
     pub fn device(&self) -> B::Device {
         self.dist.device()
     }
 
-    /// Get the datatype of the state.
+    /// Returns the datatype of the state.
     pub fn dtype(&self) -> DType {
         self.dist.dtype()
     }
 
-    /// Recast the datatype of the state.
+    /// Recasts the datatype of the state.
     pub fn to_dtype(
         self,
         dtype: DType,
@@ -151,12 +161,12 @@ impl<B: Backend> LBMD2Q9State<B> {
         }
     }
 
-    /// Get the current simulation step count.
+    /// Returns the current simulation step count.
     pub fn step_count(&self) -> u64 {
         self.step_count
     }
 
-    /// Set the current simulation step count.
+    /// Sets the current simulation step count.
     pub fn set_step_count(
         &mut self,
         step: u64,
@@ -164,17 +174,17 @@ impl<B: Backend> LBMD2Q9State<B> {
         self.step_count = step;
     }
 
-    /// Reset the simulation step count to zero.
+    /// Resets the simulation step count to zero.
     pub fn reset_step_count(&mut self) {
         self.set_step_count(0)
     }
 
-    /// Get the mass correction term.
+    /// Returns the mass correction term.
     pub fn correction_term(&self) -> f64 {
         self.correct_total_mass / self.current_total_mass()
     }
 
-    /// Advance the world simulation by one step.
+    /// Advances the world simulation by one step.
     pub fn advance_step(&mut self) {
         let dist = self.dist.clone();
 
@@ -208,12 +218,12 @@ impl<B: Backend> LBMD2Q9State<B> {
         B::sync(&self.device()).unwrap();
     }
 
-    /// Get the current mass of the simm.
+    /// Returns the current mass of the simm.
     pub fn current_total_mass(&self) -> f64 {
         self.dist.clone().sum().into_scalar().elem()
     }
 
-    /// Save the total energy of the system.
+    /// Saves the total energy of the system.
     pub fn save_correct_total_mass(&mut self) {
         self.correct_total_mass = self.current_total_mass();
     }

--- a/crates/bunsen/src/kits/sims/lbm/d2q9/space.rs
+++ b/crates/bunsen/src/kits/sims/lbm/d2q9/space.rs
@@ -19,7 +19,7 @@ use crate::contracts::unpack_shape_contract;
 ///
 /// # Returns
 ///
-/// The ``[VY=3, VX=3, (VY, VX)=2]`` int direction indices.
+/// The `[VY=3, VX=3, (VY, VX)=2]` int direction indices.
 pub fn direction_indices<B: Backend>(device: &B::Device) -> Tensor<B, 3, Int> {
     Tensor::<B, 3, Int>::from_data(
         [
@@ -35,7 +35,7 @@ pub fn direction_indices<B: Backend>(device: &B::Device) -> Tensor<B, 3, Int> {
 ///
 /// # Returns
 ///
-/// The ``[VY=3, VX=3, (VY, VX)=2]`` float direction vectors.
+/// The `[VY=3, VX=3, (VY, VX)=2]` float direction vectors.
 pub fn direction_vectors<B: Backend>(device: &B::Device) -> Tensor<B, 3> {
     direction_indices(device).float()
 }
@@ -44,7 +44,7 @@ pub fn direction_vectors<B: Backend>(device: &B::Device) -> Tensor<B, 3> {
 ///
 /// # Returns
 ///
-/// The ``[VY=3, VX=3]`` equilibrium weight matrix.
+/// The `[VY=3, VX=3]` equilibrium weight matrix.
 pub fn weight_matrix<B: Backend>(device: &B::Device) -> Tensor<B, 2> {
     Tensor::<B, 2>::from_data(
         [
@@ -57,20 +57,27 @@ pub fn weight_matrix<B: Backend>(device: &B::Device) -> Tensor<B, 2> {
 }
 
 /// LBM Space Constants
+///
+/// Bundles the static D2Q9 lattice tables: the integer direction indices
+/// (`e_idx`), the float direction vectors (`e_vec`), and the equilibrium weight
+/// matrix (`w`). Built via [`LbmTables::init`] (or [`LbmTables::for_dist`]) for
+/// a device and dtype rather than from a Config.
+///
+/// Used by [`LBMD2Q9State`](super::LBMD2Q9State).
 #[derive(Module, Debug)]
 pub struct LbmTables<B: Backend> {
-    /// ``[H, W, (Y, X)=2]`` integer direction indices.
+    /// `[H, W, (Y, X)=2]` integer direction indices.
     e_idx: Tensor<B, 3, Int>,
 
-    /// ``[H, W, (Y, X)=2]`` float direction vectors.
+    /// `[H, W, (Y, X)=2]` float direction vectors.
     e_vec: Tensor<B, 3>,
 
-    /// ``[Y=3, X=3]`` equilibrium weights
+    /// `[Y=3, X=3]` equilibrium weights
     w: Tensor<B, 2>,
 }
 
 impl<B: Backend> LbmTables<B> {
-    /// Create new space `lbm_tables`.
+    /// Creates new space `lbm_tables`.
     pub fn init(device: &B::Device) -> Self {
         let e_idx = direction_indices(device);
         let e_vec = e_idx.clone().float();
@@ -81,12 +88,12 @@ impl<B: Backend> LbmTables<B> {
         }
     }
 
-    /// Get appropriate `lbm_tables` for the distribution.
+    /// Returns appropriate `lbm_tables` for the distribution.
     pub fn for_dist(dist: &Tensor<B, 4>) -> Self {
         Self::init(&dist.device()).to_dtype(dist.dtype())
     }
 
-    /// Cast the `lbm_tables` to the given dtype.
+    /// Casts the `lbm_tables` to the given dtype.
     pub fn to_dtype(
         self,
         dtype: DType,
@@ -98,23 +105,23 @@ impl<B: Backend> LbmTables<B> {
         }
     }
 
-    /// Get the direction indices.
+    /// Returns the direction indices.
     pub fn e_idx(&self) -> Tensor<B, 3, Int> {
         self.e_idx.clone()
     }
 
-    /// Get the direction vectors.
+    /// Returns the direction vectors.
     pub fn e_vec(&self) -> Tensor<B, 3> {
         self.e_vec.clone()
     }
 
-    /// Get the equilibrium weight matrix.
+    /// Returns the equilibrium weight matrix.
     pub fn w(&self) -> Tensor<B, 2> {
         self.w.clone()
     }
 }
 
-/// Print a distribution.
+/// Prints a distribution.
 ///
 /// Doesn't work well on big distributions.
 ///
@@ -172,27 +179,27 @@ pub fn dbg_dist<B: Backend>(
 ///
 /// # Arguments
 ///
-/// - `dist`: a ``[H, W, VY=3, VX=3]`` population distribution.
+/// - `dist`: a `[H, W, VY=3, VX=3]` population distribution.
 ///
 /// # Returns
 ///
-/// A ``[H, W]`` population density.
+/// A `[H, W]` population density.
 pub fn density<B: Backend>(dist: Tensor<B, 4>) -> Tensor<B, 2> {
     dist.sum_dims(&[2, 3]).squeeze_dims::<2>(&[2, 3])
 }
 
-/// Compute the directional macroscopic momentum.
+/// Computes the directional macroscopic momentum.
 ///
 /// This is the unnormalized macroscopic momentum.
 ///
 /// # Arguments
 ///
-/// - `dist`: a ``[H, W, VY, VX]`` population distribution.
+/// - `dist`: a `[H, W, VY, VX]` population distribution.
 /// - `e`: the D2Q9 direction vectors.
 ///
 /// # Returns
 ///
-/// The ``[H, W, (Y, X)=2]`` momentum.
+/// The `[H, W, (Y, X)=2]` momentum.
 pub fn macroscopic_momentum<B: Backend>(
     dist: Tensor<B, 4>,
     e: Tensor<B, 3>,
@@ -207,12 +214,12 @@ pub fn macroscopic_momentum<B: Backend>(
 ///
 /// # Arguments
 ///
-/// - `m`: ``[H, W, (Y, X)=2]`` macroscopic momentum.
-/// - `rho`: ``[H, W]`` population density.
+/// - `m`: `[H, W, (Y, X)=2]` macroscopic momentum.
+/// - `rho`: `[H, W]` population density.
 ///
 /// # Returns
 ///
-/// The ``[H, W, (Y, X)=2]`` velocity.
+/// The `[H, W, (Y, X)=2]` velocity.
 pub fn normalize_velocity<B: Backend>(
     m: Tensor<B, 3>,
     rho: Tensor<B, 2>,
@@ -222,15 +229,15 @@ pub fn normalize_velocity<B: Backend>(
     m.div(rho.unsqueeze_dim(2))
 }
 
-/// Compute the directional macroscopic velocity.
+/// Computes the directional macroscopic velocity.
 ///
 /// # Arguments
 ///
-/// - `dist`: a ``[H, W, VY, VX]`` population distribution.
+/// - `dist`: a `[H, W, VY, VX]` population distribution.
 /// - `e`: the D2Q9 direction vectors.
 ///
 /// # Returns
-/// - ``[H, W, (Y, X)=2]`` velocity.
+/// - `[H, W, (Y, X)=2]` velocity.
 pub fn macroscopic_velocity<B: Backend>(
     dist: Tensor<B, 4>,
     rho: Tensor<B, 2>,
@@ -239,28 +246,28 @@ pub fn macroscopic_velocity<B: Backend>(
     normalize_velocity(macroscopic_momentum(dist, e), rho)
 }
 
-/// Compute the squared velocity field.
+/// Computes the squared velocity field.
 ///
 /// # Arguments
-/// - `u`: ``[H, W, (Y, X)=2]`` macroscopic velocity
+/// - `u`: `[H, W, (Y, X)=2]` macroscopic velocity
 ///
 /// # Returns
-/// - ``[H, W]`` velocity magnitude squared
+/// - `[H, W]` velocity magnitude squared
 pub fn velocity_squared<B: Backend>(u: Tensor<B, 3>) -> Tensor<B, 2> {
     u.square().sum_dim(2).squeeze_dims::<2>(&[2])
 }
 
-/// Compute the first (density) and second (macro velocity) moments.
+/// Computes the first (density) and second (macro velocity) moments.
 ///
 /// # Arguments
 ///
-/// - `dist`: a ``[H, W, VY, VX]`` population distribution.
+/// - `dist`: a `[H, W, VY, VX]` population distribution.
 /// - `e`: the D2Q9 direction vectors.
 ///
 /// # Returns
 /// ``(density, velocity)`` where:
-/// - `density`: ``[H, W]``
-/// - `velocity`: ``[H, W, (Y, X)=2]``
+/// - `density`: `[H, W]`
+/// - `velocity`: `[H, W, (Y, X)=2]`
 pub fn moments<B: Backend>(
     dist: Tensor<B, 4>,
     lbm_tables: &LbmTables<B>,
@@ -270,19 +277,19 @@ pub fn moments<B: Backend>(
     (rho, u)
 }
 
-/// Fold a distribution into windows.
+/// Folds a distribution into windows.
 ///
-/// Note the geometry: ``[H-2, W-2, VY=3, VX=3, WIN_Y=3, WIN_X=3]``
+/// Note the geometry: `[H-2, W-2, VY=3, VX=3, WIN_Y=3, WIN_X=3]`
 /// - ``(H, W)``: the spatial position of the "current" cell.
 /// - ``(WIN_Y, WIN_X)``: the current window; with the current cell in the
 ///   center.
 /// - ``(VY, VX)``: the 3x3 distribution in each cell.
 ///
 /// # Arguments
-/// - `dist`: a ``[H, W, VY=3, VX=3]`` distribution.
+/// - `dist`: a `[H, W, VY=3, VX=3]` distribution.
 ///
 /// # Returns
-/// ``[H, W, VY=3, VX=3, WIN_Y=3, WIN_X=3]`` folded windows.
+/// `[H, W, VY=3, VX=3, WIN_Y=3, WIN_X=3]` folded windows.
 pub fn dist_windows<B: Backend>(dist: Tensor<B, 4>) -> Tensor<B, 6> {
     dist.unfold::<5, _>(0, 3, 1).unfold::<6, _>(1, 3, 1)
 }

--- a/crates/bunsen/src/kits/sims/lbm/d2q9/streaming.rs
+++ b/crates/bunsen/src/kits/sims/lbm/d2q9/streaming.rs
@@ -10,14 +10,14 @@ use burn::{
 
 use crate::kits::sims::lbm::d2q9::space;
 
-/// Apply the streaming update step to the non-border cells of a population.
+/// Applies the streaming update step to the non-border cells of a population.
 ///
 /// # Arguments
 ///
-/// - `dist`: a ``[H, W, VY=3, VX=3]`` population distribution.
+/// - `dist`: a `[H, W, VY=3, VX=3]` population distribution.
 ///
 /// # Returns
-/// - The updated ``[H[1:-1], W[1:-1], VY=3, VX=3]`` interior.
+/// - The updated `[H[1:-1], W[1:-1], VY=3, VX=3]` interior.
 pub fn stream_interior_windows<B: Backend>(dist: Tensor<B, 4>) -> Tensor<B, 4> {
     #[cfg(debug_assertions)]
     let [h, w] = crate::contracts::unpack_shape_contract!(
@@ -66,7 +66,7 @@ pub fn stream_interior_windows<B: Backend>(dist: Tensor<B, 4>) -> Tensor<B, 4> {
     result
 }
 
-/// Apply the streaming update step to a population.
+/// Applies the streaming update step to a population.
 ///
 /// This combines [`stream_interior_windows`] with edge outflow-streaming.
 ///
@@ -75,10 +75,10 @@ pub fn stream_interior_windows<B: Backend>(dist: Tensor<B, 4>) -> Tensor<B, 4> {
 ///
 /// # Arguments
 ///
-/// - `dist`: a ``[H, W, VY=3, VX=3]`` population distribution.
+/// - `dist`: a `[H, W, VY=3, VX=3]` population distribution.
 ///
 /// # Returns
-/// - The updated ``[H, W, VY=3, VX=3]`` distribution.
+/// - The updated `[H, W, VY=3, VX=3]` distribution.
 pub fn outflow_clipping_stream<B: Backend>(thermal_dist: Tensor<B, 4>) -> Tensor<B, 4> {
     thermal_dist
         .zeros_like()

--- a/crates/bunsen/src/kits/sims/lbm/d2q9/thermal.rs
+++ b/crates/bunsen/src/kits/sims/lbm/d2q9/thermal.rs
@@ -11,11 +11,11 @@ use crate::kits::sims::lbm::d2q9::{
     space::LbmTables,
 };
 
-/// Compute thermal equilibrium.
+/// Computes thermal equilibrium.
 ///
 /// # Arguments
-/// - `rho`: ``[H, W]`` population density
-/// - `u`: ``[H, W, (Y, X)=2]`` macroscopic velocity
+/// - `rho`: `[H, W]` population density
+/// - `u`: `[H, W, (Y, X)=2]` macroscopic velocity
 /// - `lbm_tables`: LBM Reference Tables.
 ///
 /// # Returns
@@ -43,14 +43,14 @@ pub fn thermal_equilibrium<B: Backend>(
     )
 }
 
-/// Compute e·u for each lattice direction
+/// Computes e·u for each lattice direction.
 ///
 /// # Arguments
-/// - `e`: ``[Y=3, X=3, (Y, X)=2]`` direction vectors
-/// - `u`: ``[H, W, (Y, X)=2]`` macroscopic velocity
+/// - `e`: `[Y=3, X=3, (Y, X)=2]` direction vectors
+/// - `u`: `[H, W, (Y, X)=2]` macroscopic velocity
 ///
 /// # Returns
-/// - ``[H, W, Y=3, X=3]`` dot product at each grid point and direction.
+/// - `[H, W, Y=3, X=3]` dot product at each grid point and direction.
 pub fn lattice_dot_velocity<B: Backend>(
     u: Tensor<B, 3>,
     e: Tensor<B, 3>,
@@ -61,11 +61,11 @@ pub fn lattice_dot_velocity<B: Backend>(
 /// The projection component of [`lattice_dot_velocity`].
 ///
 /// # Arguments
-/// - `e`: ``[Y=3, X=3, (Y, X)=2]`` direction vectors
-/// - `u`: ``[H, W, (Y, X)=2]`` macroscopic velocity
+/// - `e`: `[Y=3, X=3, (Y, X)=2]` direction vectors
+/// - `u`: `[H, W, (Y, X)=2]` macroscopic velocity
 ///
 /// # Returns
-/// - ``[H, W, Y=3, X=3, (Y, X)=2]`` projection.
+/// - `[H, W, Y=3, X=3, (Y, X)=2]` projection.
 pub fn ldv_projection<B: Backend>(
     e: Tensor<B, 3>,
     u: Tensor<B, 3>,

--- a/crates/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs
@@ -39,10 +39,10 @@ use crate::{
 
 /// Common meta for [`AudioEncoder`] and [`AudioEncoderConfig`].
 pub trait AudioEncoderMeta {
-    /// Return the Mel-scale frequency resolution.
+    /// Returns the Mel-scale frequency resolution.
     fn n_mels(&self) -> usize;
 
-    /// Return the max audio context size.
+    /// Returns the max audio context size.
     ///
     /// Due to the stride reduction of the conv layers, the max context is
     /// twice the internal positional embedding.
@@ -51,10 +51,10 @@ pub trait AudioEncoderMeta {
     /// The embedding size of the model.
     fn d_model(&self) -> usize;
 
-    /// Return the number of heads.
+    /// Returns the number of heads.
     fn n_heads(&self) -> usize;
 
-    /// Return the number of layers.
+    /// Returns the number of layers.
     fn n_layers(&self) -> usize;
 }
 
@@ -146,6 +146,10 @@ impl<B: Backend> ModuleInit<B, AudioEncoder<B>> for AudioEncoderConfig {
 }
 
 /// Whisper Audio Encoder.
+///
+/// Encodes a log-Mel spectrogram into audio feature states.
+///
+/// Built by [`AudioEncoderConfig`].
 #[derive(Module, Debug)]
 pub struct AudioEncoder<B: Backend> {
     conv1: Conv1d<B>,
@@ -189,11 +193,11 @@ impl<B: Backend> AudioEncoderMeta for AudioEncoder<B> {
 impl<B: Backend> AudioEncoder<B> {
     /// Forward pass through the audio encoder.
     ///
-    /// ## Arguments
-    /// * `x`: The input audio spectrogram ``[batch, n_mels, seq]``.
+    /// # Arguments
+    /// * `x`: The input audio spectrogram `[batch, n_mels, seq]`.
     ///
-    /// ## Returns
-    /// ``[batch, seq, n_audio_states]``.
+    /// # Returns
+    /// `[batch, seq, n_audio_states]`.
     pub fn forward(
         &self,
         x: Tensor<B, 3>,

--- a/crates/bunsen/src/kits/speech/whisper/blocks/decoder_block.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/decoder_block.rs
@@ -36,20 +36,20 @@ use crate::{
 /// Common meta for [`ResidualDecoderAttentionBlock`] and
 /// [`ResidualDecoderAttentionBlockConfig`].
 pub trait ResidualDecoderAttentionBlockMeta {
-    /// Return the embedding dimensionality.
+    /// Returns the embedding dimensionality.
     fn d_model(&self) -> usize;
 
-    /// Return the number of heads.
+    /// Returns the number of heads.
     fn n_heads(&self) -> usize;
 
-    /// Return the dropout.
+    /// Returns the dropout.
     fn dropout(&self) -> f64;
 }
 
 /// Config for [`ResidualDecoderAttentionBlock`].
 #[derive(Config, Debug)]
 pub struct ResidualDecoderAttentionBlockConfig {
-    /// Return the embedding dimensionality.
+    /// Returns the embedding dimensionality.
     pub d_model: usize,
 
     /// Head Dimensionality.
@@ -105,6 +105,13 @@ impl<B: Backend> ModuleInit<B, ResidualDecoderAttentionBlock<B>>
 }
 
 /// Residual Decoder Attention Block for Whisper.
+///
+/// One Whisper decoder layer: pre-norm masked multi-head self-attention,
+/// pre-norm cross-attention over the encoder output, and a pre-norm MLP, each
+/// wrapped in a residual connection. Stacked inside the Whisper text decoder,
+/// and also returns its cross-attention weights via [`DecodeRecord`].
+///
+/// Built by [`ResidualDecoderAttentionBlockConfig`].
 #[derive(Module, Debug)]
 pub struct ResidualDecoderAttentionBlock<B: Backend> {
     /// Attention Normalization.
@@ -143,25 +150,25 @@ impl<B: Backend> ResidualDecoderAttentionBlockMeta for ResidualDecoderAttentionB
 /// Decode record for [`ResidualDecoderAttentionBlock::forward`].
 #[derive(Debug, Clone)]
 pub struct DecodeRecord<B: Backend> {
-    /// Block Output: ``[batch, seq_len, d_model]``.
+    /// Block Output: `[batch, seq_len, d_model]`.
     pub output: Tensor<B, 3>,
 
-    /// Cross-Attention Weights: ``[batch, n_heads, seq_len, seq_len]``.
+    /// Cross-Attention Weights: `[batch, n_heads, seq_len, seq_len]`.
     pub ca_weights: Tensor<B, 4>,
 }
 
 impl<B: Backend> DecodeRecord<B> {
-    /// Get the batch size.
+    /// Returns the batch size.
     pub fn batch_size(&self) -> usize {
         self.output.shape()[0]
     }
 
-    /// Get the embedding size.
+    /// Returns the embedding size.
     pub fn d_model(&self) -> usize {
         self.output.shape()[2]
     }
 
-    /// Get the sequence length.
+    /// Returns the sequence length.
     pub fn seq_len(&self) -> usize {
         self.output.shape()[1]
     }
@@ -170,15 +177,15 @@ impl<B: Backend> DecodeRecord<B> {
 impl<B: Backend> ResidualDecoderAttentionBlock<B> {
     /// Forward pass of the residual decoder attention block.
     ///
-    /// ## Arguments
-    /// * `x` : ``[batch, seq_len, d_model]`` input.
-    /// * `xa` : ``[batch, seq_len, d_model]`` cross-attention input.
-    /// * `mask` : ``[batch, seq_len, seq_len]`` attention mask.
+    /// # Arguments
+    /// * `x` : `[batch, seq_len, d_model]` input.
+    /// * `xa` : `[batch, seq_len, d_model]` cross-attention input.
+    /// * `mask` : `[batch, seq_len, seq_len]` attention mask.
     ///
-    /// ## Returns
+    /// # Returns
     /// `DecodeRecord` - forward record.
-    /// * `fr.output` : ``[batch, seq_len, d_model]``.
-    /// * `fr.ca_weights` : ``[batch, n_heads, seq_len, seq_len]``.
+    /// * `fr.output` : `[batch, seq_len, d_model]`.
+    /// * `fr.ca_weights` : `[batch, n_heads, seq_len, seq_len]`.
     pub fn forward(
         &self,
         x: Tensor<B, 3>,

--- a/crates/bunsen/src/kits/speech/whisper/blocks/encoder_block.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/encoder_block.rs
@@ -29,20 +29,20 @@ use crate::{
 /// Common meta for [`ResidualEncoderAttentionBlock`] and
 /// [`ResidualEncoderAttentionBlockConfig`].
 pub trait ResidualEncoderAttentionBlockMeta {
-    /// Return the embedding dimensionality.
+    /// Returns the embedding dimensionality.
     fn d_model(&self) -> usize;
 
-    /// Return the number of heads.
+    /// Returns the number of heads.
     fn n_heads(&self) -> usize;
 
-    /// Return the dropout.
+    /// Returns the dropout.
     fn dropout(&self) -> f64;
 }
 
 /// Config for [`ResidualEncoderAttentionBlock`].
 #[derive(Config, Debug)]
 pub struct ResidualEncoderAttentionBlockConfig {
-    /// Return the embedding dimensionality.
+    /// Returns the embedding dimensionality.
     pub d_model: usize,
 
     /// Head Dimensionality.
@@ -94,6 +94,12 @@ impl<B: Backend> ModuleInit<B, ResidualEncoderAttentionBlock<B>>
 }
 
 /// Residual Encoder Attention Block for Whisper.
+///
+/// One Whisper encoder layer: pre-norm multi-head self-attention followed by a
+/// pre-norm MLP, each wrapped in a residual connection. Stacked inside the
+/// Whisper audio encoder.
+///
+/// Built by [`ResidualEncoderAttentionBlockConfig`].
 #[derive(Module, Debug)]
 pub struct ResidualEncoderAttentionBlock<B: Backend> {
     /// Attention Normalization.
@@ -126,11 +132,11 @@ impl<B: Backend> ResidualEncoderAttentionBlockMeta for ResidualEncoderAttentionB
 impl<B: Backend> ResidualEncoderAttentionBlock<B> {
     /// Forward pass of the residual decoder attention block.
     ///
-    /// ## Arguments
-    /// * `x` : ``[batch, seq_len, d_model]`` input.
+    /// # Arguments
+    /// * `x` : `[batch, seq_len, d_model]` input.
     ///
-    /// ## Returns
-    /// ``[batch, seq_len, d_model]``
+    /// # Returns
+    /// `[batch, seq_len, d_model]`
     pub fn forward(
         &self,
         x: Tensor<B, 3>,

--- a/crates/bunsen/src/kits/speech/whisper/blocks/text_decoder.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/text_decoder.rs
@@ -37,19 +37,19 @@ use crate::{
 
 /// Common meta for [`TextDecoder`] and [`TextDecoderConfig`].
 pub trait TextDecoderMeta {
-    /// Return the size of the vocabulary.
+    /// Returns the size of the vocabulary.
     fn vocab_size(&self) -> usize;
 
     /// The embedding size of the model.
     fn d_model(&self) -> usize;
 
-    /// Return the max context size.
+    /// Returns the max context size.
     fn max_context(&self) -> usize;
 
-    /// Return the number of heads.
+    /// Returns the number of heads.
     fn n_heads(&self) -> usize;
 
-    /// Return the number of layers.
+    /// Returns the number of layers.
     fn n_layers(&self) -> usize;
 }
 
@@ -99,7 +99,7 @@ impl TextDecoderMeta for TextDecoderConfig {
     }
 }
 
-/// Build attention mask for decoder.
+/// Builds attention mask for decoder.
 pub fn attn_decoder_mask<B: Backend>(
     seq_length: usize,
     device: &B::Device,
@@ -145,6 +145,13 @@ impl<B: Backend> ModuleInit<B, TextDecoder<B>> for TextDecoderConfig {
 }
 
 /// Text decoder module for Whisper speech recognition model.
+///
+/// Autoregressive token decoder: token plus positional embeddings, a stack of
+/// [`ResidualDecoderAttentionBlock`] layers (causally-masked self-attention and
+/// cross-attention over the audio encoder output), a final layer norm, and an
+/// unembedding into vocabulary logits.
+///
+/// Built by [`TextDecoderConfig`].
 #[derive(Module, Debug)]
 pub struct TextDecoder<B: Backend> {
     /// The token embedding.
@@ -184,14 +191,14 @@ impl<B: Backend> TextDecoderMeta for TextDecoder<B> {
 }
 
 impl<B: Backend> TextDecoder<B> {
-    /// Run the decoder.
+    /// Runs the decoder.
     ///
-    /// ## Arguments
-    /// * `x`: ``[batch, seq]``.
-    /// * `xa`: ``[batch, seq, d_model]``.
+    /// # Arguments
+    /// * `x`: `[batch, seq]`.
+    /// * `xa`: `[batch, seq, d_model]`.
     ///
-    /// ## Returns
-    /// ``[batch, seq, n_vocab]``.
+    /// # Returns
+    /// `[batch, seq, n_vocab]`.
     pub fn forward(
         &self,
         x: Tensor<B, 2, Int>,

--- a/crates/bunsen/src/kits/speech/whisper/blocks/whisper_model.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/whisper_model.rs
@@ -22,6 +22,13 @@ use crate::{
 };
 
 /// Whisper API config.
+///
+/// User-facing configuration for the [`Whisper`] model, exposing the flat
+/// hyperparameters (Mel resolution, vocabulary, model/head sizes, context
+/// limits, and encoder/decoder layer counts). Expands via
+/// [`to_structure`](WhisperApiConfig::to_structure) into a
+/// [`WhisperStructuralConfig`], and builds the [`Whisper`] module directly via
+/// [`ModuleInit`].
 #[derive(Config, Debug)]
 pub struct WhisperApiConfig {
     /// The Mel-scale frequency resolution.
@@ -51,7 +58,7 @@ pub struct WhisperApiConfig {
 }
 
 impl WhisperApiConfig {
-    /// Convert to a [`WhisperStructuralConfig`].
+    /// Converts to a [`WhisperStructuralConfig`].
     pub fn to_structure(&self) -> WhisperStructuralConfig {
         WhisperStructuralConfig {
             encoder: AudioEncoderConfig::new(
@@ -83,17 +90,17 @@ impl<B: Backend> ModuleInit<B, Whisper<B>> for WhisperApiConfig {
 
 /// Common meta for [`Whisper`] and [`WhisperApiConfig`].
 pub trait WhisperMeta {
-    /// Return the Mel-scale frequency resolution.
+    /// Returns the Mel-scale frequency resolution.
     fn n_mels(&self) -> usize {
         self.encoder().n_mels()
     }
 
-    /// Return the vocabulary size.
+    /// Returns the vocabulary size.
     fn vocab_size(&self) -> usize {
         self.decoder().vocab_size()
     }
 
-    /// Return the embedding size of the model.
+    /// Returns the embedding size of the model.
     fn d_model(&self) -> usize {
         self.encoder().d_model()
     }
@@ -108,14 +115,18 @@ pub trait WhisperMeta {
         self.decoder().max_context()
     }
 
-    /// Return the [`AudioEncoder`] meta.
+    /// Returns the [`AudioEncoder`] meta.
     fn encoder(&self) -> &impl AudioEncoderMeta;
 
-    /// Return the [`TextDecoder`] meta.
+    /// Returns the [`TextDecoder`] meta.
     fn decoder(&self) -> &impl TextDecoderMeta;
 }
 
 /// [`Whisper`] structural config.
+///
+/// The fully-expanded structural configuration for the [`Whisper`] model,
+/// pairing an [`AudioEncoderConfig`] with a [`TextDecoderConfig`]. Builds the
+/// [`Whisper`] module via [`ModuleInit`].
 #[derive(Config, Debug)]
 pub struct WhisperStructuralConfig {
     /// Encoder config.
@@ -150,6 +161,12 @@ impl<B: Backend> ModuleInit<B, Whisper<B>> for WhisperStructuralConfig {
 }
 
 /// Whisper model
+///
+/// End-to-end Whisper speech recognition model, composing an [`AudioEncoder`]
+/// over the input log-Mel spectrogram with a [`TextDecoder`] that
+/// cross-attends to the encoder output to produce vocabulary logits.
+///
+/// Built by [`WhisperApiConfig`].
 #[derive(Module, Debug)]
 pub struct Whisper<B: Backend> {
     /// The [`AudioEncoder`].
@@ -172,12 +189,12 @@ impl<B: Backend> WhisperMeta for Whisper<B> {
 impl<B: Backend> Whisper<B> {
     /// Forward pass through the Whisper model.
     ///
-    /// ## Arguments
-    /// * `mel`: The input audio spectrogram ``[batch, n_mels, seq]``.
-    /// * `tokens`: ``[batch, seq]``.
+    /// # Arguments
+    /// * `mel`: The input audio spectrogram `[batch, n_mels, seq]`.
+    /// * `tokens`: `[batch, seq]`.
     ///
-    /// ## Returns
-    /// ``[batch, seq, vocab_size]``.
+    /// # Returns
+    /// `[batch, seq, vocab_size]`.
     pub fn forward(
         &self,
         mel: Tensor<B, 3>,
@@ -188,11 +205,11 @@ impl<B: Backend> Whisper<B> {
 
     /// Forward pass through the Whisper encoder.
     ///
-    /// ## Arguments
-    /// * `mel`: The input audio spectrogram ``[batch, n_mels, seq]``.
+    /// # Arguments
+    /// * `mel`: The input audio spectrogram `[batch, n_mels, seq]`.
     ///
-    /// ## Returns
-    /// ``[batch, seq, n_audio_states]``.
+    /// # Returns
+    /// `[batch, seq, n_audio_states]`.
     pub fn forward_encoder(
         &self,
         mel: Tensor<B, 3>,
@@ -202,12 +219,12 @@ impl<B: Backend> Whisper<B> {
 
     /// Forward pass through the Whisper decoder.
     ///
-    /// ## Arguments
-    /// * `tokens`: ``[batch, seq]``.
-    /// * `encoder_output`: ``[batch, seq, d_model]``.
+    /// # Arguments
+    /// * `tokens`: `[batch, seq]`.
+    /// * `encoder_output`: `[batch, seq, d_model]`.
     ///
-    /// ## Returns
-    /// ``[batch, seq, vocab_size]``.
+    /// # Returns
+    /// `[batch, seq, vocab_size]`.
     pub fn forward_decoder(
         &self,
         tokens: Tensor<B, 2, Int>,

--- a/crates/bunsen/src/kits/speech/whisper/pretrained/pytorch_utils.rs
+++ b/crates/bunsen/src/kits/speech/whisper/pretrained/pytorch_utils.rs
@@ -124,7 +124,7 @@ impl PytorchWhisperScanner {
         ))
     }
 
-    /// Load a pytorch whisper model from a checkpoint.
+    /// Loads a pytorch whisper model from a checkpoint.
     pub fn load<B: Backend, P: AsRef<Path>>(
         &self,
         path: P,

--- a/crates/bunsen/src/lib.rs
+++ b/crates/bunsen/src/lib.rs
@@ -89,7 +89,7 @@ extern crate core;
 #[doc(hidden)]
 pub use bunsen_contracts_macros::shape_contract as __proc_shape_contract;
 
-/// Re-export public dependencies.
+/// Re-exports public dependencies.
 #[allow(unused_imports)]
 #[allow(missing_docs)]
 pub mod public {

--- a/crates/bunsen/src/ops/arange.rs
+++ b/crates/bunsen/src/ops/arange.rs
@@ -11,12 +11,12 @@ use burn::prelude::{
     Tensor,
 };
 
-/// Create a vector with evenly spaced floating point values.
+/// Creates a vector with evenly spaced floating point values.
 ///
 /// This function generates a vector starting from `start`, ending at `end`, and
 /// incrementing by `step`.
 ///
-/// # Parameters
+/// # Arguments
 ///
 /// - `start`: The starting value of the range.
 /// - `end`: The end value of the range (exclusive).
@@ -59,12 +59,12 @@ pub fn float_vec_arange(
     values
 }
 
-/// Create a vector with evenly spaced floating point values.
+/// Creates a vector with evenly spaced floating point values.
 ///
 /// This function generates a vector with `num` values starting from `start`,
 /// ending at `end`, and evenly spaced.
 ///
-/// # Parameters
+/// # Arguments
 ///
 /// - `start`: The starting value of the range.
 /// - `end`: The end value of the range (inclusive).
@@ -95,13 +95,13 @@ pub fn float_vec_linspace(
 
     float_vec_arange(start, end, Some(step))
 }
-/// Create a 1D tensor with evenly spaced floating point values.
+/// Creates a 1D tensor with evenly spaced floating point values.
 ///
 /// This function generates a tensor with values starting from `start`, ending
 /// at `end`, and incrementing by `step`. If `step` is not provided, it defaults
 /// to `1.0` if `start < end`, or `-1.0` if `start > end`.
 ///
-/// # Parameters
+/// # Arguments
 ///
 /// - `start`: The starting value of the range.
 /// - `end`: The end value of the range (exclusive).
@@ -122,12 +122,12 @@ pub fn float_arange<B: Backend>(
     Tensor::from_data(values.as_slice(), device)
 }
 
-/// Create a 1D tensor with evenly spaced floating point values.
+/// Creates a 1D tensor with evenly spaced floating point values.
 ///
 /// This function generates a tensor with `num` values starting from `start`,
 /// ending at `end`, and evenly spaced.
 ///
-/// # Parameters
+/// # Arguments
 ///
 /// - `start`: The starting value of the range.
 /// - `end`: The end value of the range (inclusive).

--- a/crates/bunsen/src/ops/clamp.rs
+++ b/crates/bunsen/src/ops/clamp.rs
@@ -39,7 +39,7 @@ impl ModuleDisplayDefault for ClampOp {
 }
 
 impl ClampOp {
-    /// Create a new `ClampConfig`..
+    /// Creates a new `ClampConfig`.
     pub fn new<A, B>(
         min: A,
         max: B,
@@ -54,17 +54,17 @@ impl ClampOp {
         }
     }
 
-    /// Get the minimum value.
+    /// Returns the minimum value.
     pub fn min(&self) -> Option<f64> {
         self.min
     }
 
-    /// Get the maximum value.
+    /// Returns the maximum value.
     pub fn max(&self) -> Option<f64> {
         self.max
     }
 
-    /// Extend the clamp with a minimum value.
+    /// Extends the clamp with a minimum value.
     pub fn with_min(
         self,
         min: f64,
@@ -75,7 +75,7 @@ impl ClampOp {
         }
     }
 
-    /// Extend the clamp with a maximum value.
+    /// Extends the clamp with a maximum value.
     pub fn with_max(
         self,
         max: f64,
@@ -86,7 +86,7 @@ impl ClampOp {
         }
     }
 
-    /// Apply the clamp.
+    /// Applies the clamp.
     pub fn clamp<B: Backend, const D: usize>(
         &self,
         tensor: Tensor<B, D>,

--- a/crates/bunsen/src/ops/conv/conv_func_2d.rs
+++ b/crates/bunsen/src/ops/conv/conv_func_2d.rs
@@ -6,22 +6,22 @@ use burn::{
     tensor::BasicOps,
 };
 
-/// Convolve a neighborhood function over a 2D tensor.
+/// Convolves a neighborhood function over a 2D tensor.
 ///
 /// Here ``h_wins`` and ``w_wins`` refer to
 /// ``burn::tensor::ops::unfold::calculate_unfold_windows(dim, kernel, 1)``
 ///
 /// # Arguments
 ///
-/// * `input` - a ``[batch, c_in, height, width]`` tensor.
-/// * `func` - a func from ``[batch, h_wins, w_wins, c_in, kernel[0],
-///   kernel[1]]`` to ``[batch, h_wins, w_wins, c_out]``
-/// * `kernel` - a kernel shape, e.g. ``[3, 3]``.
-/// * `stride` - a kernel stride, e.g. ``[1, 1]``.
+/// * `input` - a `[batch, c_in, height, width]` tensor.
+/// * `func` - a func from `[batch, h_wins, w_wins, c_in, kernel[0], kernel[1]]`
+///   to `[batch, h_wins, w_wins, c_out]`
+/// * `kernel` - a kernel shape, e.g. `[3, 3]`.
+/// * `stride` - a kernel stride, e.g. `[1, 1]`.
 ///
 /// # Returns
 ///
-/// A tensor in ``[batch, c_out, h_wins, w_wins]``
+/// A tensor in `[batch, c_out, h_wins, w_wins]`
 pub fn convolve_func_2d<B, KIn, KOut, F>(
     input: Tensor<B, 4, KIn>,
     func: F,

--- a/crates/bunsen/src/ops/conv/conv_shape.rs
+++ b/crates/bunsen/src/ops/conv/conv_shape.rs
@@ -11,7 +11,7 @@ use burn::{
 
 use crate::contracts::unpack_shape_contract;
 
-/// Predict the output size of a 1D convolution operation.
+/// Predicts the output size of a 1D convolution operation.
 ///
 /// ```text
 /// out_size = floor( ((in_size + 2*padding - dilation*(kernel_size-1) - 1) / stride) + 1 )
@@ -58,7 +58,7 @@ pub fn maybe_conv1d_output_size(
     if x < 1 { None } else { Some(x) }
 }
 
-/// Predict the output size of a 1D convolution operation.
+/// Predicts the output size of a 1D convolution operation.
 ///
 /// This is the ``panic``-ing variant of [`maybe_conv1d_output_size`].
 ///
@@ -103,7 +103,7 @@ pub fn expect_conv1d_output_size(
     }
 }
 
-/// Predict the output shape of a D convolution operation; for dynamic slices.
+/// Predicts the output shape of a D convolution operation; for dynamic slices.
 ///
 /// This is the generalization of [`maybe_conv1d_output_size`] to D dimensions.
 ///
@@ -148,7 +148,7 @@ pub fn maybe_conv_output_shape_dyn(
     Some(output_shape)
 }
 
-/// Predict the output shape of a D convolution operation.
+/// Predicts the output shape of a D convolution operation.
 ///
 /// This is the ``panic``-ing variant of [`maybe_conv_output_shape_dyn`];
 /// which is the generalization of [`maybe_conv1d_output_size`] to D dimensions.
@@ -180,7 +180,7 @@ pub fn expect_conv_output_shape_dyn(
     }
 }
 
-/// Predict the output shape of a D convolution operation.
+/// Predicts the output shape of a D convolution operation.
 ///
 /// This is the generalization of [`maybe_conv1d_output_size`] to D dimensions.
 ///
@@ -216,7 +216,7 @@ pub fn maybe_conv_output_shape<const D: usize>(
     Some(output_shape)
 }
 
-/// Predict the output shape of a D convolution operation.
+/// Predicts the output shape of a D convolution operation.
 ///
 /// This is the ``panic``-ing variant of [`maybe_conv_output_shape`];
 /// which is the generalization of [`maybe_conv1d_output_size`] to D dimensions.
@@ -248,18 +248,18 @@ pub fn expect_conv_output_shape<const D: usize>(
     }
 }
 
-/// Get the output resolution for a given input resolution.
+/// Returns the output resolution for a given input resolution.
 ///
 /// The input must be a multiple of the stride.
 ///
 /// # Arguments
 ///
-/// - `input_resolution`: ``[in_height=out_height*stride,
-///   in_width=out_width*stride]``.
+/// - `input_resolution`: `[in_height=out_height*stride,
+///   in_width=out_width*stride]`.
 ///
 /// # Returns
 ///
-/// ``[out_height, out_width]``
+/// `[out_height, out_width]`
 ///
 /// # Panics
 ///
@@ -285,7 +285,7 @@ pub static CONV_INTO_RELU_INITIALIZER: Initializer = Initializer::KaimingNormal 
     fan_out_only: true,
 };
 
-/// Compute the necessary [`burn::nn::conv::Conv2d`] padding for the given
+/// Computes the necessary [`burn::nn::conv::Conv2d`] padding for the given
 /// square parameters.
 ///
 /// All parameters are assumed square (the same in height and width).
@@ -310,7 +310,7 @@ pub fn get_square_conv2d_padding(
     ((stride - 1) + dilation * (kernel - 1)) / 2
 }
 
-/// Compute the necessary [`burn::nn::conv::Conv2d`] padding for the given
+/// Computes the necessary [`burn::nn::conv::Conv2d`] padding for the given
 /// square parameters.
 ///
 /// All parameters are assumed square (the same in height and width).

--- a/crates/bunsen/src/ops/conv/midpoint_filter.rs
+++ b/crates/bunsen/src/ops/conv/midpoint_filter.rs
@@ -8,7 +8,7 @@ use burn::{
     tensor::Numeric,
 };
 
-/// Build a filter of kernel midpoints.
+/// Builds a filter of kernel midpoints.
 ///
 /// Filter is `1.0` at the mid-points of kernels; `0.0` everywhere else.
 ///

--- a/crates/bunsen/src/ops/drop/drop_block.rs
+++ b/crates/bunsen/src/ops/drop/drop_block.rs
@@ -52,7 +52,7 @@ pub struct DropBlockOptions {
     /// Should color drop be coupled, or independent?
     pub couple_channels: bool,
 
-    /// Permit partial conv at the edges.
+    /// Permits partial conv at the edges.
     /// This results in a significant speedup when using noise.
     pub partial_edge_blocks: bool,
 
@@ -95,7 +95,7 @@ impl Default for DropBlockOptions {
 }
 
 impl DropBlockOptions {
-    /// Extend the options with the given validators.
+    /// Extends the options with the given validators.
     ///
     /// # Arguments
     ///
@@ -103,7 +103,7 @@ impl DropBlockOptions {
     ///
     /// # Panics
     ///
-    /// If the `drop_prob` is not in ``[0.0, 1.0]``.
+    /// If the `drop_prob` is not in `[0.0, 1.0]`.
     pub fn with_drop_prob(
         self,
         drop_prob: f64,
@@ -114,7 +114,7 @@ impl DropBlockOptions {
         }
     }
 
-    /// Set the symmetric kernel block size.
+    /// Sets the symmetric kernel block size.
     ///
     /// This is equivalent to `.with_kernel([block_size; 2])`
     ///
@@ -151,7 +151,7 @@ impl DropBlockOptions {
         Self { kernel, ..self }
     }
 
-    /// Set the gamma scale.
+    /// Sets the gamma scale.
     pub fn with_gamma_scale(
         self,
         gamma_scale: f64,
@@ -162,7 +162,7 @@ impl DropBlockOptions {
         }
     }
 
-    /// Set whether to use noise.
+    /// Sets whether to use noise.
     pub fn with_noise<N>(
         self,
         noise_cfg: N,
@@ -176,7 +176,7 @@ impl DropBlockOptions {
         }
     }
 
-    /// Set if batchwise noise should be used.
+    /// Sets if batchwise noise should be used.
     ///
     /// When `batchwise` is enabled, the entire batch shares the same noise;
     /// otherwise, each image gets its own noise.
@@ -193,7 +193,7 @@ impl DropBlockOptions {
         Self { batchwise, ..self }
     }
 
-    /// Set if channels should be coupled.
+    /// Sets if channels should be coupled.
     pub fn with_couple_channels(
         self,
         couple_channels: bool,
@@ -204,7 +204,7 @@ impl DropBlockOptions {
         }
     }
 
-    /// Set if partial edge conv should be used.
+    /// Sets if partial edge conv should be used.
     ///
     /// Partial edge conv are conv which overlap the edge;
     /// and are smaller than the full kernel; but not performing
@@ -223,7 +223,7 @@ impl DropBlockOptions {
         }
     }
 
-    /// Clip the kernel to fit within the shape.
+    /// Clips the kernel to fit within the shape.
     ///
     /// # Arguments
     ///
@@ -244,7 +244,7 @@ impl DropBlockOptions {
         [core::cmp::min(h, kh), core::cmp::min(w, kw)]
     }
 
-    /// Compute the adjusted gamma rate.
+    /// Computes the adjusted gamma rate.
     ///
     /// Gamma is the adjusted validators that any given point is the midpoint
     /// of a dropped block; given the desired `drop_rate`, the block size, and
@@ -266,7 +266,7 @@ impl DropBlockOptions {
             / (((h - kh + 1) * (w - kw + 1)) as f64)
     }
 
-    /// Compute the gamma noise for the given noise batch shape.
+    /// Computes the gamma noise for the given noise batch shape.
     ///
     /// # Args
     ///
@@ -286,7 +286,7 @@ impl DropBlockOptions {
     }
 }
 
-/// Convert drop block gamma noise to a selection filter.
+/// Converts drop block gamma noise to a selection filter.
 ///
 /// This is a deterministic internal component of `drop_block`.
 ///
@@ -358,12 +358,12 @@ pub fn drop_block_2d_drop_filter_<B: Backend>(
 ///
 /// # Arguments
 ///
-/// * `tensor` - the tensor to operate on, ``[batch, channels, height, width]``.
+/// * `tensor` - the tensor to operate on, `[batch, channels, height, width]`.
 /// * `options` - the algorithm options.
 ///
 /// # Returns
 ///
-/// A ``[batch, channels, height, width]`` tensor.
+/// A `[batch, channels, height, width]` tensor.
 pub fn drop_block_2d<B: Backend>(
     tensor: Tensor<B, 4>,
     options: &DropBlockOptions,

--- a/crates/bunsen/src/ops/drop/dropout_func.rs
+++ b/crates/bunsen/src/ops/drop/dropout_func.rs
@@ -11,7 +11,7 @@ use burn::{
 /// input * input.random_like(Bernoulli(p_keep)) / p_keep
 /// ```
 ///
-/// ## Arguments
+/// # Arguments
 /// * `prob` - the drop probability.
 /// * `input` - the input tensor.
 pub fn dropout<B: Backend, const D: usize>(

--- a/crates/bunsen/src/ops/embedding/inverse.rs
+++ b/crates/bunsen/src/ops/embedding/inverse.rs
@@ -22,14 +22,14 @@ impl<B: Backend> EmbeddingArg<B> for Tensor<B, 2> {
     }
 }
 
-/// Invert an Embedding layer to get logits.
+/// Inverts an Embedding layer to get logits.
 ///
 /// # Arguments
 /// * `emb` - The `[n_vocab, d_model]`, embedding layer to invert.
 /// * `x` - The `[batch, seq_len, d_model]` tensor to unembed.
 ///
 /// # Returns
-/// The logits tensor of shape `[batch, seq_len, n_vocab]`.
+/// The `[batch, seq_len, n_vocab]` logits tensor.
 pub fn unembed<B: Backend, A: EmbeddingArg<B>>(
     emb: A,
     x: Tensor<B, 3>,

--- a/crates/bunsen/src/ops/embedding/trivial_builders.rs
+++ b/crates/bunsen/src/ops/embedding/trivial_builders.rs
@@ -8,7 +8,7 @@ use burn::{
     },
 };
 
-/// Build an iota embedding.
+/// Builds an iota embedding.
 ///
 /// `weight[i, j] = i * d + j` - every row distinct, lookups hand-verifiable.
 pub fn iota_embedding<B: Backend>(
@@ -24,7 +24,7 @@ pub fn iota_embedding<B: Backend>(
     }
 }
 
-/// Build a one-hot passthrough embedding.
+/// Builds a one-hot passthrough embedding.
 ///
 /// Square identity (`num_embeddings == dim == n`): embedding acts as a one-hot
 /// passthrough.

--- a/crates/bunsen/src/ops/noise.rs
+++ b/crates/bunsen/src/ops/noise.rs
@@ -62,7 +62,7 @@ impl Default for NoiseConfig {
 }
 
 impl NoiseConfig {
-    /// Extend the config with the given [`Distribution`].
+    /// Extends the config with the given [`Distribution`].
     pub fn with_distribution(
         self,
         distribution: Distribution,
@@ -73,7 +73,7 @@ impl NoiseConfig {
         }
     }
 
-    /// Extend the config with the given [`ClampOp`].
+    /// Extends the config with the given [`ClampOp`].
     pub fn with_clamp<C>(
         self,
         clamp: C,
@@ -87,7 +87,7 @@ impl NoiseConfig {
         }
     }
 
-    /// Generate noise.
+    /// Generates noise.
     ///
     /// Noise is drawn from the distribution; and optionally clamped.
     ///

--- a/crates/bunsen/src/ops/norm/rms_norm_impl.rs
+++ b/crates/bunsen/src/ops/norm/rms_norm_impl.rs
@@ -18,7 +18,7 @@ impl Default for RmsNormOptions {
 }
 
 impl RmsNormOptions {
-    /// Set epsilon value.
+    /// Sets epsilon value.
     pub fn with_eps(
         mut self,
         eps: f32,
@@ -27,7 +27,7 @@ impl RmsNormOptions {
         self
     }
 
-    /// Apply root-mean-square norm.
+    /// Applies root-mean-square norm.
     pub fn norm<B: Backend, const R: usize>(
         &self,
         x: Tensor<B, R>,
@@ -36,7 +36,7 @@ impl RmsNormOptions {
     }
 }
 
-/// Apply root-mean-square norm.
+/// Applies root-mean-square norm.
 pub fn rms_norm<B: Backend, const R: usize>(
     x: Tensor<B, R>,
     options: &RmsNormOptions,

--- a/crates/bunsen/src/support/arrays.rs
+++ b/crates/bunsen/src/support/arrays.rs
@@ -1,5 +1,6 @@
 //! # Array Utilities
-/// Convert a `T` to a `[T; D]`.
+
+/// Converts a `T` to a `[T; D]`.
 pub fn scalar_to_array<const D: usize, T>(v: T) -> [T; D]
 where
     T: Copy,

--- a/crates/bunsen/src/support/math/iroot.rs
+++ b/crates/bunsen/src/support/math/iroot.rs
@@ -1,11 +1,11 @@
-/// Find the exact integer nth root if it exists.
+/// Finds the exact integer nth root if it exists.
 ///
-/// ## Arguments
+/// # Arguments
 ///
 /// - `value` - the value.
 /// - `exp` - the exponent.
 ///
-/// ## Returns
+/// # Returns
 ///
 /// Either the exact root (positive if possible) or None.
 pub fn maybe_iroot(

--- a/crates/bunsen/src/support/validators/grid_shape.rs
+++ b/crates/bunsen/src/support/validators/grid_shape.rs
@@ -1,6 +1,6 @@
 //! # Config Parsers
 
-/// Parse a shape string into a ``(H, W)`` tuple.
+/// Parses a shape string into a ``(H, W)`` tuple.
 ///
 /// Accepts:
 /// - ``SHAPE``: ``(SHAPE, SHAPE)``.

--- a/crates/bunsen/src/support/validators/prob.rs
+++ b/crates/bunsen/src/support/validators/prob.rs
@@ -11,7 +11,7 @@ use crate::errors::{
     BunsenResult,
 };
 
-/// Validate a validators in the range ``[0.0, 1.0]``.
+/// Validates a validators in the range `[0.0, 1.0]`.
 ///
 /// # Arguments
 ///
@@ -31,7 +31,7 @@ pub fn try_probability<F: Float + Debug>(prob: F) -> BunsenResult<F> {
     }
 }
 
-/// Expect a validators to be in range ``[0.0, 1.0]``, or panic.
+/// Expects a validators to be in range `[0.0, 1.0]`, or panic.
 ///
 /// # Arguments
 ///

--- a/crates/bunsen/src/zspace/bounds.rs
+++ b/crates/bunsen/src/zspace/bounds.rs
@@ -77,7 +77,7 @@ pub fn zspace_partial_cmp<T: PartialOrd>(
     Some(ord)
 }
 
-/// Check if a `point` is in the half-open range ``[start, end)``
+/// Checks if a `point` is in the half-open range ``[start, end)``.
 ///
 /// # Returns
 ///

--- a/crates/bunsen/src/zspace/parse_shapes.rs
+++ b/crates/bunsen/src/zspace/parse_shapes.rs
@@ -6,7 +6,7 @@ use crate::errors::{
     BunsenResult,
 };
 
-/// Encode a [`Shape`] to XML/XPath attribute style.
+/// Encodes a [`Shape`] to XML/XPath attribute style.
 ///
 /// Bracketless space-seperated style, eg: "1", "2 4"
 ///
@@ -19,7 +19,7 @@ pub fn shape_to_xml_attr(shape: &Shape) -> String {
         .join(" ")
 }
 
-/// Decode a [`Shape`] from XML/XPath attribute style.
+/// Decodes a [`Shape`] from XML/XPath attribute style.
 ///
 /// Bracketless space-seperated style, eg: "1", "2 4"
 ///

--- a/crates/bunsen/src/zspace/ravel_utils.rs
+++ b/crates/bunsen/src/zspace/ravel_utils.rs
@@ -8,7 +8,7 @@ use burn::{
     },
 };
 
-/// Compute the ravel index for the given coordinates.
+/// Computes the ravel index for the given coordinates.
 ///
 /// This returns the row-major order raveling.
 ///
@@ -24,7 +24,7 @@ pub fn ravel_shape<I: AsIndex>(
     ravel_dims(shape.as_slice(), coords)
 }
 
-/// Compute the ravel index for the given coordinates.
+/// Computes the ravel index for the given coordinates.
 ///
 /// This returns the row-major order raveling.
 ///


### PR DESCRIPTION
This pull request introduces `STYLE.md` as the definitive guide for style and documentation conventions across the codebase. Specific changes include:

- Addition of `STYLE.md` to outline rules for documentation, rustdoc standards, and tensor shape notation.
- Updates to tensor shape documentation throughout modules for consistency with `STYLE.md` guidelines.
- Use of single backtick code spans for tensor shapes and emphasis on "shape-first" descriptions across rustdoc.
- General improvements to readability and consistency in rustdoc comments within the `bunsen` crate.
