### PR TITLE
feat: fix hashbrown build with no-train

### DIFF
--- a/crates/bunsen/src/data/pretrained/weights.rs
+++ b/crates/bunsen/src/data/pretrained/weights.rs
@@ -10,6 +10,7 @@ use alloc::{
     vec,
     vec::Vec,
 };
+#[cfg(feature = "cache")]
 use std::path::PathBuf;
 
 use serde::{
@@ -17,12 +18,11 @@ use serde::{
     Serialize,
 };
 
-use crate::{
-    data::cache::BunsenDiskCache,
-    errors::{
-        BunsenError,
-        BunsenResult,
-    },
+#[cfg(feature = "cache")]
+use crate::data::cache::BunsenDiskCache;
+use crate::errors::{
+    BunsenError,
+    BunsenResult,
 };
 
 const X25: crc::Crc<u16> = crc::Crc::<u16>::new(&crc::CRC_16_IBM_SDLC);

--- a/crates/bunsen/src/kits/bimm/resnet/blocks/resnet_model.rs
+++ b/crates/bunsen/src/kits/bimm/resnet/blocks/resnet_model.rs
@@ -42,16 +42,15 @@ use burn::{
     },
 };
 
+#[allow(unused_imports)]
+use crate::errors::BunsenError;
 use crate::{
     blocks::conv::{
         ConvBlock2d,
         ConvBlock2dConfig,
     },
     burner::module::ModuleInit,
-    errors::{
-        BunsenError,
-        BunsenResult,
-    },
+    errors::BunsenResult,
     kits::bimm::resnet::{
         RESNET18_BLOCKS,
         blocks::{

--- a/crates/bunsen/src/kits/speech/whisper/mod.rs
+++ b/crates/bunsen/src/kits/speech/whisper/mod.rs
@@ -14,5 +14,3 @@ pub use blocks::{
     WhisperMeta,
     WhisperStructuralConfig,
 };
-#[doc(inline)]
-pub use pretrained::PytorchWhisperScanner;

--- a/crates/bunsen/src/lib.rs
+++ b/crates/bunsen/src/lib.rs
@@ -47,6 +47,7 @@ pub use bunsen_contracts_macros::shape_contract as __proc_shape_contract;
 #[allow(missing_docs)]
 pub mod public {
     pub use burn;
+    #[cfg(feature = "train")]
     pub use hashbrown;
 }
 

--- a/examples/whisper-dev/src/main.rs
+++ b/examples/whisper-dev/src/main.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use bunsen::kits::speech::whisper::PytorchWhisperScanner;
+use bunsen::kits::speech::whisper::pretrained::PytorchWhisperScanner;
 use burn::prelude::Backend;
 use clap::Parser;
 


### PR DESCRIPTION

- Removed unused imports across various files to enhance code readability.
- Added conditional imports (`#[cfg(feature = "cache")]` and `#[cfg(feature = "train")]`) to align with feature flags.
- Reorganized the Whisper module by moving `PytorchWhisperScanner` under the `pretrained` namespace.

### Related Issues

Fixes: https://github.com/zspacelabs/bunsen/issues/95
