### PR TITLE
chore: release v0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bunsen"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "bunsen",
  "bunsen-contracts-macros",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-contracts-macros"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-firehose"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "burn",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-firehose-image"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "bunsen",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-preview-chat-dataloader"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "arrow",
  "burn",
@@ -10855,7 +10855,7 @@ dependencies = [
 
 [[package]]
 name = "whisper-dev"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "bunsen",
  "burn",
@@ -12034,7 +12034,7 @@ dependencies = [
 
 [[package]]
 name = "zsl-data-cache"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "burn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 edition = "2024"
 rust-version = "1.94.1"
-version = "0.23.0"
+version = "0.24.0"
 repository = "https://github.com/zspacelabs/bunsen"
 license = "MIT or Apache-2.0"
 

--- a/crates/bunsen-firehose-image/Cargo.toml
+++ b/crates/bunsen-firehose-image/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [dependencies]
 burn = { workspace = true, features = ["dataset", "vision", "autotune"] }
-bunsen-firehose = { version = "0.23.0", path = "../bunsen-firehose" }
+bunsen-firehose = { version = "0.24.0", path = "../bunsen-firehose" }
 
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/bunsen/CHANGELOG.md
+++ b/crates/bunsen/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0](https://github.com/zspacelabs/bunsen/compare/bunsen-v0.23.0...bunsen-v0.24.0) - 2026-06-09
+
+### Fixed
+
+- conditionally import `contracts` APIs only in debug builds ([#84](https://github.com/zspacelabs/bunsen/pull/84))
+
+### Other
+
+- crutcher/convseq ([#88](https://github.com/zspacelabs/bunsen/pull/88))
+- consolidate module organization under `blocks` directories across kits ([#87](https://github.com/zspacelabs/bunsen/pull/87))
+- remove `ResNetDownsample`, migrate to `ConvBlock2d` for downsampling ([#86](https://github.com/zspacelabs/bunsen/pull/86)) ([#86](https://github.com/zspacelabs/bunsen/pull/86))
+- replace `ResNetDownsample` with `ConvBlock2d` for residual connections ([#85](https://github.com/zspacelabs/bunsen/pull/85))
+
 ## [0.23.0](https://github.com/zspacelabs/bunsen/compare/bunsen-v0.22.2...bunsen-v0.23.0) - 2026-06-08
 
 ### Added

--- a/crates/bunsen/Cargo.toml
+++ b/crates/bunsen/Cargo.toml
@@ -107,7 +107,7 @@ flex = ["burn/flex"]
 
 
 [dependencies]
-bunsen-contracts-macros = { version = "0.23.0", path = "../bunsen-contracts-macros" }
+bunsen-contracts-macros = { version = "0.24.0", path = "../bunsen-contracts-macros" }
 
 burn = { workspace = true }
 burn-store = { workspace = true, optional = true }


### PR DESCRIPTION



## 🤖 New release

* `bunsen-contracts-macros`: 0.23.0 -> 0.24.0
* `bunsen`: 0.23.0 -> 0.24.0 (⚠ API breaking changes)
* `bunsen-firehose`: 0.23.0 -> 0.24.0
* `bunsen-firehose-image`: 0.23.0 -> 0.24.0
* `bunsen-preview-chat-dataloader`: 0.23.0 -> 0.24.0

### ⚠ `bunsen` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field AudioEncoderRecord.head in /tmp/.tmpmsh1ZN/bunsen/crates/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs:156
  field AudioEncoder.head in /tmp/.tmpmsh1ZN/bunsen/crates/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs:160
  field AudioEncoderRecordItem.head in /tmp/.tmpmsh1ZN/bunsen/crates/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs:156

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_missing.ron

Failed in:
  enum bunsen::kits::bimm::resnet::ResidualBlockRecordItem, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/residual_block.rs:288
  enum bunsen::kits::bimm::resnet::ResidualBlockStructureConfig, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/residual_block.rs:187
  enum bunsen::kits::bimm::resnet::ResidualBlockRecord, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/residual_block.rs:288
  enum bunsen::kits::bimm::resnet::ResidualBlock, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/residual_block.rs:290
  enum bunsen::kits::bimm::resnet::ResNetStemContractConfig, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/stems.rs:96

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function bunsen::kits::bimm::swin::v2::window_attention::apply_attention_mask, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/window_attention/attention_mask.rs:25
  function bunsen::kits::bimm::swin::v2::window_attention::sw_attn_mask, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/window_attention/attention_mask.rs:132
  function bunsen::kits::bimm::swin::v2::window_attention::window_index_offset_grid, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/window_attention/pos_grid.rs:30
  function bunsen::kits::bimm::swin::v2::patch_merge::collate_patches, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/patch_merge.rs:223
  function bunsen::kits::bimm::swin::v2::window_attention::window_attention_relative_position_index, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/window_attention/pos_grid.rs:143
  function bunsen::kits::bimm::swin::v2::windowing::window_partition, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/windowing.rs:30
  function bunsen::kits::bimm::swin::v2::window_attention::window_relative_offset_grid, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/window_attention/pos_grid.rs:66
  function bunsen::kits::bimm::swin::v2::patch_merge::decollate_patches, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/patch_merge.rs:271
  function bunsen::kits::bimm::swin::v2::windowing::window_reverse, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/windowing.rs:74
  function bunsen::kits::gpts::nanochat::layer_norm_mlp, previously in file /tmp/.tmpxVXi77/bunsen/src/blocks/transformers/mlp.rs:35
  function bunsen::kits::bimm::swin::v2::window_attention::window_log1p_relative_offset_grid, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/window_attention/pos_grid.rs:94

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/module_missing.ron

Failed in:
  mod bunsen::kits::bimm::swin::v2::windowing, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/windowing.rs:1
  mod bunsen::kits::bimm::swin::v2::patch_merge, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/patch_merge.rs:1
  mod bunsen::kits::bimm::swin::v2::block_sequence, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/block_sequence.rs:1
  mod bunsen::kits::bimm::swin::v2::swin_block, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/swin_block.rs:1
  mod bunsen::kits::bimm::swin::v2::window_attention, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/window_attention/mod.rs:1
  mod bunsen::kits::bimm::swin::v2::swin_model, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/swin_model.rs:1

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  BOTTLENECK_BLOCK_DEFAULT_PINCH_FACTOR in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/bottleneck_block.rs:158
  EPS in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/window_attention/attention.rs:47

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct bunsen::kits::bimm::resnet::ResNetDownsample, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/downsample.rs:209
  struct bunsen::kits::bimm::swin::v2::swin_block::ShiftedWindowTransformerBlockConfig, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/swin_block.rs:333
  struct bunsen::kits::bimm::resnet::BasicBlockRecordItem, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/basic_block.rs:300
  struct bunsen::kits::bimm::resnet::BottleneckBlockRecordItem, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/bottleneck_block.rs:378
  struct bunsen::kits::bimm::resnet::LayerBlockContractConfig, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/layer_block.rs:66
  struct bunsen::kits::bimm::swin::v2::window_attention::WindowAttention, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/window_attention/attention.rs:180
  struct bunsen::kits::bimm::swin::v2::swin_model::SwinTransformerV2Record, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/swin_model.rs:437
  struct bunsen::kits::bimm::resnet::LayerBlockStructureConfig, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/layer_block.rs:214
  struct bunsen::kits::bimm::resnet::ResNetStemRecord, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/stems.rs:193
  struct bunsen::kits::gpts::nanochat::NanoChatGptBlock, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/gpts/nanochat/block.rs:110
  struct bunsen::kits::bimm::swin::v2::window_attention::OffsetGridRelativePositionBiasConfig, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/window_attention/pos_bias.rs:55
  struct bunsen::kits::bimm::swin::v2::window_attention::OffsetGridRelativePositionBiasRecord, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/window_attention/pos_bias.rs:122
  struct bunsen::kits::gpts::nanochat::Mlp, previously in file /tmp/.tmpxVXi77/bunsen/src/blocks/transformers/mlp.rs:116
  struct bunsen::kits::bimm::swin::v2::block_sequence::StochasticDepthTransformerBlockSequence, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/block_sequence.rs:244
  struct bunsen::kits::gpts::nanochat::MlpConfig, previously in file /tmp/.tmpxVXi77/bunsen/src/blocks/transformers/mlp.rs:54
  struct bunsen::kits::bimm::resnet::BasicBlock, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/basic_block.rs:301
  struct bunsen::kits::bimm::swin::v2::patch_merge::PatchMergingConfig, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/patch_merge.rs:80
  struct bunsen::kits::bimm::resnet::BottleneckBlockConfig, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/bottleneck_block.rs:168
  struct bunsen::kits::bimm::swin::v2::swin_block::ShiftedWindowTransformerBlock, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/swin_block.rs:516
  struct bunsen::kits::bimm::resnet::ResNetDownsampleRecord, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/downsample.rs:208
  struct bunsen::kits::bimm::resnet::LayerBlock, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/layer_block.rs:343
  struct bunsen::kits::bimm::swin::v2::swin_model::SwinTransformerV2Config, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/swin_model.rs:146
  struct bunsen::kits::bimm::resnet::LayerBlockRecordItem, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/layer_block.rs:342
  struct bunsen::kits::bimm::swin::v2::swin_block::ShiftedWindowTransformerBlockRecord, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/swin_block.rs:515
  struct bunsen::kits::bimm::swin::v2::window_attention::ContinuousPositionBiasMlpRecordItem, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/window_attention/pos_bias.rs:260
  struct bunsen::kits::gpts::nanochat::NanoChatGptBlockConfig, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/gpts/nanochat/block.rs:46
  struct bunsen::kits::bimm::swin::v2::patch_merge::PatchMergingRecordItem, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/patch_merge.rs:134
  struct bunsen::kits::bimm::swin::v2::window_attention::OffsetGridRelativePositionBias, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/window_attention/pos_bias.rs:123
  struct bunsen::kits::bimm::resnet::BottleneckBlockRecord, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/bottleneck_block.rs:378
  struct bunsen::kits::gpts::nanochat::MlpRecordItem, previously in file /tmp/.tmpxVXi77/bunsen/src/blocks/transformers/mlp.rs:115
  struct bunsen::kits::bimm::resnet::BasicBlockRecord, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/basic_block.rs:300
  struct bunsen::kits::bimm::swin::v2::window_attention::ContinuousPositionBiasMlpConfig, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/window_attention/pos_bias.rs:234
  struct bunsen::kits::bimm::resnet::ResNetDownsampleRecordItem, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/downsample.rs:208
  struct bunsen::kits::bimm::resnet::BottleneckPolicyConfig, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/bottleneck_block.rs:74
  struct bunsen::kits::bimm::resnet::LayerBlockRecord, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/layer_block.rs:342
  struct bunsen::kits::bimm::swin::v2::patch_merge::PatchMerging, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/patch_merge.rs:135
  struct bunsen::kits::bimm::swin::v2::swin_block::BlockMlpRecordItem, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/swin_block.rs:133
  struct bunsen::kits::gpts::nanochat::NanoChatGptBlockRecordItem, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/gpts/nanochat/block.rs:109
  struct bunsen::kits::gpts::nanochat::MlpRecord, previously in file /tmp/.tmpxVXi77/bunsen/src/blocks/transformers/mlp.rs:115
  struct bunsen::kits::bimm::resnet::ResNetStem, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/stems.rs:194
  struct bunsen::kits::bimm::resnet::BottleneckBlock, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/bottleneck_block.rs:379
  struct bunsen::kits::bimm::swin::v2::swin_block::BlockMlpConfig, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/swin_block.rs:74
  struct bunsen::kits::bimm::swin::v2::swin_model::SwinTransformerV2RecordItem, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/swin_model.rs:437
  struct bunsen::kits::bimm::resnet::ResNetDownsampleConfig, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/downsample.rs:112
  struct bunsen::kits::bimm::resnet::ResidualBlockContractConfig, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/residual_block.rs:63
  struct bunsen::kits::bimm::swin::v2::swin_model::SwinTransformerV2, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/swin_model.rs:438
  struct bunsen::kits::bimm::swin::v2::block_sequence::StochasticDepthTransformerBlockSequenceRecordItem, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/block_sequence.rs:243
  struct bunsen::kits::bimm::swin::v2::window_attention::OffsetGridRelativePositionBiasRecordItem, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/window_attention/pos_bias.rs:122
  struct bunsen::kits::bimm::swin::v2::window_attention::WindowAttentionConfig, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/window_attention/attention.rs:140
  struct bunsen::kits::bimm::swin::v2::swin_block::BlockMlpRecord, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/swin_block.rs:133
  struct bunsen::kits::gpts::nanochat::NanoChatGptBlockRecord, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/gpts/nanochat/block.rs:109
  struct bunsen::kits::bimm::swin::v2::swin_model::SwinTransformerV2Plan, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/swin_model.rs:258
  struct bunsen::kits::bimm::swin::v2::window_attention::ContinuousPositionBiasMlp, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/window_attention/pos_bias.rs:261
  struct bunsen::kits::bimm::swin::v2::window_attention::WindowAttentionRecordItem, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/window_attention/attention.rs:179
  struct bunsen::kits::bimm::swin::v2::swin_model::LayerConfig, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/swin_model.rs:74
  struct bunsen::kits::bimm::swin::v2::block_sequence::StochasticDepthTransformerBlockSequenceRecord, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/block_sequence.rs:243
  struct bunsen::kits::bimm::swin::v2::block_sequence::StochasticDepthTransformerBlockSequenceConfig, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/block_sequence.rs:84
  struct bunsen::kits::bimm::swin::v2::window_attention::ContinuousPositionBiasMlpRecord, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/window_attention/pos_bias.rs:260
  struct bunsen::kits::bimm::swin::v2::window_attention::WindowAttentionRecord, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/window_attention/attention.rs:179
  struct bunsen::kits::bimm::swin::v2::patch_merge::PatchMergingRecord, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/patch_merge.rs:134
  struct bunsen::kits::bimm::resnet::ResNetStemRecordItem, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/stems.rs:193
  struct bunsen::kits::bimm::resnet::ResNetStemStructureConfig, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/stems.rs:169
  struct bunsen::kits::bimm::resnet::BasicBlockConfig, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/basic_block.rs:131
  struct bunsen::kits::bimm::swin::v2::swin_block::ShiftedWindowTransformerBlockRecordItem, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/swin_block.rs:515
  struct bunsen::kits::bimm::swin::v2::swin_block::BlockMlp, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/swin_block.rs:134

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field cb1 of struct AudioEncoder, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs:158
  field cb2 of struct AudioEncoder, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs:161
  field cb1 of struct AudioEncoderRecord, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs:155
  field cb2 of struct AudioEncoderRecord, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs:155
  field cb1 of struct AudioEncoderRecordItem, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs:155
  field cb2 of struct AudioEncoderRecordItem, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs:155

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_added.ron

Failed in:
  trait method bunsen::blocks::conv::ConvBlock1dMeta::kernel_size in file /tmp/.tmpmsh1ZN/bunsen/crates/bunsen/src/blocks/conv/conv_block_1d.rs:95
  trait method bunsen::blocks::conv::ConvBlock1dMeta::dilation in file /tmp/.tmpmsh1ZN/bunsen/crates/bunsen/src/blocks/conv/conv_block_1d.rs:98
  trait method bunsen::blocks::conv::ConvBlock1dMeta::padding in file /tmp/.tmpmsh1ZN/bunsen/crates/bunsen/src/blocks/conv/conv_block_1d.rs:101
  trait method bunsen::blocks::conv::ConvBlock2dMeta::kernel_size in file /tmp/.tmpmsh1ZN/bunsen/crates/bunsen/src/blocks/conv/conv_block_2d.rs:95
  trait method bunsen::blocks::conv::ConvBlock2dMeta::dilation in file /tmp/.tmpmsh1ZN/bunsen/crates/bunsen/src/blocks/conv/conv_block_2d.rs:98
  trait method bunsen::blocks::conv::ConvBlock2dMeta::padding in file /tmp/.tmpmsh1ZN/bunsen/crates/bunsen/src/blocks/conv/conv_block_2d.rs:101

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_missing.ron

Failed in:
  trait bunsen::kits::bimm::swin::v2::window_attention::OffsetGridRelativePositionBiasMeta, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/window_attention/pos_bias.rs:28
  trait bunsen::kits::bimm::swin::v2::window_attention::ContinuousPositionBiasMlpMeta, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/window_attention/pos_bias.rs:220
  trait bunsen::kits::bimm::resnet::BottleneckBlockMeta, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/bottleneck_block.rs:87
  trait bunsen::kits::bimm::swin::v2::patch_merge::PatchMergingMeta, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/patch_merge.rs:35
  trait bunsen::kits::bimm::swin::v2::swin_block::BlockMlpMeta, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/swin_block.rs:54
  trait bunsen::kits::bimm::resnet::BasicBlockMeta, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/basic_block.rs:66
  trait bunsen::kits::gpts::nanochat::MlpMeta, previously in file /tmp/.tmpxVXi77/bunsen/src/blocks/transformers/mlp.rs:44
  trait bunsen::kits::bimm::swin::v2::window_attention::WindowAttentionMeta, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/window_attention/attention.rs:50
  trait bunsen::kits::bimm::swin::v2::swin_model::SwinTransformerV2Meta, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/swin_model.rs:84
  trait bunsen::kits::bimm::swin::v2::swin_block::ShiftedWindowTransformerBlockMeta, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/swin_block.rs:258
  trait bunsen::kits::bimm::resnet::ResidualBlockMeta, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/residual_block.rs:142
  trait bunsen::kits::gpts::nanochat::NanoChatGptBlockMeta, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/gpts/nanochat/block.rs:39
  trait bunsen::kits::bimm::resnet::LayerBlockMeta, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/layer_block.rs:164
  trait bunsen::kits::bimm::resnet::ResNetDownsampleMeta, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/resnet/downsample.rs:48
  trait bunsen::kits::bimm::swin::v2::block_sequence::StochasticDepthTransformerBlockSequenceMeta, previously in file /tmp/.tmpxVXi77/bunsen/src/kits/bimm/swin/v2/block_sequence.rs:32
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `bunsen-contracts-macros`

<blockquote>

## [0.22.0](https://github.com/zspacelabs/bunsen/compare/bunsen-contracts-macros-v0.21.3...bunsen-contracts-macros-v0.22.0) - 2026-06-05

### Other

- crutcher/chatloader ([#38](https://github.com/zspacelabs/bunsen/pull/38))
</blockquote>

## `bunsen`

<blockquote>

## [0.24.0](https://github.com/zspacelabs/bunsen/compare/bunsen-v0.23.0...bunsen-v0.24.0) - 2026-06-09

### Fixed

- conditionally import `contracts` APIs only in debug builds ([#84](https://github.com/zspacelabs/bunsen/pull/84))

### Other

- crutcher/convseq ([#88](https://github.com/zspacelabs/bunsen/pull/88))
- consolidate module organization under `blocks` directories across kits ([#87](https://github.com/zspacelabs/bunsen/pull/87))
- remove `ResNetDownsample`, migrate to `ConvBlock2d` for downsampling ([#86](https://github.com/zspacelabs/bunsen/pull/86)) ([#86](https://github.com/zspacelabs/bunsen/pull/86))
- replace `ResNetDownsample` with `ConvBlock2d` for residual connections ([#85](https://github.com/zspacelabs/bunsen/pull/85))
</blockquote>

## `bunsen-firehose`

<blockquote>

## [0.22.0](https://github.com/zspacelabs/bunsen/compare/bunsen-firehose-v0.21.3...bunsen-firehose-v0.22.0) - 2026-06-05

### Other

- Merge sub-workspaces ([#41](https://github.com/zspacelabs/bunsen/pull/41))
- firehose docs ([#40](https://github.com/zspacelabs/bunsen/pull/40))
- crutcher/chatloader ([#38](https://github.com/zspacelabs/bunsen/pull/38))
</blockquote>

## `bunsen-firehose-image`

<blockquote>

## [0.22.0](https://github.com/zspacelabs/bunsen/compare/bunsen-firehose-image-v0.21.3...bunsen-firehose-image-v0.22.0) - 2026-06-05

### Other

- firehose docs ([#40](https://github.com/zspacelabs/bunsen/pull/40))
- crutcher/chatloader ([#38](https://github.com/zspacelabs/bunsen/pull/38))
- Partial impl of bunsen::data::cache ([#34](https://github.com/zspacelabs/bunsen/pull/34))
</blockquote>

## `bunsen-preview-chat-dataloader`

<blockquote>

## [0.22.0](https://github.com/zspacelabs/bunsen/compare/bunsen-preview-chat-dataloader-v0.21.3...bunsen-preview-chat-dataloader-v0.22.0) - 2026-06-05

### Other

- gate releases on release-PR merge; ready preview crate for publish ([#65](https://github.com/zspacelabs/bunsen/pull/65))
- Merge sub-workspaces ([#41](https://github.com/zspacelabs/bunsen/pull/41))
- Write docs for chat dataloader crate. ([#39](https://github.com/zspacelabs/bunsen/pull/39))
- crutcher/chatloader ([#38](https://github.com/zspacelabs/bunsen/pull/38))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).