### PR TITLE
refactor[resnet]: replace `ResNetDownsample` with `ConvBlock2d` for residual connections

### DIFF
--- a/crates/bunsen/src/kits/bimm/resnet/basic_block.rs
+++ b/crates/bunsen/src/kits/bimm/resnet/basic_block.rs
@@ -48,10 +48,7 @@ use crate::{
     },
     burner::module::ModuleInit,
     errors::BunsenResult,
-    kits::bimm::resnet::{
-        ResNetDownsample,
-        ResNetDownsampleConfig,
-    },
+    kits::bimm::resnet::ResNetDownsampleConfig,
     ops::{
         conv::stride_div_output_resolution,
         drop::DropBlockOptions,
@@ -221,11 +218,17 @@ impl<B: Backend> ModuleInit<B, BasicBlock<B>> for BasicBlockConfig {
         // stride = 1 if use_aa else stride
 
         let downsample = if stride != 1 || in_planes != out_planes {
-            ResNetDownsampleConfig::new(self.in_planes(), self.out_planes(), self.down_kernel_size)
+            Some(
+                ResNetDownsampleConfig::new(
+                    self.in_planes(),
+                    self.out_planes(),
+                    self.down_kernel_size,
+                )
                 .with_stride(self.stride())
                 .with_dilation(first_dilation)
                 .with_norm(self.normalization.clone())
-                .into()
+                .to_conv_block_config(),
+            )
         } else {
             None
         };
@@ -302,8 +305,8 @@ pub struct BasicBlock<B: Backend> {
     /// Reduction factor.
     pub reduce_first: usize,
 
-    /// Optional `DownSample` layer; for the residual connection.
-    pub downsample: Option<ResNetDownsample<B>>,
+    /// Optional downsample (conv + norm) for the residual connection.
+    pub downsample: Option<ConvBlock2d<B>>,
 
     /// First Conv/Norm/Act Block.
     pub cb1: ConvBlock2d<B>,

--- a/crates/bunsen/src/kits/bimm/resnet/bottleneck_block.rs
+++ b/crates/bunsen/src/kits/bimm/resnet/bottleneck_block.rs
@@ -49,10 +49,7 @@ use crate::{
     },
     burner::module::ModuleInit,
     errors::BunsenResult,
-    kits::bimm::resnet::{
-        ResNetDownsample,
-        ResNetDownsampleConfig,
-    },
+    kits::bimm::resnet::ResNetDownsampleConfig,
     ops::{
         conv::stride_div_output_resolution,
         drop::DropBlockOptions,
@@ -296,11 +293,13 @@ impl<B: Backend> ModuleInit<B, BottleneckBlock<B>> for BottleneckBlockConfig {
         let _use_aa = enable_aa && (stride != 1 || first_dilation != dilation);
 
         let downsample = if stride != 1 || in_planes != out_planes {
-            ResNetDownsampleConfig::new(in_planes, out_planes, self.down_kernel_size)
-                .with_stride(self.stride())
-                .with_dilation(self.dilation())
-                .with_norm(self.normalization.clone())
-                .into()
+            Some(
+                ResNetDownsampleConfig::new(in_planes, out_planes, self.down_kernel_size)
+                    .with_stride(self.stride())
+                    .with_dilation(self.dilation())
+                    .with_norm(self.normalization.clone())
+                    .to_conv_block_config(),
+            )
         } else {
             None
         };
@@ -386,8 +385,8 @@ pub struct BottleneckBlock<B: Backend> {
     /// Reduction factor.
     pub reduce_first: usize,
 
-    /// Optional `DownSample` layer; for the residual connection.
-    pub downsample: Option<ResNetDownsample<B>>,
+    /// Optional downsample (conv + norm) for the residual connection.
+    pub downsample: Option<ConvBlock2d<B>>,
 
     /// First conv/norm/act layer.
     pub cb1: ConvBlock2d<B>,

--- a/crates/bunsen/src/kits/bimm/resnet/downsample.rs
+++ b/crates/bunsen/src/kits/bimm/resnet/downsample.rs
@@ -21,6 +21,7 @@ use burn::{
 };
 
 use crate::{
+    blocks::conv::ConvBlock2dConfig,
     burner::module::ModuleInit,
     errors::BunsenResult,
     ops::conv::{
@@ -152,11 +153,12 @@ impl ResNetDownsampleMeta for ResNetDownsampleConfig {
     }
 }
 
-impl<B: Backend> ModuleInit<B, ResNetDownsample<B>> for ResNetDownsampleConfig {
-    fn try_init(
-        &self,
-        device: &B::Device,
-    ) -> BunsenResult<ResNetDownsample<B>> {
+impl ResNetDownsampleConfig {
+    /// Builds the downsample [`Conv2dConfig`].
+    ///
+    /// A `stride == 1`, `dilation == 1` downsample collapses to a `1x1` conv;
+    /// dilation only applies when the kernel is larger than `1`.
+    fn build_conv(&self) -> Conv2dConfig {
         let kernel_size = if self.stride == 1 && self.dilation == 1 {
             1
         } else {
@@ -165,17 +167,37 @@ impl<B: Backend> ModuleInit<B, ResNetDownsample<B>> for ResNetDownsampleConfig {
         let dilation = if kernel_size > 1 { self.dilation } else { 1 };
         let padding = build_square_conv2d_padding_config(kernel_size, self.stride, dilation);
 
-        let conv = Conv2dConfig::new(
+        Conv2dConfig::new(
             [self.in_channels, self.out_channels],
             scalar_to_array(kernel_size),
         )
         .with_stride(scalar_to_array(self.stride))
         .with_padding(padding)
         .with_dilation(scalar_to_array(dilation))
-        .with_bias(false);
+        .with_bias(false)
+    }
 
+    /// Lifts this downsample into an equivalent [`ConvBlock2dConfig`].
+    ///
+    /// The result is a conv + norm with no activation, matching the historical
+    /// [`ResNetDownsample`] behavior. The norm features are matched to the conv
+    /// output channels. This is the preferred way to embed a downsample into a
+    /// residual block.
+    pub fn to_conv_block_config(&self) -> ConvBlock2dConfig {
+        ConvBlock2dConfig::new(self.build_conv())
+            .with_norm(Some(self.norm.clone()))
+            .with_act(None)
+            .match_norm_features()
+    }
+}
+
+impl<B: Backend> ModuleInit<B, ResNetDownsample<B>> for ResNetDownsampleConfig {
+    fn try_init(
+        &self,
+        device: &B::Device,
+    ) -> BunsenResult<ResNetDownsample<B>> {
         Ok(ResNetDownsample {
-            conv: conv.init(device),
+            conv: self.build_conv().init(device),
 
             norm: self
                 .norm


### PR DESCRIPTION
- Updated `ResNetDownsample` implementations to use `ConvBlock2d` as the preferred embedding for residual connections.
- Added builder methods to `ResNetDownsampleConfig`, including `to_conv_block_config` and `build_conv`, for seamless transitions to conv + norm configurations.
- Simplified downsample definitions in `bottleneck_block` and `basic_block` to improve modularity and consistency.
