### PR TITLE
fix[contracts]: conditionally import `contracts` APIs only in debug builds

### DIFF
--- a/crates/bunsen/src/kits/bimm/resnet/basic_block.rs
+++ b/crates/bunsen/src/kits/bimm/resnet/basic_block.rs
@@ -376,7 +376,10 @@ impl<B: Backend> BasicBlock<B> {
         input: Tensor<B, 4>,
     ) -> Tensor<B, 4> {
         #[cfg(debug_assertions)]
-        let [batch, out_height, out_width] = crate::contracts::unpack_shape_contract!(
+        use crate::contracts::*;
+
+        #[cfg(debug_assertions)]
+        let [batch, out_height, out_width] = unpack_shape_contract!(
             [
                 "batch",
                 "in_planes",
@@ -394,7 +397,7 @@ impl<B: Backend> BasicBlock<B> {
         };
 
         #[cfg(debug_assertions)]
-        crate::contracts::define_shape_contract!(
+        define_shape_contract!(
             OUT_CONTRACT,
             ["batch", "out_planes", "out_height", "out_width"],
         );
@@ -405,9 +408,8 @@ impl<B: Backend> BasicBlock<B> {
             ("out_height", out_height),
             ("out_width", out_width),
         ];
-        // #[cfg(debug_assertions)]
-        //  bunsen::contracts::assert_shape_contract_periodically!(OUT_CONTRACT,
-        // &identity, &out_bindings);
+        #[cfg(debug_assertions)]
+        assert_shape_contract_periodically!(OUT_CONTRACT, &identity, &out_bindings);
 
         let x = self.cb1.map_forward(input, |x| match &self.drop_block {
             Some(drop_block) => drop_block.forward(x),
@@ -415,7 +417,7 @@ impl<B: Backend> BasicBlock<B> {
         });
 
         #[cfg(debug_assertions)]
-        crate::contracts::assert_shape_contract_periodically!(
+        assert_shape_contract_periodically!(
             ["batch", "first_planes", "out_height", "out_width"],
             &x.dims(),
             &[
@@ -440,11 +442,7 @@ impl<B: Backend> BasicBlock<B> {
         });
 
         #[cfg(debug_assertions)]
-        crate::contracts::assert_shape_contract_periodically!(
-            OUT_CONTRACT,
-            &x.dims(),
-            &out_bindings
-        );
+        assert_shape_contract_periodically!(OUT_CONTRACT, &x.dims(), &out_bindings);
 
         x
     }

--- a/crates/bunsen/src/kits/bimm/resnet/bottleneck_block.rs
+++ b/crates/bunsen/src/kits/bimm/resnet/bottleneck_block.rs
@@ -480,7 +480,10 @@ impl<B: Backend> BottleneckBlock<B> {
         &self,
         input: Tensor<B, 4>,
     ) -> Tensor<B, 4> {
-        let [batch, in_height, out_height, in_width, out_width] = crate::contracts::unpack_shape_contract!(
+        #[cfg(debug_assertions)]
+        use crate::contracts::*;
+        #[cfg(debug_assertions)]
+        let [batch, in_height, out_height, in_width, out_width] = unpack_shape_contract!(
             [
                 "batch",
                 "in_planes",
@@ -497,25 +500,25 @@ impl<B: Backend> BottleneckBlock<B> {
             None => input.clone(),
         };
 
-        crate::contracts::define_shape_contract!(
+        #[cfg(debug_assertions)]
+        define_shape_contract!(
             OUT_CONTRACT,
             ["batch", "out_planes", "out_height", "out_width"],
         );
+        #[cfg(debug_assertions)]
         let out_bindings = [
             ("batch", batch),
             ("out_planes", self.out_planes()),
             ("out_height", out_height),
             ("out_width", out_width),
         ];
-        crate::contracts::assert_shape_contract_periodically!(
-            OUT_CONTRACT,
-            &identity.dims(),
-            &out_bindings
-        );
+        #[cfg(debug_assertions)]
+        assert_shape_contract_periodically!(OUT_CONTRACT, &identity.dims(), &out_bindings);
 
         let x = self.cb1.forward(input);
 
-        crate::contracts::assert_shape_contract_periodically!(
+        #[cfg(debug_assertions)]
+        assert_shape_contract_periodically!(
             ["batch", "pinch_planes", "in_height", "in_width"],
             &x.dims(),
             &[
@@ -531,7 +534,8 @@ impl<B: Backend> BottleneckBlock<B> {
             None => x,
         });
 
-        crate::contracts::assert_shape_contract_periodically!(
+        #[cfg(debug_assertions)]
+        assert_shape_contract_periodically!(
             ["batch", "width", "out_height", "out_width"],
             &x.dims(),
             &[
@@ -545,11 +549,8 @@ impl<B: Backend> BottleneckBlock<B> {
         // TODO: anti-aliasing
 
         self.cb3.map_forward(x, |x| {
-            crate::contracts::assert_shape_contract_periodically!(
-                OUT_CONTRACT,
-                &x.dims(),
-                &out_bindings
-            );
+            #[cfg(debug_assertions)]
+            assert_shape_contract_periodically!(OUT_CONTRACT, &x.dims(), &out_bindings);
 
             // TODO: attention
 

--- a/crates/bunsen/src/kits/bimm/resnet/downsample.rs
+++ b/crates/bunsen/src/kits/bimm/resnet/downsample.rs
@@ -22,10 +22,6 @@ use burn::{
 
 use crate::{
     burner::module::ModuleInit,
-    contracts::{
-        assert_shape_contract_periodically,
-        unpack_shape_contract,
-    },
     errors::BunsenResult,
     ops::conv::{
         build_square_conv2d_padding_config,
@@ -251,6 +247,10 @@ impl<B: Backend> ResNetDownsample<B> {
         &self,
         input: Tensor<B, 4>,
     ) -> Tensor<B, 4> {
+        #[cfg(debug_assertions)]
+        use crate::contracts::*;
+
+        #[cfg(debug_assertions)]
         let [batch, in_height, in_width] = unpack_shape_contract!(
             ["batch", "in_channels", "in_height", "in_width",],
             &input.dims(),
@@ -261,18 +261,20 @@ impl<B: Backend> ResNetDownsample<B> {
         let out = self.conv.forward(input);
         let out = self.norm.forward(out);
 
-        let [out_height, out_width] = self.output_resolution([in_height, in_width]);
-
-        assert_shape_contract_periodically!(
-            ["batch", "out_channels", "out_height", "out_width"],
-            &out.dims(),
-            &[
-                ("batch", batch),
-                ("out_channels", self.out_channels()),
-                ("out_height", out_height),
-                ("out_width", out_width)
-            ]
-        );
+        #[cfg(debug_assertions)]
+        {
+            let [out_height, out_width] = self.output_resolution([in_height, in_width]);
+            assert_shape_contract_periodically!(
+                ["batch", "out_channels", "out_height", "out_width"],
+                &out.dims(),
+                &[
+                    ("batch", batch),
+                    ("out_channels", self.out_channels()),
+                    ("out_height", out_height),
+                    ("out_width", out_width)
+                ]
+            );
+        }
 
         out
     }

--- a/crates/bunsen/src/kits/bimm/resnet/layer_block.rs
+++ b/crates/bunsen/src/kits/bimm/resnet/layer_block.rs
@@ -40,10 +40,6 @@ use super::{
 };
 use crate::{
     burner::module::ModuleInit,
-    contracts::{
-        assert_shape_contract_periodically,
-        unpack_shape_contract,
-    },
     errors::{
         BunsenError,
         BunsenResult,
@@ -381,6 +377,10 @@ impl<B: Backend> LayerBlock<B> {
         &self,
         input: Tensor<B, 4>,
     ) -> Tensor<B, 4> {
+        #[cfg(debug_assertions)]
+        use crate::contracts::*;
+
+        #[cfg(debug_assertions)]
         let [batch, out_height, out_width] = unpack_shape_contract!(
             [
                 "batch",
@@ -398,6 +398,7 @@ impl<B: Backend> LayerBlock<B> {
             x = block.forward(x);
         }
 
+        #[cfg(debug_assertions)]
         assert_shape_contract_periodically!(
             ["batch", "out_planes", "out_height", "out_width"],
             &x.dims(),


### PR DESCRIPTION
- mask out resnet components to only use contracts under debug builds.