### PR TITLE
feat[tensor]: add `shape` deref tests and examples for TensorDataIndexView and TensorDataIndexMutView

### DIFF
--- a/crates/bunsen/src/burner/tensor/data_view.rs
+++ b/crates/bunsen/src/burner/tensor/data_view.rs
@@ -25,6 +25,7 @@ use crate::zspace::ravel_dims;
 /// use burn::prelude::*;
 ///
 /// let data = TensorData::from([[1.0, 2.0], [3.0, 4.0]]);
+/// let shape = data.shape.clone();
 /// let view: TensorDataIndexView<f64> = TensorDataIndexView::view(&data);
 ///
 /// // Deref
@@ -87,6 +88,7 @@ impl<'a, I: AsIndex, E: Element> Index<&[I]> for TensorDataIndexView<'a, E> {
 /// use burn::prelude::*;
 ///
 /// let mut data = TensorData::from([[1.0, 2.0], [3.0, 4.0]]);
+/// let shape = data.shape.clone();
 /// let mut view: TensorDataIndexView<f64> =
 ///     TensorDataIndexView::view(&mut data);
 ///

--- a/crates/bunsen/src/burner/tensor/data_view.rs
+++ b/crates/bunsen/src/burner/tensor/data_view.rs
@@ -89,8 +89,8 @@ impl<'a, I: AsIndex, E: Element> Index<&[I]> for TensorDataIndexView<'a, E> {
 ///
 /// let mut data = TensorData::from([[1.0, 2.0], [3.0, 4.0]]);
 /// let shape = data.shape.clone();
-/// let mut view: TensorDataIndexView<f64> =
-///     TensorDataIndexView::view(&mut data);
+/// let mut view: TensorDataIndexMutView<f64> =
+///     TensorDataIndexMutView::view(&mut data);
 ///
 /// // Deref
 /// assert_eq!(&view.shape, &shape);

--- a/crates/bunsen/src/burner/tensor/data_view.rs
+++ b/crates/bunsen/src/burner/tensor/data_view.rs
@@ -27,6 +27,9 @@ use crate::zspace::ravel_dims;
 /// let data = TensorData::from([[1.0, 2.0], [3.0, 4.0]]);
 /// let view: TensorDataIndexView<f64> = TensorDataIndexView::view(&data);
 ///
+/// // Deref
+/// assert_eq!(&view.shape, &shape);
+///
 /// assert_eq!(view[&[0, 0]], 1.0);
 /// assert_eq!(view[&[0, 1]], 2.0);
 /// assert_eq!(view[&[1, 0]], 3.0);
@@ -87,10 +90,16 @@ impl<'a, I: AsIndex, E: Element> Index<&[I]> for TensorDataIndexView<'a, E> {
 /// let mut view: TensorDataIndexView<f64> =
 ///     TensorDataIndexView::view(&mut data);
 ///
+/// // Deref
+/// assert_eq!(&view.shape, &shape);
+///
 /// assert_eq!(view[&[0, 0]], 1.0);
 /// assert_eq!(view[&[0, 1]], 2.0);
 /// assert_eq!(view[&[1, 0]], 3.0);
 /// assert_eq!(view[&[1, 1]], 4.0);
+///
+/// view[&[0, 0]] = 10.0;
+/// assert_eq!(view[&[0, 0]], 10.0);
 /// ```
 #[derive(Debug)]
 pub struct TensorDataIndexMutView<'a, E: Element> {


### PR DESCRIPTION
- Extended tests to validate dereferencing `shape` in `TensorDataIndexView` and `TensorDataIndexMutView`.
- Updated examples with assertions for `shape` and mutation handling.
