### PR TITLE
feat[README]: Restructure README files for better clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,27 +15,49 @@ community standard library for extending the [burn](https://burn.dev) tensor lib
 
 Read the [bunsen book](https://zspacelabs.ai/bunsen/book)
 
-# Components
+# Crates
 
-### Burn Extensions
+## Public / API Crates
 
-* `bunsen::burner` - this is a library of `burn::module::Module` lifecycle
-  components which extend the current functionality of burn.
-* `bunsen::contracts` - this is a library of runtime tensor-shape contracts.
+* [`bunsen-firehose`](crates/bunsen-firehose) — a columnar dataloader /
+  processing pipeline, with a burn batcher bridge.
 
-### Component Libraries
+## Utility Crates
 
-* `bunsen::blocks` - this is a library of `burn::module::Module` components.
-  This includes simple inner layers, recurrent utility blocks.
-* `bunsen::kit` - this is a library complete modules and simulators.
-* `bunsen::ops` - this is a library `burn::tensor::Tensor` operations.
+* [`bunsen-contracts-macros`](crates/bunsen-contracts-macros) — the
+  `shape_contract![]` proc-macro backing `bunsen`'s runtime tensor-shape
+  contracts.
 
-### App and Testing Support Libs
+## Experimental Crates
 
-* `bunsen::errors` - this is a library of error types and tooling.
-* `bunsen::support` - this is a library of support functions for bunsen, including
-  testing tooling which may be useful for clients.
-* `bunsen::zspace` - this is a library of z-space / index utilities.
+These represent complex-interface + work-in-progress, unstable interface
+extensions to `bunsen`; particulary those which incur large dependencies
+or are not yet ready for general consumption.
+
+* [`bunsen-firehose-image`](crates/bunsen-firehose-image) — image loading,
+  augmentation, and tensor-conversion operators for `bunsen-firehose`.
+* [`bunsen`](crates/bunsen) — the main "batteries included" library extending
+  burn: model blocks, kits, ops, contracts, and support tooling.
+* [`bunsen-preview-chat-dataloader`](crates/bunsen-preview-chat-dataloader) —
+  *(preview)* an Arrow-backed chat dataloader with tokenization for LLM
+  training.
+
+# Examples
+
+The `bunsen` repo includes a number of complex demos. The goal of the demos is to showcase the capabilities of the
+library; while also collecting a working edge of problems which could and should be improved by further development.
+
+See [`examples/`](examples/) for the full index. At a glance:
+
+* [`conway_benchmark`](examples/conway_benchmark) — headless Game of Life (2D/3D) throughput benchmark.
+* [`conway_vis`](examples/conway_vis) — real-time OpenGL Game of Life visualization.
+* [`lbm2d_vis`](examples/lbm2d_vis) — real-time 2D Lattice Boltzmann fluid-flow visualization.
+* [`resnet_finetune`](examples/resnet_finetune) — fine-tune a pretrained ResNet with model surgery.
+* [`resnet_tiny`](examples/resnet_tiny) — train a ResNet from scratch on CINIC-10 via a firehose pipeline.
+* [`swin_tiny`](examples/swin_tiny) — train a Swin Transformer V2 Tiny on CINIC-10.
+* [`train-chat`](examples/train-chat) — train a NanoChat-style GPT with per-group Muon/AdamW optimizers.
+* [`whisper-dev`](examples/whisper-dev) — import an OpenAI Whisper model from a PyTorch checkpoint.
+* [`zsl-data-cache`](examples/zsl-data-cache) — nanochat dataset shard download/disk cache (+ `pull_shards` CLI).
 
 # Motivation
 
@@ -74,11 +96,6 @@ yet.
   arguments/setup
   machinery
   could be shared.
-
-# Examples
-
-The `bunsen` repo includes a number of complex demos. The goal of the demos is to showcase the capabilities of the
-library; while also collecting a working edge of problems which could and should be improved by further development.
 
 # License
 

--- a/crates/bunsen/Cargo.toml
+++ b/crates/bunsen/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "bunsen"
-readme = "../../README.md"
 edition.workspace = true
 
 authors.workspace = true

--- a/crates/bunsen/README.md
+++ b/crates/bunsen/README.md
@@ -1,0 +1,53 @@
+# Bunsen
+
+*by [ZSpaceLabs](https://zspacelabs.ai)*
+
+[![Crates.io Version](https://img.shields.io/crates/v/bunsen)](https://crates.io/crates/bunsen)
+[![Documentation](https://img.shields.io/docsrs/bunsen)](https://docs.rs/bunsen/latest/bunsen/)
+[![license](https://shields.io/badge/license-MIT%2FApache--2.0-blue)](#license)
+[![Discord](https://img.shields.io/discord/1475229838754316502?label=discord)](https://discord.gg/vBgXHWCeah)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/zspacelabs/bunsen)
+
+`bunsen` aims to be a "batteries included" complementary
+community standard library for extending the [burn](https://burn.dev) tensor library.
+
+# Book
+
+Read the [bunsen book](https://zspacelabs.ai/bunsen/book)
+
+## Organization
+
+### Burn Extensions
+
+* `bunsen::burner` - this is a library of `burn::module::Module` lifecycle
+  components that extend the current functionality of burn.
+    * `bunsen::burner::module::reflection` has powerful tools for dynamic `burn::module::Module` reflection.
+    * `bunsen::burner::optim` has parameter-group optimizer extensions.
+* `contracts` - this is a library of runtime tensor-shape contracts.
+
+### Component Libraries
+
+* `blocks` - this is a library of `burn::module::Module` components.
+  This includes simple inner layers, recurrent utility blocks, and entire
+  model families.
+* `ops` - this is a library `burn::tensor::Tensor` operations.
+* `kits` - this is a library of full models and simulation kits.
+
+### App and Testing Support Libs
+
+* `errors` - this is a library of error types and tooling.
+* `support` - this is a library of support functions for bunsen, including
+  testing tooling which may be useful for clients.
+* `zspace` - this is a library of z-space / index utilities.
+
+# Examples
+
+The `bunsen` repo includes a number of complex demos. The goal of the demos is to showcase the capabilities of the
+library; while also collecting a working edge of problems which could and should be improved by further development.
+
+See [`examples/`](https://github.io/zspacelabs/bunsen/tree/main/examples/) for the full index.
+
+# License
+
+`bunsen` is distributed under the terms of both the MIT license and the Apache License
+(Version 2.0).

--- a/crates/bunsen/src/lib.rs
+++ b/crates/bunsen/src/lib.rs
@@ -5,27 +5,7 @@
 //! `bunsen` aims to be a "batteries included" complementary
 //! community standard library for extending the [burn](https://burn.dev) tensor library.
 //!
-//! # Motivation
-//!
-//! This library is a synthesis of the utility and extension work that
-//! I've been accumulating in:
-//!
-//! * <https://github.com/zspacelabs/wordchipper>
-//! * <https://github.com/zspacelabs/bimm>
-//! * <https://github.com/zspacelabs/bimm-contracts>
-//! * <https://github.com/zspacelabs/zsl-chat>
-//! * <https://github.com/crutcher/clockmill>
-//!
-//! This library is a work in progress, and I'm working to fold the various
-//! utilities and support code from these projects into a single place; where we
-//! can closely track the burn release cycle, and minimize the dependency-hell
-//! churn problem for writing extensions.
-//!
-//! I plan on continuing to work on this library, and recruit community
-//! involvement for landing and publishing new operators and blocks in a place
-//! we can lock down their testings and documentation.
-//!
-//! # Organization
+//! ## Organization
 //!
 //! ### Burn Extensions
 //!
@@ -43,10 +23,6 @@
 //!   model families.
 //! * [`ops`] - this is a library [`burn::tensor::Tensor`] operations.
 //! * [`kits`] - this is a library of full models and simulation kits.
-//!   * [`sims`](`kits::sims`) - this is a library of simulation kits, currently
-//!     including "Conways Game of Life" and a 2D "LBM"."
-//!   * [`gpts`](`kits::gpts`) - GPT/Transformer models.
-//!   * [`bimm`](`kits::bimm`) - Image models.
 //!
 //! ### App and Testing Support Libs
 //!
@@ -54,29 +30,6 @@
 //! * [`support`] - this is a library of support functions for bunsen, including
 //!   testing tooling which may be useful for clients.
 //! * [`zspace`] - this is a library of z-space / index utilities.
-//!
-//! # Future Components
-//!
-//! The base libraries have significant features which haven't been polished and
-//! stabilized for bunsen yet.
-//!
-//! * weight/data download disk cache - there are several implementations of
-//!   this in my codebase so far, the most robust is probably in the
-//!   `wordchipper` code.
-//! * shard fetching - being able to bind a family of shards to URL template +
-//!   range pattern; with information on the target format; and wire that
-//!   smoothly into the download and cache layer. this is also currently in some
-//!   of the LLM/chat codebases.
-//! * LLM `DataLoader` - a high-performance burn data loader for LLM models,
-//!   built on parquet/arrow; and `wordchipper`. This is currently in the `chat`
-//!   codebase.
-//! * Data transform pipeline - I did a pretty solid pass over an in-memory data
-//!   transform pipeline for images, called `bunsen-firehose`; and it is still
-//!   in the `bimm` codebase. Something like it is needed to train image models.
-//! * `clap` tooling - I've built a lot of burn-related clap tools, and I'm
-//!   pretty sure some of the arguments/setup machinery could be shared.
-//! * the rest of the `bimm` models.
-//! * the `bimm` and `chat` training demos.
 //!
 //! ## Crate Features
 #![doc = document_features::document_features!()]

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,89 @@
+# Bunsen Examples
+
+This directory collects complex, runnable demos for `bunsen`. The goal is to
+showcase the capabilities of the library — across simulators, vision models,
+language-model training, data loading, and weight import — while also surfacing
+a working edge of problems that further development should improve.
+
+Each example has its own `README.md` with a full description and run
+instructions. The overview below summarizes what each one does and which bunsen
+features it exercises.
+
+### Example: conway_benchmark
+
+Headless throughput benchmark for Conway's Game of Life (2D and 3D), reporting
+`steps/sec` for a chosen backend and grid size.
+
+- **Bunsen coverage:** `kits::sims::conway::life2d` / `life3d` simulators on
+  backend-generic Burn tensors.
+
+### Example: conway_vis
+
+Real-time OpenGL visualization of Conway's Game of Life, with the automaton
+running on a worker thread and frames streamed to a `piston` window.
+
+- **Bunsen coverage:** `kits::sims::conway::life2d`,
+  `support::validators::parse_grid_shape`, `zspace::ravel_dims`.
+
+### Example: lbm2d_vis
+
+Real-time 2D Lattice Boltzmann (D2Q9) fluid simulation with an OpenGL flow-field
+visualization and mass-conserving source/outflow forcing.
+
+- **Bunsen coverage:** `kits::sims::lbm::d2q9` (solver, `LbmTables`,
+  `macroscopic_momentum`), `burner::tensor::TensorDataIndexView`,
+  `support::validators::parse_grid_shape`.
+
+### Example: resnet_finetune
+
+Fine-tunes a pretrained ImageNet ResNet for multi-label classification, with
+model surgery (activation swap, DropBlock/stochastic depth, layer freezing,
+cautious weight decay).
+
+- **Bunsen coverage:** `kits::bimm::resnet` (model, `PREFAB_RESNET_MAP`,
+  `ResNetContractConfig`), `burner::module` (`ModuleInit`, `DTypeMapper`),
+  `data::cache::BunsenDiskCache`.
+
+### Example: resnet_tiny
+
+Trains a ResNet from scratch on CINIC-10 using a bunsen-firehose image pipeline.
+
+- **Bunsen coverage:** `kits::bimm::resnet`, `burner::module`,
+  `data::cache::BunsenDiskCache`, plus `bunsen-firehose` /
+  `bunsen-firehose-image` data loading and augmentation.
+
+### Example: swin_tiny
+
+Trains a Swin Transformer V2 Tiny on CINIC-10 with DropBlock regularization,
+sharing the firehose image pipeline with `resnet_tiny`.
+
+- **Bunsen coverage:** `kits::bimm::swin::v2`,
+  `blocks::images::drop::drop_block::DropBlock2d`, `burner::module::ModuleInit`,
+  `errors`, plus `bunsen-firehose` / `bunsen-firehose-image`.
+
+### Example: train-chat
+
+Trains a NanoChat-style GPT on the fineweb-edu corpus, using per-group
+optimizers (Muon for matrices, AdamW for embeddings/head/scalars) selected via
+module-tree reflection.
+
+- **Bunsen coverage:** `kits::gpts::nanochat`,
+  `burner::module::reflection::XmlModuleTree`, `burner::optim`
+  (`GroupOptimizerAdaptor2`, `OptimizerGroup`),
+  `bunsen-preview-chat-dataloader`, `zsl-data-cache`.
+
+### Example: whisper-dev
+
+Development utility that imports an OpenAI Whisper model from a PyTorch
+checkpoint and prints the inferred config.
+
+- **Bunsen coverage:** `kits::speech::whisper::pretrained::PytorchWhisperScanner`.
+
+### Example: zsl-data-cache
+
+Reusable on-disk shard download/cache for the nanochat (fineweb) dataset,
+consumed by `train-chat`; includes a `pull_shards` CLI.
+
+- **Bunsen coverage:** support library for bunsen training examples
+  (`DatasetCacheConfig`, `DatasetSource`), built on Burn `Config` and
+  `parquet`/`arrow`.

--- a/examples/conway_benchmark/README.md
+++ b/examples/conway_benchmark/README.md
@@ -1,0 +1,34 @@
+# conway_benchmark example
+
+A headless throughput benchmark for Conway's Game of Life implemented as a
+GPU-tensor cellular automaton. It seeds a random grid, runs a fixed number of
+steps (with a warmup fraction discounted from the timing), and reports the
+sustained `steps/sec` for the selected backend. Both the 2D and 3D life rules
+can be benchmarked, across grids of arbitrary size.
+
+This is useful for comparing backend/device performance and for measuring the
+cost of the tensor kernels behind the simulation kits.
+
+## Bunsen features exercised
+
+- `bunsen::kits::sims::conway::life2d` — the `ConwayLife2DConfig` / `ConwayLife2DState`
+  2D life simulator (`init`, `fuzz`, `step`), built entirely on Burn tensors.
+- `bunsen::kits::sims::conway::life3d` — the `ConwayLife3DConfig` / `ConwayLife3DState`
+  3D simulator with configurable `LifeRules`.
+
+It demonstrates that the `kits::sims` simulators are backend-generic and run on
+any Burn backend (CPU or GPU).
+
+## Running the Example
+
+Select `BACKEND` from:
+
+* `wgpu` - web-gpu backend.
+* `cuda` - nvidia backend.
+* `metal` - apple backend.
+* `flex` - cpu backend.
+
+```bash
+$ cargo run --release -p conway_benchmark --features BACKEND -- \
+  --steps 1000 --dims 2 --grid-size 100 --progress
+```

--- a/examples/conway_vis/README.md
+++ b/examples/conway_vis/README.md
@@ -1,15 +1,34 @@
 # Conway's Game of Life
 
-This example demonstrates a visualization of Conway's Game of Life, a cellular automaton devised by mathematician John
-Conway. The simulation is rendered using the `conway` crate and visualized with `wgpu`.
+This example demonstrates a real-time visualization of Conway's Game of Life, a
+cellular automaton devised by mathematician John Conway. The simulation runs on
+a background thread as a GPU-tensor automaton, while the main thread renders the
+latest published frame in an OpenGL window (via `piston` / `opengl_graphics`).
+The grid is periodically re-seeded with a small amount of noise to keep the
+field lively, and most parameters (grid shape, density, noise, FPS, ticks/sec,
+zoom, opacity) are configurable from the CLI.
+
+## Bunsen features exercised
+
+- `bunsen::kits::sims::conway::life2d` — the `ConwayLife2DConfig` /
+  `ConwayLife2DState` 2D life simulator (`init`, `fuzz`, `step`).
+- `bunsen::support::validators::parse_grid_shape` — a `clap` value-parser that
+  accepts either `HEIGHT,WIDTH` or a single `SIZE`.
+- `bunsen::zspace::ravel_dims` — flattens 2D grid coordinates into a linear
+  index when reading back the published frame data.
+
+It demonstrates running a backend-generic bunsen simulator on a worker thread
+and streaming its `TensorData` out for display.
+
+## Running the Example
 
 Select `BACKEND` from:
 
-* `wpgu` - web-gpu backend.
+* `wgpu` - web-gpu backend.
 * `cuda` - nvidia backend.
 * `metal` - apple backend.
 * `flex` - cpu backend.
 
 ```bash
-$ cargo run --release -p conwawy_vis --features BACKEND
+$ cargo run --release -p conway_vis --features BACKEND
 ```

--- a/examples/lbm2d_vis/README.md
+++ b/examples/lbm2d_vis/README.md
@@ -1,8 +1,33 @@
 # Lattice Boltzmann 2D Demo
 
+This example runs a 2D fluid simulation using the Lattice Boltzmann method on a
+D2Q9 lattice and visualizes the resulting flow field in real time. The solver
+steps on a background thread (streaming + BGK collision with a configurable
+relaxation `tau`, solid-wall masks, and a periodic source/outflow forcing),
+while the main thread renders the macroscopic momentum field as a colored grid
+in an OpenGL window (`piston` / `opengl_graphics`). Mass is conserved by
+tracking and re-injecting drift.
+
+## Bunsen features exercised
+
+- `bunsen::kits::sims::lbm::d2q9` — the D2Q9 solver: `LBMD2Q9Config` /
+  `LBMD2Q9State` (`init`, `advance_step`, `solid_mask`, mass-conservation
+  helpers), `RelaxationParam`, the `LbmTables` lattice constants, the
+  `SPEED_OF_SOUND` constant, and `macroscopic_momentum` for deriving velocity
+  from the distribution tensor.
+- `bunsen::burner::tensor::TensorDataIndexView` — ergonomic multi-dimensional
+  indexing into `TensorData` (`view`, `[&[y, x, c]]`) used by the renderer.
+- `bunsen::support::validators::parse_grid_shape` — `clap` value-parser for
+  `HEIGHT,WIDTH` or a single `SIZE`.
+
+It demonstrates a more involved physics kit driven through Burn tensor slicing
+(`slice_fill`, `slice_assign`) and dtype casting.
+
+## Running the Example
+
 Select `BACKEND` from:
 
-* `wpgu` - web-gpu backend.
+* `wgpu` - web-gpu backend.
 * `cuda` - nvidia backend.
 * `metal` - apple backend.
 * `flex` - cpu backend.

--- a/examples/resnet_finetune/README.md
+++ b/examples/resnet_finetune/README.md
@@ -1,7 +1,31 @@
 # resnet-finetune example
 
-The dataload on this example is base on the tracel-ai models repository:
+This example fine-tunes a pretrained ImageNet ResNet for multi-label image
+classification. It downloads pretrained weights and a sample fine-tune dataset,
+rebuilds the classifier head, and trains with the Burn `Learner` (gradient
+accumulation, label smoothing, a multi-label Hamming-score metric, and
+early-stopping). It also showcases bunsen's model-surgery options: swapping the
+network's activation (e.g. LeakyReLU / GELU), enabling DropBlock / stochastic
+depth regularization, optionally freezing layers, and cautious weight decay.
+Running with `--help` (or with no dataset present) will also list the available
+pretrained ResNet variants.
+
+The data loading in this example is based on the tracel-ai models repository:
 https://github.com/tracel-ai/models/blob/main/resnet-burn/examples/finetune/examples/finetune.rs
+
+## Bunsen features exercised
+
+- `bunsen::kits::bimm::resnet` — the bimm `ResNet` model, the
+  `PREFAB_RESNET_MAP` registry of pretrained variants, and `ResNetContractConfig`
+  shape contracts.
+- `bunsen::burner::module` — `ModuleInit` for building/initializing the module
+  and `DTypeMapper` for dtype remapping during load.
+- `bunsen::data::cache::BunsenDiskCache` — on-disk caching of downloaded model
+  weights and dataset artifacts.
+
+It demonstrates pretrained-weight loading plus post-hoc module rewriting
+(activation replacement, regularization injection, layer freezing) on a bimm
+backbone.
 
 ## Running the Example
 

--- a/examples/resnet_tiny/README.md
+++ b/examples/resnet_tiny/README.md
@@ -1,7 +1,28 @@
 # resnet_tiny example
 
-This example shows how to train a basic ResNet model
-for image classification.
+This example trains a ResNet image classifier from scratch on the CINIC-10
+dataset (a CIFAR-10-style 10-class image set). It scans an on-disk image folder,
+streams batches through a bunsen-firehose data pipeline with on-the-fly image
+decoding, resizing, tensor conversion, and randomized augmentation (horizontal
+flip), and trains with the Burn `Learner`. It is the lighter-weight companion to
+the `swin_tiny` example, sharing the same data-loading machinery.
+
+## Bunsen features exercised
+
+- `bunsen::kits::bimm::resnet` — the bimm `ResNet` model and `PREFAB_RESNET_MAP`
+  registry.
+- `bunsen::burner::module` — `ModuleInit` / `DTypeMapper` for module init and
+  dtype mapping.
+- `bunsen::data::cache::BunsenDiskCache` — on-disk artifact caching.
+- `bunsen-firehose` — the columnar batch data engine: `FirehoseTableSchema` /
+  `ColumnSchema`, row readers/writers, path scanning, and the Burn
+  `FirehoseExecutorBatcher` bridge.
+- `bunsen-firehose-image` — image loading/augmentation operators
+  (`ImageLoader`, `ResizeSpec`, `HorizontalFlipStage`, `WithProbStage`) and
+  `ImageToTensorData` / `stack_tensor_data_column` Burn conversion helpers.
+
+It demonstrates wiring a bunsen-firehose image pipeline into a Burn training
+loop.
 
 ## Installing the Dataset
 

--- a/examples/swin_tiny/README.md
+++ b/examples/swin_tiny/README.md
@@ -1,6 +1,28 @@
 # swin_tiny example
 
-This example shows how to use a Swin Transformer V2 Tiny model for image classification.
+This example trains a Swin Transformer V2 Tiny model for image classification on
+the CINIC-10 dataset. Like `resnet_tiny`, it scans an on-disk image folder and
+streams batches through a bunsen-firehose pipeline (decode, resize, tensor
+conversion, randomized horizontal-flip augmentation), then trains the
+hierarchical windowed-attention transformer with the Burn `Learner`. It
+additionally applies DropBlock regularization to the model.
+
+## Bunsen features exercised
+
+- `bunsen::kits::bimm::swin::v2` — the bimm `SwinTransformerV2` model with
+  `SwinTransformerV2Config` / `LayerConfig`.
+- `bunsen::blocks::images::drop::drop_block` — the `DropBlock2d` /
+  `DropBlock2dConfig` structured-dropout regularizer.
+- `bunsen::burner::module::ModuleInit` — module initialization.
+- `bunsen::errors` — `BunsenResult` and the `WithOkOrPanic` error helpers.
+- `bunsen-firehose` — the columnar batch data engine (`FirehoseTableSchema`,
+  row readers/writers, path scanning, `FirehoseExecutorBatcher`).
+- `bunsen-firehose-image` — image loading/augmentation operators
+  (`ImageLoader`, `ResizeSpec`, `HorizontalFlipStage`, `WithProbStage`) and
+  Burn tensor-conversion helpers.
+
+It demonstrates assembling a transformer backbone plus regularization blocks fed
+by a bunsen-firehose image pipeline.
 
 ## Installing the Dataset
 

--- a/examples/train-chat/README.md
+++ b/examples/train-chat/README.md
@@ -1,6 +1,39 @@
-# train
+# train-chat example
 
-```terminaloutput
-$ cargo run --release -p train -- \
-  --dataset-dir ~/Data/nanochat/dataset/ --shards 0..10 --cautious-weight-decay --weight-decay 0.02 
+This example trains a NanoChat-style GPT language model from scratch on the
+karpathy/nanochat (`fineweb-edu-100b-shuffle`) corpus. It loads a pretrained
+tokenizer vocabulary, lazily downloads and caches dataset shards, streams packed
+token blocks through a chat data loader, and trains with the Burn `Learner`. Its
+defining feature is a per-parameter-group optimizer setup that mirrors nanochat:
+the model's 2D matrix weights are optimized with Muon while embeddings, the LM
+head, and remaining scalar parameters use separately-tuned AdamW groups, with a
+linear learning-rate warmup.
+
+## Bunsen features exercised
+
+- `bunsen::kits::gpts::nanochat` — the `NanoChatGpt` model with
+  `NanoChatGptConfig` / `NanoChatGptMeta`.
+- `bunsen::burner::module::reflection::XmlModuleTree` — reflect over the module
+  tree and select parameters by XPath-like queries (`select_params`,
+  `to_param_ids`) to build optimizer groups.
+- `bunsen::burner::optim` — `GroupOptimizerAdaptor2` and `OptimizerGroup` for
+  composing multiple optimizers (Muon + AdamW) with per-group learning-rate
+  selectors over disjoint parameter sets.
+- `bunsen::public::hashbrown` — re-exported `HashSet` / `HashMap`.
+- `bunsen-preview-chat-dataloader` — the `ChatDataLoader` plus dense
+  token-block batching options (`DenseTokenBlocksOptions`,
+  `TokenBatchIteratorOptions`).
+- `zsl-data-cache` — the nanochat shard download/disk cache (see the
+  [`zsl-data-cache`](../zsl-data-cache) example).
+
+It demonstrates bunsen's reflection-driven optimizer-group machinery, the most
+advanced training-configuration feature in the example set.
+
+## Running the Example
+
+First fetch some dataset shards (see the `zsl-data-cache` example), then train:
+
+```bash
+$ cargo run --release -p train-chat -- \
+  --dataset-dir ~/Data/nanochat/dataset/ --shards 0..10 --weight-decay 0.02
 ```

--- a/examples/whisper-dev/README.md
+++ b/examples/whisper-dev/README.md
@@ -1,0 +1,27 @@
+# whisper-dev example
+
+A small development utility for importing OpenAI Whisper speech-to-text models
+from PyTorch checkpoints into Burn. It loads a `model_state_dict` (or a
+caller-specified top-level key) from a `.pt`/`.pth` file, reconstructs the
+matching Whisper module and its configuration, and prints the inferred config.
+
+This is primarily a scaffold for exercising and debugging the PyTorch weight
+scanner against real Whisper checkpoints.
+
+## Bunsen features exercised
+
+- `bunsen::kits::speech::whisper::pretrained::PytorchWhisperScanner` — scans a
+  PyTorch state dict, infers the Whisper architecture/config, and materializes a
+  Burn module with the loaded weights (`with_top_level_key`, `load`).
+
+It demonstrates bunsen's pretrained-weight import path for speech models layered
+on top of `burn-store`'s PyTorch loader.
+
+## Running the Example
+
+Select `BACKEND` from `cuda`, `metal`, `wgpu`, or `flex` (default: `flex`):
+
+```bash
+$ cargo run --release -p whisper-dev --features BACKEND -- \
+  --source /path/to/whisper.pt
+```

--- a/examples/zsl-data-cache/README.md
+++ b/examples/zsl-data-cache/README.md
@@ -1,0 +1,28 @@
+# zsl-data-cache example
+
+A reusable on-disk dataset cache for the karpathy/nanochat
+(`fineweb-edu-100b-shuffle`) training corpus. It models the upstream dataset as
+a family of numbered parquet shards, downloads requested shards on demand,
+caches them locally, and exposes a parquet `RecordBatch` reader for training
+loops. The `train-chat` example consumes this crate to feed its data loader.
+
+The bundled `pull_shards` example binary is a small CLI that pre-fetches a range
+of shards into a cache directory.
+
+## Bunsen features exercised
+
+This crate is a support library rather than a bunsen API showcase: it provides
+the shard-cache plumbing (`DatasetCacheConfig`, `DatasetSource`) that backs
+bunsen-based training examples. It builds on Burn's `Config` derive for its
+configuration types and on `parquet`/`arrow` for shard reading, and demonstrates
+the download-and-disk-cache pattern that bunsen aims to fold into a first-class
+component (see the "Future Components" section of the top-level README).
+
+## Running the Example
+
+Pull a range of shards (each shard is ~90MB):
+
+```bash
+$ cargo run --release -p pull_shards -- \
+  --dataset-dir /media/data/nanochat/dataset --shards ..8
+```


### PR DESCRIPTION
Reorganized and improved the structure of README files in the project:
- Added a README per example under respective directories.
- Created an example/README.md index for summarizing all available examples.
- Split the project-level README and bunsen crate README for distinct purposes.
- Cleaned up and revised the content in both README files for better readability and clarity.