### PR TITLE
chore: release v0.22.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bunsen"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "bunsen",
  "bunsen-contracts-macros",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-contracts-macros"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-firehose"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "burn",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-firehose-image"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "bunsen",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-preview-chat-dataloader"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "arrow",
  "burn",
@@ -10855,7 +10855,7 @@ dependencies = [
 
 [[package]]
 name = "whisper-dev"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "bunsen",
  "burn",
@@ -12034,7 +12034,7 @@ dependencies = [
 
 [[package]]
 name = "zsl-data-cache"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "burn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 edition = "2024"
 rust-version = "1.94.1"
-version = "0.22.1"
+version = "0.22.2"
 repository = "https://github.com/zspacelabs/bunsen"
 license = "MIT or Apache-2.0"
 

--- a/crates/bunsen-firehose-image/Cargo.toml
+++ b/crates/bunsen-firehose-image/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [dependencies]
 burn = { workspace = true, features = ["dataset", "vision", "autotune"] }
-bunsen-firehose = { version = "0.22.1", path = "../bunsen-firehose" }
+bunsen-firehose = { version = "0.22.2", path = "../bunsen-firehose" }
 
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/bunsen/CHANGELOG.md
+++ b/crates/bunsen/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.2](https://github.com/zspacelabs/bunsen/compare/bunsen-v0.22.1...bunsen-v0.22.2) - 2026-06-06
+
+### Fixed
+
+- fix a README link. ([#74](https://github.com/zspacelabs/bunsen/pull/74))
+
 ## [0.22.1](https://github.com/zspacelabs/bunsen/compare/bunsen-v0.22.0...bunsen-v0.22.1) - 2026-06-05
 
 ### Added

--- a/crates/bunsen/Cargo.toml
+++ b/crates/bunsen/Cargo.toml
@@ -107,7 +107,7 @@ flex = ["burn/flex"]
 
 
 [dependencies]
-bunsen-contracts-macros = { version = "0.22.1", path = "../bunsen-contracts-macros" }
+bunsen-contracts-macros = { version = "0.22.2", path = "../bunsen-contracts-macros" }
 
 burn = { workspace = true }
 burn-store = { workspace = true, optional = true }


### PR DESCRIPTION



## 🤖 New release

* `bunsen-contracts-macros`: 0.22.1 -> 0.22.2
* `bunsen`: 0.22.1 -> 0.22.2 (✓ API compatible changes)
* `bunsen-firehose`: 0.22.1 -> 0.22.2
* `bunsen-firehose-image`: 0.22.1 -> 0.22.2
* `bunsen-preview-chat-dataloader`: 0.22.1 -> 0.22.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `bunsen-contracts-macros`

<blockquote>

## [0.22.0](https://github.com/zspacelabs/bunsen/compare/bunsen-contracts-macros-v0.21.3...bunsen-contracts-macros-v0.22.0) - 2026-06-05

### Other

- crutcher/chatloader ([#38](https://github.com/zspacelabs/bunsen/pull/38))
</blockquote>

## `bunsen`

<blockquote>

## [0.22.2](https://github.com/zspacelabs/bunsen/compare/bunsen-v0.22.1...bunsen-v0.22.2) - 2026-06-06

### Fixed

- fix a README link. ([#74](https://github.com/zspacelabs/bunsen/pull/74))
</blockquote>

## `bunsen-firehose`

<blockquote>

## [0.22.0](https://github.com/zspacelabs/bunsen/compare/bunsen-firehose-v0.21.3...bunsen-firehose-v0.22.0) - 2026-06-05

### Other

- Merge sub-workspaces ([#41](https://github.com/zspacelabs/bunsen/pull/41))
- firehose docs ([#40](https://github.com/zspacelabs/bunsen/pull/40))
- crutcher/chatloader ([#38](https://github.com/zspacelabs/bunsen/pull/38))
</blockquote>

## `bunsen-firehose-image`

<blockquote>

## [0.22.0](https://github.com/zspacelabs/bunsen/compare/bunsen-firehose-image-v0.21.3...bunsen-firehose-image-v0.22.0) - 2026-06-05

### Other

- firehose docs ([#40](https://github.com/zspacelabs/bunsen/pull/40))
- crutcher/chatloader ([#38](https://github.com/zspacelabs/bunsen/pull/38))
- Partial impl of bunsen::data::cache ([#34](https://github.com/zspacelabs/bunsen/pull/34))
</blockquote>

## `bunsen-preview-chat-dataloader`

<blockquote>

## [0.22.0](https://github.com/zspacelabs/bunsen/compare/bunsen-preview-chat-dataloader-v0.21.3...bunsen-preview-chat-dataloader-v0.22.0) - 2026-06-05

### Other

- gate releases on release-PR merge; ready preview crate for publish ([#65](https://github.com/zspacelabs/bunsen/pull/65))
- Merge sub-workspaces ([#41](https://github.com/zspacelabs/bunsen/pull/41))
- Write docs for chat dataloader crate. ([#39](https://github.com/zspacelabs/bunsen/pull/39))
- crutcher/chatloader ([#38](https://github.com/zspacelabs/bunsen/pull/38))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).