### PR TITLE
chore: release v0.23.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bunsen"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "bunsen",
  "bunsen-contracts-macros",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-contracts-macros"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-firehose"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "burn",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-firehose-image"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "bunsen",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-preview-chat-dataloader"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "arrow",
  "burn",
@@ -10855,7 +10855,7 @@ dependencies = [
 
 [[package]]
 name = "whisper-dev"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "bunsen",
  "burn",
@@ -12034,7 +12034,7 @@ dependencies = [
 
 [[package]]
 name = "zsl-data-cache"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "burn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 edition = "2024"
 rust-version = "1.94.1"
-version = "0.22.2"
+version = "0.23.0"
 repository = "https://github.com/zspacelabs/bunsen"
 license = "MIT or Apache-2.0"
 

--- a/crates/bunsen-firehose-image/Cargo.toml
+++ b/crates/bunsen-firehose-image/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [dependencies]
 burn = { workspace = true, features = ["dataset", "vision", "autotune"] }
-bunsen-firehose = { version = "0.22.2", path = "../bunsen-firehose" }
+bunsen-firehose = { version = "0.23.0", path = "../bunsen-firehose" }
 
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/bunsen/CHANGELOG.md
+++ b/crates/bunsen/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0](https://github.com/zspacelabs/bunsen/compare/bunsen-v0.22.2...bunsen-v0.23.0) - 2026-06-08
+
+### Added
+
+- unify around reusable Conv blocks. ([#81](https://github.com/zspacelabs/bunsen/pull/81))
+- add `shape` deref tests and examples for TensorDataIndexView and TensorDataIndexMutView ([#76](https://github.com/zspacelabs/bunsen/pull/76))
+
+### Fixed
+
+- update module path for `unpack_shape_contract` in debug/test builds ([#80](https://github.com/zspacelabs/bunsen/pull/80))
+
+### Other
+
+- make `AudioEncoder` fields public with detailed rustdoc comments ([#82](https://github.com/zspacelabs/bunsen/pull/82))
+- add API examples showcasing key `bunsen` features ([#77](https://github.com/zspacelabs/bunsen/pull/77))
+
 ## [0.22.2](https://github.com/zspacelabs/bunsen/compare/bunsen-v0.22.1...bunsen-v0.22.2) - 2026-06-06
 
 ### Fixed

--- a/crates/bunsen/Cargo.toml
+++ b/crates/bunsen/Cargo.toml
@@ -107,7 +107,7 @@ flex = ["burn/flex"]
 
 
 [dependencies]
-bunsen-contracts-macros = { version = "0.22.2", path = "../bunsen-contracts-macros" }
+bunsen-contracts-macros = { version = "0.23.0", path = "../bunsen-contracts-macros" }
 
 burn = { workspace = true }
 burn-store = { workspace = true, optional = true }


### PR DESCRIPTION



## 🤖 New release

* `bunsen-contracts-macros`: 0.22.2 -> 0.23.0
* `bunsen`: 0.22.2 -> 0.23.0 (⚠ API breaking changes)
* `bunsen-firehose`: 0.22.2 -> 0.23.0
* `bunsen-firehose-image`: 0.22.2 -> 0.23.0
* `bunsen-preview-chat-dataloader`: 0.22.2 -> 0.23.0

### ⚠ `bunsen` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field BasicBlockRecordItem.cb1 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/basic_block.rs:300
  field BasicBlockRecordItem.cb2 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/basic_block.rs:300
  field BottleneckBlockRecordItem.cb1 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/bottleneck_block.rs:378
  field BottleneckBlockRecordItem.cb2 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/bottleneck_block.rs:378
  field BottleneckBlockRecordItem.cb3 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/bottleneck_block.rs:378
  field ResNetRecordItem.input_cb in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/resnet_model.rs:368
  field ResNetStemRecord.cb1 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/stems.rs:193
  field ResNetStemRecord.cb2 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/stems.rs:193
  field ResNetStemRecord.cb3 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/stems.rs:193
  field BasicBlock.cb1 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/basic_block.rs:309
  field BasicBlock.cb2 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/basic_block.rs:311
  field BottleneckBlockRecord.cb1 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/bottleneck_block.rs:378
  field BottleneckBlockRecord.cb2 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/bottleneck_block.rs:378
  field BottleneckBlockRecord.cb3 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/bottleneck_block.rs:378
  field BasicBlockRecord.cb1 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/basic_block.rs:300
  field BasicBlockRecord.cb2 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/basic_block.rs:300
  field ResNetStructureConfig.input_cb in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/resnet_model.rs:243
  field AudioEncoderRecord.cb1 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs:155
  field AudioEncoderRecord.cb2 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs:155
  field ResNetStem.cb1 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/stems.rs:196
  field ResNetStem.cb2 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/stems.rs:198
  field ResNetStem.cb3 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/stems.rs:200
  field BottleneckBlock.cb1 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/bottleneck_block.rs:393
  field BottleneckBlock.cb2 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/bottleneck_block.rs:395
  field BottleneckBlock.cb3 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/bottleneck_block.rs:397
  field AudioEncoderRecordItem.cb1 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs:155
  field AudioEncoderRecordItem.cb2 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs:155
  field ResNet.input_cb in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/resnet_model.rs:371
  field ResNetRecord.input_cb in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/resnet_model.rs:368
  field ResNetStemRecordItem.cb1 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/stems.rs:193
  field ResNetStemRecordItem.cb2 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/stems.rs:193
  field ResNetStemRecordItem.cb3 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/stems.rs:193
  field ResNetStemStructureConfig.cb1 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/stems.rs:171
  field ResNetStemStructureConfig.cb2 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/stems.rs:174
  field ResNetStemStructureConfig.cb3 in /tmp/.tmpAkJSi6/bunsen/crates/bunsen/src/kits/bimm/resnet/stems.rs:177

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/inherent_method_missing.ron

Failed in:
  ResNetStructureConfig::with_input_conv_norm_initializer, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/resnet_model.rs:242
  ResNetStructureConfig::with_input_act, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/resnet_model.rs:242

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/module_missing.ron

Failed in:
  mod bunsen::blocks::images::conv::conv_norm, previously in file /tmp/.tmprLrpp7/bunsen/src/blocks/images/conv/conv_norm.rs:1
  mod bunsen::blocks::images::conv::cna, previously in file /tmp/.tmprLrpp7/bunsen/src/blocks/images/conv/cna.rs:1
  mod bunsen::blocks::images::conv, previously in file /tmp/.tmprLrpp7/bunsen/src/blocks/images/conv/mod.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/struct_missing.ron

Failed in:
  struct bunsen::blocks::images::conv::cna::AbstractCNA2dConfig, previously in file /tmp/.tmprLrpp7/bunsen/src/blocks/images/conv/cna.rs:51
  struct bunsen::blocks::images::conv::conv_norm::ConvNorm2d, previously in file /tmp/.tmprLrpp7/bunsen/src/blocks/images/conv/conv_norm.rs:111
  struct bunsen::blocks::images::conv::conv_norm::ConvNorm2dRecordItem, previously in file /tmp/.tmprLrpp7/bunsen/src/blocks/images/conv/conv_norm.rs:110
  struct bunsen::blocks::images::conv::cna::CNA2dRecord, previously in file /tmp/.tmprLrpp7/bunsen/src/blocks/images/conv/cna.rs:175
  struct bunsen::blocks::images::conv::cna::CNA2d, previously in file /tmp/.tmprLrpp7/bunsen/src/blocks/images/conv/cna.rs:176
  struct bunsen::blocks::images::conv::conv_norm::ConvNorm2dConfig, previously in file /tmp/.tmprLrpp7/bunsen/src/blocks/images/conv/conv_norm.rs:49
  struct bunsen::blocks::images::conv::conv_norm::ConvNorm2dRecord, previously in file /tmp/.tmprLrpp7/bunsen/src/blocks/images/conv/conv_norm.rs:110
  struct bunsen::blocks::images::conv::cna::CNA2dRecordItem, previously in file /tmp/.tmprLrpp7/bunsen/src/blocks/images/conv/cna.rs:175
  struct bunsen::blocks::images::conv::cna::CNA2dConfig, previously in file /tmp/.tmprLrpp7/bunsen/src/blocks/images/conv/cna.rs:101

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field input_conv_norm of struct ResNet, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/resnet_model.rs:387
  field input_act of struct ResNet, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/resnet_model.rs:389
  field input_conv_norm of struct ResNetRecord, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/resnet_model.rs:384
  field input_act of struct ResNetRecord, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/resnet_model.rs:384
  field cna1 of struct ResNetStem, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/stems.rs:196
  field cna2 of struct ResNetStem, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/stems.rs:198
  field cna3 of struct ResNetStem, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/stems.rs:200
  field cna1 of struct BasicBlockRecordItem, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/basic_block.rs:300
  field cna2 of struct BasicBlockRecordItem, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/basic_block.rs:300
  field cna1 of struct BottleneckBlockRecordItem, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/bottleneck_block.rs:378
  field cna2 of struct BottleneckBlockRecordItem, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/bottleneck_block.rs:378
  field cna3 of struct BottleneckBlockRecordItem, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/bottleneck_block.rs:378
  field cna1 of struct BasicBlock, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/basic_block.rs:309
  field cna2 of struct BasicBlock, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/basic_block.rs:311
  field cna1 of struct ResNetStemRecordItem, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/stems.rs:193
  field cna2 of struct ResNetStemRecordItem, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/stems.rs:193
  field cna3 of struct ResNetStemRecordItem, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/stems.rs:193
  field cna1 of struct ResNetStemStructureConfig, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/stems.rs:171
  field cna2 of struct ResNetStemStructureConfig, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/stems.rs:174
  field cna3 of struct ResNetStemStructureConfig, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/stems.rs:177
  field input_conv_norm of struct ResNetRecordItem, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/resnet_model.rs:384
  field input_act of struct ResNetRecordItem, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/resnet_model.rs:384
  field cna1 of struct BottleneckBlockRecord, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/bottleneck_block.rs:378
  field cna2 of struct BottleneckBlockRecord, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/bottleneck_block.rs:378
  field cna3 of struct BottleneckBlockRecord, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/bottleneck_block.rs:378
  field cna1 of struct ResNetStemRecord, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/stems.rs:193
  field cna2 of struct ResNetStemRecord, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/stems.rs:193
  field cna3 of struct ResNetStemRecord, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/stems.rs:193
  field cna1 of struct BasicBlockRecord, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/basic_block.rs:300
  field cna2 of struct BasicBlockRecord, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/basic_block.rs:300
  field input_conv_norm of struct ResNetStructureConfig, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/resnet_model.rs:245
  field input_conv_norm_initializer of struct ResNetStructureConfig, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/resnet_model.rs:249
  field input_act of struct ResNetStructureConfig, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/resnet_model.rs:253
  field conv1 of struct AudioEncoderRecordItem, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs:153
  field act1 of struct AudioEncoderRecordItem, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs:153
  field conv2 of struct AudioEncoderRecordItem, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs:153
  field act2 of struct AudioEncoderRecordItem, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs:153
  field cna1 of struct BottleneckBlock, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/bottleneck_block.rs:393
  field cna2 of struct BottleneckBlock, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/bottleneck_block.rs:395
  field cna3 of struct BottleneckBlock, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/bimm/resnet/bottleneck_block.rs:397
  field conv1 of struct AudioEncoderRecord, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs:153
  field act1 of struct AudioEncoderRecord, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs:153
  field conv2 of struct AudioEncoderRecord, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs:153
  field act2 of struct AudioEncoderRecord, previously in file /tmp/.tmprLrpp7/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs:153

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/trait_missing.ron

Failed in:
  trait bunsen::blocks::images::conv::cna::CNA2dMeta, previously in file /tmp/.tmprLrpp7/bunsen/src/blocks/images/conv/cna.rs:80
  trait bunsen::blocks::images::conv::conv_norm::ConvNorm2dMeta, previously in file /tmp/.tmprLrpp7/bunsen/src/blocks/images/conv/conv_norm.rs:33
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `bunsen-contracts-macros`

<blockquote>

## [0.22.0](https://github.com/zspacelabs/bunsen/compare/bunsen-contracts-macros-v0.21.3...bunsen-contracts-macros-v0.22.0) - 2026-06-05

### Other

- crutcher/chatloader ([#38](https://github.com/zspacelabs/bunsen/pull/38))
</blockquote>

## `bunsen`

<blockquote>

## [0.23.0](https://github.com/zspacelabs/bunsen/compare/bunsen-v0.22.2...bunsen-v0.23.0) - 2026-06-08

### Added

- unify around reusable Conv blocks. ([#81](https://github.com/zspacelabs/bunsen/pull/81))
- add `shape` deref tests and examples for TensorDataIndexView and TensorDataIndexMutView ([#76](https://github.com/zspacelabs/bunsen/pull/76))

### Fixed

- update module path for `unpack_shape_contract` in debug/test builds ([#80](https://github.com/zspacelabs/bunsen/pull/80))

### Other

- make `AudioEncoder` fields public with detailed rustdoc comments ([#82](https://github.com/zspacelabs/bunsen/pull/82))
- add API examples showcasing key `bunsen` features ([#77](https://github.com/zspacelabs/bunsen/pull/77))
</blockquote>

## `bunsen-firehose`

<blockquote>

## [0.22.0](https://github.com/zspacelabs/bunsen/compare/bunsen-firehose-v0.21.3...bunsen-firehose-v0.22.0) - 2026-06-05

### Other

- Merge sub-workspaces ([#41](https://github.com/zspacelabs/bunsen/pull/41))
- firehose docs ([#40](https://github.com/zspacelabs/bunsen/pull/40))
- crutcher/chatloader ([#38](https://github.com/zspacelabs/bunsen/pull/38))
</blockquote>

## `bunsen-firehose-image`

<blockquote>

## [0.22.0](https://github.com/zspacelabs/bunsen/compare/bunsen-firehose-image-v0.21.3...bunsen-firehose-image-v0.22.0) - 2026-06-05

### Other

- firehose docs ([#40](https://github.com/zspacelabs/bunsen/pull/40))
- crutcher/chatloader ([#38](https://github.com/zspacelabs/bunsen/pull/38))
- Partial impl of bunsen::data::cache ([#34](https://github.com/zspacelabs/bunsen/pull/34))
</blockquote>

## `bunsen-preview-chat-dataloader`

<blockquote>

## [0.22.0](https://github.com/zspacelabs/bunsen/compare/bunsen-preview-chat-dataloader-v0.21.3...bunsen-preview-chat-dataloader-v0.22.0) - 2026-06-05

### Other

- gate releases on release-PR merge; ready preview crate for publish ([#65](https://github.com/zspacelabs/bunsen/pull/65))
- Merge sub-workspaces ([#41](https://github.com/zspacelabs/bunsen/pull/41))
- Write docs for chat dataloader crate. ([#39](https://github.com/zspacelabs/bunsen/pull/39))
- crutcher/chatloader ([#38](https://github.com/zspacelabs/bunsen/pull/38))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).