### PR TITLE
fix: make downloader and directories-next optional, activated by the cache feature

### DIFF
--- a/crates/bunsen/Cargo.toml
+++ b/crates/bunsen/Cargo.toml
@@ -73,6 +73,8 @@ train = [
 ## Enable the disk cache.
 cache = [
     "std",
+    "dep:downloader",
+    "dep:directories-next",
     "downloader/default-tls",
 ]
 
@@ -120,9 +122,9 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 crc = { workspace = true }
 
-directories-next = { workspace = true }
+directories-next = { workspace = true, optional = true }
 # features=["tui"] incompatible with conflicting indicatif versions.
-downloader = { workspace = true, default-features = false }
+downloader = { workspace = true, default-features = false, optional = true }
 
 num-traits = { workspace = true }
 strum = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
## Problem

The disk-cache module (`src/data/cache/`) is already `#[cfg(feature = "cache")]`-gated, but its two supporting dependencies — `downloader` and `directories-next` — are declared as **unconditional** dependencies of the `bunsen` crate. Every consumer pays for them, including `default-features = false, features = ["std"]` builds that compile the cache module out entirely. `downloader` in particular brings network-download machinery (and its TLS stack) into dependency graphs that never touch the cache.

This is the follow-up to #95 (ungated `pub use hashbrown`, fixed in 0.25.0): it's the last unconditional edge that keeps minimal `std`-only consumers from a lean graph. Context: we (geode-fem, a deterministic FEM solver) adopt `bunsen` for the `shape_contract!` DSL under `default-features = false, features = ["std"]` and gate our dependency tree against network/download machinery.

## Change

Manifest-only (`crates/bunsen/Cargo.toml`, +4/−2):

- `downloader` and `directories-next` → `optional = true`
- `cache` feature now activates them explicitly: `["std", "dep:downloader", "dep:directories-next", "downloader/default-tls"]`

Cache-enabled builds (including the default feature set, via `store` → `cache`) are unchanged — same deps, same features. No source changes needed: the module gating and all its consumers (`data/pretrained/weights.rs`, resnet tests) are already correctly `cfg`-gated.

## Verification

- `cargo check -p bunsen --no-default-features --features std` — compiles; `cargo tree -i downloader` / `-i directories-next` show both reachable **only via dev-dependencies** (the self-dev-dep uses default features), so they no longer appear in downstream consumers' graphs
- `cargo check -p bunsen --no-default-features --features cache` — compiles; `downloader` present as intended
- `cargo check -p bunsen` (default features) — unchanged
- `cargo clippy -p bunsen --no-deps` (default and std-only) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)