### PR TITLE
[feat]: Expand index views for tensor data manipulation

### DIFF
--- a/crates/bunsen/benches/drop_block.rs
+++ b/crates/bunsen/benches/drop_block.rs
@@ -1,7 +1,7 @@
 use std::hint::black_box;
 
 use bunsen::ops::{
-    drop::drop_block::{
+    drop::{
         DropBlockOptions,
         drop_block_2d,
     },

--- a/crates/bunsen/src/burner/distribution.rs
+++ b/crates/bunsen/src/burner/distribution.rs
@@ -10,6 +10,38 @@ use burn::{
 };
 
 /// Adapter to display a [`Distribution`] in a module.
+///
+/// This exists to allow [`Distribution`] to be included in formated
+/// [`ModuleDisplay`] implementations.
+///
+/// # Example
+/// ```rust,ignore
+/// #[derive(Debug, Clone)]
+/// pub struct NoiseConfig {
+///     /// The noise distribution.
+///     pub distribution: Distribution,
+///
+///     /// The noise clip range.
+///     pub clamp: Option<ClampOp>,
+/// }
+///
+/// impl ModuleDisplay for crate::ops::noise::NoiseConfig {}
+/// impl ModuleDisplayDefault for crate::ops::noise::NoiseConfig {
+///     fn content(
+///         &self,
+///         content: Content,
+///     ) -> Option<Content> {
+///         Some(
+///             content
+///                 .add(
+///                     "distribution",
+///                     &DistributionDisplayAdapter::new(self.distribution),
+///                 )
+///                 .add("clamp", &self.clamp),
+///         )
+///     }
+/// }
+/// ```
 pub struct DistributionDisplayAdapter(Distribution);
 
 impl DistributionDisplayAdapter {

--- a/crates/bunsen/src/burner/tensor/data_view.rs
+++ b/crates/bunsen/src/burner/tensor/data_view.rs
@@ -1,6 +1,11 @@
 //! # `TensorData` View Wrappers
 
-use std::ops::Index;
+use std::ops::{
+    Deref,
+    DerefMut,
+    Index,
+    IndexMut,
+};
 
 use burn::{
     prelude::TensorData,
@@ -12,11 +17,33 @@ use burn::{
 
 use crate::zspace::ravel_dims;
 
-/// Ravel Index View for a `TensorData`.
+/// [Index] view wrapper for a [`TensorData`].
+///
+/// # Example
+/// ```rust,no_run
+/// use bunsen::burner::tensor::*;
+/// use burn::prelude::*;
+///
+/// let data = TensorData::from([[1.0, 2.0], [3.0, 4.0]]);
+/// let view: TensorDataIndexView<f64> = TensorDataIndexView::view(&data);
+///
+/// assert_eq!(view[&[0, 0]], 1.0);
+/// assert_eq!(view[&[0, 1]], 2.0);
+/// assert_eq!(view[&[1, 0]], 3.0);
+/// assert_eq!(view[&[1, 1]], 4.0);
+/// ```
 #[derive(Debug)]
 pub struct TensorDataIndexView<'a, E: Element> {
     data: &'a TensorData,
     _phantom: std::marker::PhantomData<&'a E>,
+}
+
+impl<'a, E: Element> Deref for TensorDataIndexView<'a, E> {
+    type Target = TensorData;
+
+    fn deref(&self) -> &Self::Target {
+        self.data
+    }
 }
 
 impl<'a, E: Element> TensorDataIndexView<'a, E> {
@@ -27,6 +54,14 @@ impl<'a, E: Element> TensorDataIndexView<'a, E> {
             _phantom: std::marker::PhantomData,
         }
     }
+
+    /// Ravels the dims via [`ravel_dims`] and the view's shape.
+    pub fn ravel_dims<I: AsIndex>(
+        &self,
+        dims: &[I],
+    ) -> usize {
+        ravel_dims(&self.data.shape, dims)
+    }
 }
 
 impl<'a, I: AsIndex, E: Element> Index<&[I]> for TensorDataIndexView<'a, E> {
@@ -36,6 +71,121 @@ impl<'a, I: AsIndex, E: Element> Index<&[I]> for TensorDataIndexView<'a, E> {
         &self,
         index: &[I],
     ) -> &Self::Output {
-        &self.data.as_slice::<E>().unwrap()[ravel_dims(&self.data.shape, index)]
+        let o = self.ravel_dims(index);
+        &self.data.as_slice::<E>().unwrap()[o]
+    }
+}
+
+/// Mutable [`IndexMut`] view wrapper for a [`TensorData`].
+///
+/// # Example
+/// ```rust,no_run
+/// use bunsen::burner::tensor::*;
+/// use burn::prelude::*;
+///
+/// let mut data = TensorData::from([[1.0, 2.0], [3.0, 4.0]]);
+/// let mut view: TensorDataIndexView<f64> =
+///     TensorDataIndexView::view(&mut data);
+///
+/// assert_eq!(view[&[0, 0]], 1.0);
+/// assert_eq!(view[&[0, 1]], 2.0);
+/// assert_eq!(view[&[1, 0]], 3.0);
+/// assert_eq!(view[&[1, 1]], 4.0);
+/// ```
+#[derive(Debug)]
+pub struct TensorDataIndexMutView<'a, E: Element> {
+    data: &'a mut TensorData,
+    _phantom: std::marker::PhantomData<&'a E>,
+}
+
+impl<'a, E: Element> Deref for TensorDataIndexMutView<'a, E> {
+    type Target = TensorData;
+
+    fn deref(&self) -> &Self::Target {
+        self.data
+    }
+}
+
+impl<'a, E: Element> DerefMut for TensorDataIndexMutView<'a, E> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.data
+    }
+}
+
+impl<'a, E: Element> TensorDataIndexMutView<'a, E> {
+    /// Returns an indexed view of the data.
+    pub fn view(data: &'a mut TensorData) -> TensorDataIndexMutView<'a, E> {
+        TensorDataIndexMutView {
+            data,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Ravels the dims via [`ravel_dims`] and the view's shape.
+    pub fn ravel_dims<I: AsIndex>(
+        &self,
+        dims: &[I],
+    ) -> usize {
+        ravel_dims(&self.data.shape, dims)
+    }
+}
+
+impl<'a, I: AsIndex, E: Element> Index<&[I]> for TensorDataIndexMutView<'a, E> {
+    type Output = E;
+
+    fn index(
+        &self,
+        index: &[I],
+    ) -> &Self::Output {
+        let o = self.ravel_dims(index);
+        &self.data.as_slice::<E>().unwrap()[o]
+    }
+}
+
+impl<'a, I: AsIndex, E: Element> IndexMut<&[I]> for TensorDataIndexMutView<'a, E> {
+    fn index_mut(
+        &mut self,
+        index: &[I],
+    ) -> &mut Self::Output {
+        let o = self.ravel_dims(index);
+        &mut self.data.as_mut_slice::<E>().unwrap()[o]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tensor_data_index_view() {
+        let data = TensorData::from([[1.0, 2.0], [3.0, 4.0]]);
+        let view: TensorDataIndexView<f64> = TensorDataIndexView::view(&data);
+
+        // Deref
+        assert_eq!(&data.shape, &view.shape);
+
+        assert_eq!(view[&[0, 0]], 1.0);
+        assert_eq!(view[&[0, 1]], 2.0);
+        assert_eq!(view[&[1, 0]], 3.0);
+        assert_eq!(view[&[1, 1]], 4.0);
+    }
+
+    #[test]
+    fn test_tensor_data_index_mut_view() {
+        let mut data = TensorData::from([[1.0, 2.0], [3.0, 4.0]]);
+        let shape = data.shape.clone();
+
+        let mut view: TensorDataIndexMutView<f64> = TensorDataIndexMutView::view(&mut data);
+
+        // Deref
+        assert_eq!(&view.shape, &shape);
+
+        assert_eq!(view[&[0, 0]], 1.0);
+        assert_eq!(view[&[0, 1]], 2.0);
+        assert_eq!(view[&[1, 0]], 3.0);
+        assert_eq!(view[&[1, 1]], 4.0);
+
+        view[&[0, 0]] = 10.0;
+        assert_eq!(view[&[0, 0]], 10.0);
     }
 }

--- a/crates/bunsen/src/kits/mod.rs
+++ b/crates/bunsen/src/kits/mod.rs
@@ -19,6 +19,8 @@
 //!   compact GPT suitable for experimentation and fine-tuning.
 //! - [`sims`] &mdash; Iterative tensor simulations. Currently includes Conway's
 //!   Game of Life in 2D and 3D, and a D2Q9 lattice-Boltzmann fluid solver.
+//! - [`speech`] &mdash; Full speech recognition models. Currently includes
+//!   `Whisper` and `Hubert`.
 //!
 //! ## Stability
 //!


### PR DESCRIPTION
This pull request introduces enhancements to tensor indexing capabilities:
- Expanded `TensorDataIndexView` with additional functionality, documentation, and tests.
- Added `TensorDataIndexMutView` for mutable tensor index operations.
- Included implementations for `Deref` and `ravel_dims`.
- Performed general cleanup of related documentation.