### PR TITLE
chore: release v0.29.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,7 +963,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bunsen"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "bunsen",
  "bunsen-contracts-macros",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-contracts-macros"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1003,7 +1003,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-firehose"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "burn",
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-firehose-image"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "bunsen",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-onnx-gen"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "burn",
  "burn-onnx",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-preview-chat-dataloader"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "arrow",
  "burn",
@@ -9095,7 +9095,7 @@ dependencies = [
 
 [[package]]
 name = "silero-bench"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "bunsen",
  "burn",
@@ -11074,7 +11074,7 @@ dependencies = [
 
 [[package]]
 name = "whisper-dev"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "bunsen",
  "burn",
@@ -12165,7 +12165,7 @@ dependencies = [
 
 [[package]]
 name = "zsl-data-cache"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "burn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ authors = [
 ]
 edition = "2024"
 rust-version = "1.94.1"
-version = "0.28.0"
+version = "0.29.0"
 repository = "https://github.com/zspacelabs/bunsen"
 license = "MIT or Apache-2.0"
 

--- a/crates/bunsen-contracts-macros/CHANGELOG.md
+++ b/crates/bunsen-contracts-macros/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.0](https://github.com/zspacelabs/bunsen/compare/bunsen-contracts-macros-v0.28.0...bunsen-contracts-macros-v0.29.0) - 2026-07-17
+
+### Other
+
+- crutcher/key index ([#130](https://github.com/zspacelabs/bunsen/pull/130))
+
 ## [0.22.0](https://github.com/zspacelabs/bunsen/compare/bunsen-contracts-macros-v0.21.3...bunsen-contracts-macros-v0.22.0) - 2026-06-05
 
 ### Other

--- a/crates/bunsen-firehose-image/Cargo.toml
+++ b/crates/bunsen-firehose-image/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [dependencies]
 burn = { workspace = true, features = ["dataset", "vision", "autotune"] }
-bunsen-firehose = { version = "0.28.0", path = "../bunsen-firehose" }
+bunsen-firehose = { version = "0.29.0", path = "../bunsen-firehose" }
 
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/bunsen-onnx-gen/CHANGELOG.md
+++ b/crates/bunsen-onnx-gen/CHANGELOG.md
@@ -6,3 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.29.0](https://github.com/zspacelabs/bunsen/compare/bunsen-onnx-gen-v0.28.0...bunsen-onnx-gen-v0.29.0) - 2026-07-17
+
+### Other
+
+- Refactor and modularize TenVad implementation ([#126](https://github.com/zspacelabs/bunsen/pull/126))
+- add ten-vad to onnx gen ([#124](https://github.com/zspacelabs/bunsen/pull/124))

--- a/crates/bunsen/CHANGELOG.md
+++ b/crates/bunsen/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.0](https://github.com/zspacelabs/bunsen/compare/bunsen-v0.28.0...bunsen-v0.29.0) - 2026-07-17
+
+### Added
+
+- *(ten-vad)* initial shape contracts for ten-vad. ([#128](https://github.com/zspacelabs/bunsen/pull/128))
+
+### Fixed
+
+- fix docs ([#122](https://github.com/zspacelabs/bunsen/pull/122))
+
+### Other
+
+- crutcher/key index ([#130](https://github.com/zspacelabs/bunsen/pull/130))
+- *(ten)* minor shape refactor ([#129](https://github.com/zspacelabs/bunsen/pull/129))
+- Refactor and modularize TenVad implementation ([#126](https://github.com/zspacelabs/bunsen/pull/126))
+- Backport LstmState updates ([#127](https://github.com/zspacelabs/bunsen/pull/127))
+
 ## [0.28.0](https://github.com/zspacelabs/bunsen/compare/bunsen-v0.27.0...bunsen-v0.28.0) - 2026-07-13
 
 ### Other

--- a/crates/bunsen/Cargo.toml
+++ b/crates/bunsen/Cargo.toml
@@ -110,8 +110,8 @@ flex = ["burn/flex"]
 
 
 [dependencies]
-bunsen-contracts-macros = { version = "0.28.0", path = "../bunsen-contracts-macros" }
-bunsen-onnx-gen = { version = "0.28.0", path = "../bunsen-onnx-gen", optional = true }
+bunsen-contracts-macros = { version = "0.29.0", path = "../bunsen-contracts-macros" }
+bunsen-onnx-gen = { version = "0.29.0", path = "../bunsen-onnx-gen", optional = true }
 
 burn = { workspace = true }
 burn-store = { workspace = true, optional = true }


### PR DESCRIPTION



## 🤖 New release

* `bunsen-contracts-macros`: 0.28.0 -> 0.29.0
* `bunsen-onnx-gen`: 0.28.0 -> 0.29.0 (✓ API compatible changes)
* `bunsen`: 0.28.0 -> 0.29.0 (⚠ API breaking changes)
* `bunsen-firehose`: 0.28.0 -> 0.29.0
* `bunsen-firehose-image`: 0.28.0 -> 0.29.0
* `bunsen-preview-chat-dataloader`: 0.28.0 -> 0.29.0

### ⚠ `bunsen` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant DimExpr::Param 0 -> 1 in /tmp/.tmpspMVGU/bunsen/crates/bunsen/src/contracts/expressions.rs:20
  variant DimExpr::Negate 1 -> 2 in /tmp/.tmpspMVGU/bunsen/crates/bunsen/src/contracts/expressions.rs:26
  variant DimExpr::Pow 2 -> 3 in /tmp/.tmpspMVGU/bunsen/crates/bunsen/src/contracts/expressions.rs:32
  variant DimExpr::Sum 3 -> 4 in /tmp/.tmpspMVGU/bunsen/crates/bunsen/src/contracts/expressions.rs:41
  variant DimExpr::Prod 4 -> 5 in /tmp/.tmpspMVGU/bunsen/crates/bunsen/src/contracts/expressions.rs:47

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant DimExpr:Const in /tmp/.tmpspMVGU/bunsen/crates/bunsen/src/contracts/expressions.rs:14
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `bunsen-contracts-macros`

<blockquote>

## [0.29.0](https://github.com/zspacelabs/bunsen/compare/bunsen-contracts-macros-v0.28.0...bunsen-contracts-macros-v0.29.0) - 2026-07-17

### Other

- crutcher/key index ([#130](https://github.com/zspacelabs/bunsen/pull/130))
</blockquote>

## `bunsen-onnx-gen`

<blockquote>

## [0.29.0](https://github.com/zspacelabs/bunsen/compare/bunsen-onnx-gen-v0.28.0...bunsen-onnx-gen-v0.29.0) - 2026-07-17

### Other

- Refactor and modularize TenVad implementation ([#126](https://github.com/zspacelabs/bunsen/pull/126))
- add ten-vad to onnx gen ([#124](https://github.com/zspacelabs/bunsen/pull/124))
</blockquote>

## `bunsen`

<blockquote>

## [0.29.0](https://github.com/zspacelabs/bunsen/compare/bunsen-v0.28.0...bunsen-v0.29.0) - 2026-07-17

### Added

- *(ten-vad)* initial shape contracts for ten-vad. ([#128](https://github.com/zspacelabs/bunsen/pull/128))

### Fixed

- fix docs ([#122](https://github.com/zspacelabs/bunsen/pull/122))

### Other

- crutcher/key index ([#130](https://github.com/zspacelabs/bunsen/pull/130))
- *(ten)* minor shape refactor ([#129](https://github.com/zspacelabs/bunsen/pull/129))
- Refactor and modularize TenVad implementation ([#126](https://github.com/zspacelabs/bunsen/pull/126))
- Backport LstmState updates ([#127](https://github.com/zspacelabs/bunsen/pull/127))
</blockquote>

## `bunsen-firehose`

<blockquote>

## [0.26.0](https://github.com/zspacelabs/bunsen/compare/bunsen-firehose-v0.25.0...bunsen-firehose-v0.26.0) - 2026-07-13

### Added

- *(silero-vad bench)* benchmark tool ([#105](https://github.com/zspacelabs/bunsen/pull/105))
</blockquote>

## `bunsen-firehose-image`

<blockquote>

## [0.22.0](https://github.com/zspacelabs/bunsen/compare/bunsen-firehose-image-v0.21.3...bunsen-firehose-image-v0.22.0) - 2026-06-05

### Other

- firehose docs ([#40](https://github.com/zspacelabs/bunsen/pull/40))
- crutcher/chatloader ([#38](https://github.com/zspacelabs/bunsen/pull/38))
- Partial impl of bunsen::data::cache ([#34](https://github.com/zspacelabs/bunsen/pull/34))
</blockquote>

## `bunsen-preview-chat-dataloader`

<blockquote>

## [0.22.0](https://github.com/zspacelabs/bunsen/compare/bunsen-preview-chat-dataloader-v0.21.3...bunsen-preview-chat-dataloader-v0.22.0) - 2026-06-05

### Other

- gate releases on release-PR merge; ready preview crate for publish ([#65](https://github.com/zspacelabs/bunsen/pull/65))
- Merge sub-workspaces ([#41](https://github.com/zspacelabs/bunsen/pull/41))
- Write docs for chat dataloader crate. ([#39](https://github.com/zspacelabs/bunsen/pull/39))
- crutcher/chatloader ([#38](https://github.com/zspacelabs/bunsen/pull/38))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).