### PR TITLE
feat(cuda, silero-vad): add CUDA test support, document features, and update configurations

### DIFF
--- a/.idea/runConfigurations/Test__cuda_.xml
+++ b/.idea/runConfigurations/Test__cuda_.xml
@@ -1,0 +1,20 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Test (cuda)" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="buildProfileId" value="test" />
+    <option name="command" value="test --workspace --features cuda" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="RunConfigurationTask" enabled="false" run_configuration_name="Format" run_configuration_type="CargoCommandRunConfiguration" />
+    </method>
+  </configuration>
+</component>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,6 +1042,7 @@ dependencies = [
  "burn",
  "burn-onnx",
  "burn-store",
+ "document-features",
 ]
 
 [[package]]

--- a/crates/bunsen-onnx-gen/Cargo.toml
+++ b/crates/bunsen-onnx-gen/Cargo.toml
@@ -10,9 +10,14 @@ license.workspace = true
 [dependencies]
 burn = { workspace = true, features = ["store"] }
 burn-store = { workspace = true }
+document-features = { workspace = true }
 
 [build-dependencies]
 burn-onnx = { workspace = true }
 
 [lints]
 workspace = true
+
+[features]
+default = ["silero"]
+silero = []

--- a/crates/bunsen-onnx-gen/src/lib.rs
+++ b/crates/bunsen-onnx-gen/src/lib.rs
@@ -1,4 +1,10 @@
-pub mod silero_vad_op18_ifless {
+//! Bunsen ONNX model generation.
+//!
+//! ## Crate Features
+#![doc = document_features::document_features!()]
+
+#[cfg(feature = "silero")]
+pub mod silero {
     include!(concat!(env!("OUT_DIR"), "/silero_vad_op18_ifless.rs"));
 
     /// Pretrained dual branch 16khz/8khs model.

--- a/crates/bunsen/src/kits/speech/silero_vad/cross_test.rs
+++ b/crates/bunsen/src/kits/speech/silero_vad/cross_test.rs
@@ -76,10 +76,10 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
-    /// This is stable for `flex`, `wgpu`.
-    ///
-    /// This produces inaccurate results for `cuda`.
     fn test_golden_context() -> Result<(), Box<dyn std::error::Error>> {
+        #[cfg(feature = "cuda")]
+        eprintln!("This test is known to fail on the CUDA backend.\n");
+
         let wav_path = concat!(env!("CARGO_MANIFEST_DIR"), "/testdata/silero/test.wav");
         let expected_path = concat!(env!("CARGO_MANIFEST_DIR"), "/testdata/silero/test.json");
         let sample_rate = 16000;

--- a/crates/bunsen/src/kits/speech/silero_vad/mod.rs
+++ b/crates/bunsen/src/kits/speech/silero_vad/mod.rs
@@ -1,9 +1,12 @@
 //! Silero VAD voice-activity-detection model.
+//!
+//! There is *some* bug in the burn CUDA backend, which we see
+//! by model divergence from the golden tests on that backend alone.
 
 /// The reference model.
 #[cfg(feature = "store")]
 pub mod reference {
-    pub use bunsen_onnx_gen::silero_vad_op18_ifless::*;
+    pub use bunsen_onnx_gen::silero::*;
 
     /// Reference ONNX Model.
     pub type ReferenceModel<B> = Model<B>;


### PR DESCRIPTION
- Enabled CUDA-specific test configuration in IntelliJ.
- Documented crate features in `bunsen-onnx-gen` using `document-features`.
- Updated Silero VAD tests with CUDA-specific exclusions and added notes on backend divergence.
- Added `silero` feature support in `bunsen-onnx-gen` and refined module imports for maintainability.
