### PR TITLE
feat[conv_blocks]: add `with_act` and `with_norm` methods to `ConvSeq1dConfig` and `ConvSeq2dConfig`

### DIFF
--- a/crates/bunsen/src/blocks/conv/conv_seq_1d.rs
+++ b/crates/bunsen/src/blocks/conv/conv_seq_1d.rs
@@ -4,6 +4,10 @@ use burn::{
     Tensor,
     config::Config,
     module::Module,
+    nn::{
+        activation::ActivationConfig,
+        norm::NormalizationConfig,
+    },
     prelude::Backend,
 };
 
@@ -200,6 +204,38 @@ impl ConvSeq1dMeta for ConvSeq1dConfig {
             .iter()
             .map(|config| config as &dyn ConvBlock1dMeta)
             .collect()
+    }
+}
+
+impl ConvSeq1dConfig {
+    /// Set the [Option<ActivationConfig>] for all blocks.
+    pub fn with_act<A: Into<Option<ActivationConfig>>>(
+        self,
+        act: A,
+    ) -> Self {
+        let act = act.into();
+        Self {
+            blocks: self
+                .blocks
+                .into_iter()
+                .map(|block| block.with_act(act.clone()))
+                .collect(),
+        }
+    }
+
+    /// Set the [Option<NormalizationConfig>] for all blocks.
+    pub fn with_norm<N: Into<Option<NormalizationConfig>>>(
+        self,
+        norm: N,
+    ) -> Self {
+        let norm = norm.into();
+        Self {
+            blocks: self
+                .blocks
+                .into_iter()
+                .map(|block| block.with_norm(norm.clone()))
+                .collect(),
+        }
     }
 }
 

--- a/crates/bunsen/src/blocks/conv/conv_seq_1d.rs
+++ b/crates/bunsen/src/blocks/conv/conv_seq_1d.rs
@@ -208,7 +208,7 @@ impl ConvSeq1dMeta for ConvSeq1dConfig {
 }
 
 impl ConvSeq1dConfig {
-    /// Set the [Option<ActivationConfig>] for all blocks.
+    /// Set the [`Option<ActivationConfig>`] for all blocks.
     pub fn with_act<A: Into<Option<ActivationConfig>>>(
         self,
         act: A,
@@ -223,7 +223,7 @@ impl ConvSeq1dConfig {
         }
     }
 
-    /// Set the [Option<NormalizationConfig>] for all blocks.
+    /// Set the [`Option<NormalizationConfig>`] for all blocks.
     pub fn with_norm<N: Into<Option<NormalizationConfig>>>(
         self,
         norm: N,

--- a/crates/bunsen/src/blocks/conv/conv_seq_2d.rs
+++ b/crates/bunsen/src/blocks/conv/conv_seq_2d.rs
@@ -4,6 +4,10 @@ use burn::{
     Tensor,
     config::Config,
     module::Module,
+    nn::{
+        activation::ActivationConfig,
+        norm::NormalizationConfig,
+    },
     prelude::Backend,
 };
 
@@ -201,6 +205,38 @@ impl ConvSeq2dMeta for ConvSeq2dConfig {
             .iter()
             .map(|config| config as &dyn ConvBlock2dMeta)
             .collect()
+    }
+}
+
+impl ConvSeq2dConfig {
+    /// Set the [Option<ActivationConfig>] for all blocks.
+    pub fn with_act<A: Into<Option<ActivationConfig>>>(
+        self,
+        act: A,
+    ) -> Self {
+        let act = act.into();
+        Self {
+            blocks: self
+                .blocks
+                .into_iter()
+                .map(|block| block.with_act(act.clone()))
+                .collect(),
+        }
+    }
+
+    /// Set the [Option<NormalizationConfig>] for all blocks.
+    pub fn with_norm<N: Into<Option<NormalizationConfig>>>(
+        self,
+        norm: N,
+    ) -> Self {
+        let norm = norm.into();
+        Self {
+            blocks: self
+                .blocks
+                .into_iter()
+                .map(|block| block.with_norm(norm.clone()))
+                .collect(),
+        }
     }
 }
 

--- a/crates/bunsen/src/blocks/conv/conv_seq_2d.rs
+++ b/crates/bunsen/src/blocks/conv/conv_seq_2d.rs
@@ -209,7 +209,7 @@ impl ConvSeq2dMeta for ConvSeq2dConfig {
 }
 
 impl ConvSeq2dConfig {
-    /// Set the [Option<ActivationConfig>] for all blocks.
+    /// Set the [`Option<ActivationConfig>`] for all blocks.
     pub fn with_act<A: Into<Option<ActivationConfig>>>(
         self,
         act: A,
@@ -224,7 +224,7 @@ impl ConvSeq2dConfig {
         }
     }
 
-    /// Set the [Option<NormalizationConfig>] for all blocks.
+    /// Set the [`Option<NormalizationConfig>`] for all blocks.
     pub fn with_norm<N: Into<Option<NormalizationConfig>>>(
         self,
         norm: N,

--- a/crates/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs
+++ b/crates/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs
@@ -118,15 +118,14 @@ impl<B: Backend> ModuleInit<B, AudioEncoder<B>> for AudioEncoderConfig {
                 ConvBlock1dConfig::new(
                     Conv1dConfig::new(self.n_mels, self.d_model, 3)
                         .with_padding(PaddingConfig1d::Explicit(1, 1)),
-                )
-                .with_act(Some(self.head_activation.clone())),
+                ),
                 ConvBlock1dConfig::new(
                     Conv1dConfig::new(self.d_model, self.d_model, 3)
                         .with_padding(PaddingConfig1d::Explicit(1, 1))
                         .with_stride(2),
-                )
-                .with_act(Some(self.head_activation.clone())),
+                ),
             ])
+            .with_act(self.head_activation.clone())
             .try_init(device)?,
 
             positional_embedding: Param::from_tensor(Tensor::random(


### PR DESCRIPTION
- Introduced builder methods `with_act` and `with_norm` to `ConvSeq1dConfig` and `ConvSeq2dConfig` for streamlined configuration of activation and normalization across all blocks.
- Updated `AudioEncoder` to simplify activation handling using `with_act`.
