### PR TITLE
crutcher/key index

### DIFF
--- a/crates/bunsen-contracts-macros/src/lib.rs
+++ b/crates/bunsen-contracts-macros/src/lib.rs
@@ -88,6 +88,9 @@ fn parse_dim_matcher_tokens(input: ParseStream) -> SynResult<DimMatcherAST> {
 /// Represents a node in a dimension expression.
 #[derive(Debug, Clone, PartialEq)]
 enum ExprAST {
+    /// A constant value (integer literal).
+    Const(isize),
+
     /// A parameter (string literal).
     Param(String),
 
@@ -111,6 +114,7 @@ impl ExprAST {
         labels: &mut BTreeSet<String>,
     ) {
         match self {
+            ExprAST::Const(_) => {}
             ExprAST::Param(name) => {
                 labels.insert(name.clone());
             }
@@ -300,9 +304,16 @@ fn parse_factor_expr(input: ParseStream) -> SynResult<ExprAST> {
         return Ok(ExprAST::Param(lit.value()));
     }
 
+    // Handle integer literals (constants)
+    if input.peek(syn::LitInt) {
+        let lit: syn::LitInt = input.parse()?;
+        let value: isize = lit.base10_parse()?;
+        return Ok(ExprAST::Const(value));
+    }
+
     Err(syn::Error::new(
         input.span(),
-        "Expected parameter, parentheses, or unary operator",
+        "Expected parameter, constant, parentheses, or unary operator",
     ))
 }
 
@@ -312,6 +323,11 @@ impl ExprAST {
         index: &[&str],
     ) -> TokenStream2 {
         match self {
+            ExprAST::Const(value) => {
+                quote! {
+                    DimExpr::Const{value: #value}
+                }
+            }
             ExprAST::Param(name) => {
                 let param_id = label_to_slot(name, index);
                 quote! {
@@ -419,8 +435,9 @@ impl ShapeContractAST {
 /// Expr => <Term> { <AddOp> <Term> }
 /// Term => <Power> { <MulOp> <Power> }
 /// Power => <Factor> [ ^ <usize> ]
-/// Factor => <Param> | ( '(' <Expression> ')' ) | NegOp <Factor>
+/// Factor => <Param> | <Const> | ( '(' <Expression> ')' ) | NegOp <Factor>
 /// Param => '"' <identifier> '"'
+/// Const => <integer literal>
 /// identifier => { <alpha> | "_" } { <alphanumeric> | "_" }*
 /// NegOp =>      '+' | '-'
 /// AddOp =>      '+' | '-'
@@ -576,6 +593,97 @@ mod tests {
         assert_eq!(
             input.expr.to_tokens(&index).to_string(),
             "DimExpr :: Pow { base : & DimExpr :: Negate { child : & DimExpr :: Param { id : 0usize } } , exp : 3usize }"
+        );
+    }
+
+    #[test]
+    fn test_parse_const() {
+        let tokens: proc_macro2::TokenStream = r#"3"#.parse().unwrap();
+        let input = syn::parse2::<ExprSyntax>(tokens).unwrap();
+        assert_eq!(input.expr, ExprAST::Const(3));
+
+        let index: [&str; 0] = [];
+        assert_token_stream_eq(
+            &input.expr.to_tokens(&index),
+            &quote! {
+            DimExpr::Const { value: 3isize }
+            },
+        );
+    }
+
+    #[test]
+    fn test_parse_negative_const() {
+        let tokens: proc_macro2::TokenStream = r#"-3"#.parse().unwrap();
+        let input = syn::parse2::<ExprSyntax>(tokens).unwrap();
+        assert_eq!(input.expr, ExprAST::Negate(Box::new(ExprAST::Const(3))));
+
+        let index: [&str; 0] = [];
+        assert_token_stream_eq(
+            &input.expr.to_tokens(&index),
+            &quote! {
+            DimExpr::Negate { child:
+                &DimExpr::Const { value: 3isize } }
+            },
+        );
+    }
+
+    #[test]
+    fn test_parse_const_expression() {
+        let tokens: proc_macro2::TokenStream = r#"2 * "x" + 1"#.parse().unwrap();
+        let input = syn::parse2::<ExprSyntax>(tokens).unwrap();
+        assert_eq!(
+            input.expr,
+            ExprAST::Sum(vec![
+                ExprAST::Prod(vec![ExprAST::Const(2), ExprAST::Param("x".to_string()),]),
+                ExprAST::Const(1),
+            ])
+        );
+
+        // Constants contribute no labels.
+        let mut labels = BTreeSet::new();
+        input.expr.collect_labels(&mut labels);
+        assert_eq!(labels.into_iter().collect::<Vec<_>>(), vec!["x"]);
+
+        let index = ["x"];
+        assert_token_stream_eq(
+            &input.expr.to_tokens(&index),
+            &quote! {
+            DimExpr::Sum { children: &[
+                DimExpr::Prod { children: &[
+                    DimExpr::Const { value: 2isize },
+                    DimExpr::Param { id: 0usize }
+                ] },
+                DimExpr::Const { value: 1isize }
+            ] }
+            },
+        );
+    }
+
+    #[test]
+    fn test_parse_shape_contract_with_const() {
+        let tokens: proc_macro2::TokenStream = r#""x", 3"#.parse().unwrap();
+        let input = syn::parse2::<ContractSyntax>(tokens).unwrap();
+        let contract = input.contract;
+
+        assert_eq!(contract.terms.len(), 2);
+        assert_eq!(
+            contract.terms[1],
+            DimMatcherAST::Expr {
+                label: None,
+                expr: ExprAST::Const(3)
+            }
+        );
+
+        assert_token_stream_eq(
+            &contract.to_tokens(),
+            &quote! {
+            ShapeContract::new(
+                &["x"],
+                &[
+                    DimMatcher::expr(DimExpr::Param { id: 0usize }),
+                    DimMatcher::expr(DimExpr::Const { value: 3isize })
+                ],
+            )},
         );
     }
 

--- a/crates/bunsen/src/contracts/expressions.rs
+++ b/crates/bunsen/src/contracts/expressions.rs
@@ -10,6 +10,12 @@ use crate::support::math::maybe_iroot;
 /// A stack/static expression algebra for dimension sizes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DimExpr<'a> {
+    /// A constant value.
+    Const {
+        /// The value of the constant.
+        value: isize,
+    },
+
     /// A parameter reference.
     Param {
         /// The id of the parameter.
@@ -59,6 +65,7 @@ impl<'a> Display for ExprDisplayAdapter<'a> {
         f: &mut Formatter<'_>,
     ) -> core::fmt::Result {
         match self.expr {
+            DimExpr::Const { value } => write!(f, "{value}"),
             DimExpr::Param { id } => write!(f, "{}", self.index[*id]),
             DimExpr::Negate { child } => write!(
                 f,
@@ -193,6 +200,7 @@ impl<'a> DimExpr<'a> {
         }
 
         match self {
+            DimExpr::Const { value } => EvalResult::Value { value: *value },
             DimExpr::Param { id } => match env[*id] {
                 Some(value) => EvalResult::Value { value },
                 None => EvalResult::UnboundParams { count: 1 },
@@ -266,6 +274,13 @@ impl<'a> DimExpr<'a> {
         }
 
         match self {
+            DimExpr::Const { value } => {
+                if *value == target {
+                    Ok(MatchResult::Match)
+                } else {
+                    Ok(MatchResult::Conflict)
+                }
+            }
             DimExpr::Param { id } => {
                 let id = *id;
                 if let Some(value) = env[id] {
@@ -328,11 +343,14 @@ mod tests {
             format!(
                 "{}",
                 ExprDisplayAdapter {
-                    expr: &expr,
+                    expr,
                     index: &INDEX
                 }
             )
         }
+
+        assert_eq!(fmt(&DimExpr::Const { value: 7 }), "7");
+        assert_eq!(fmt(&DimExpr::Const { value: -7 }), "-7");
 
         assert_eq!(
             fmt(&DimExpr::Param {
@@ -364,6 +382,47 @@ mod tests {
             ],
         };
         assert_eq!(fmt(&_expr), "(a*b*(c+(d^2)+(-e)))");
+    }
+
+    #[test]
+    fn test_eval_const() {
+        let env: [Option<isize>; 0] = [];
+
+        let expr = DimExpr::Const { value: 5 };
+        assert_eq!(expr.try_eval(&env), EvalResult::Value { value: 5 });
+        assert_eq!(expr.try_match(5, &env), Ok(MatchResult::Match));
+        assert_eq!(expr.try_match(42, &env), Ok(MatchResult::Conflict));
+
+        let expr = DimExpr::Const { value: -3 };
+        assert_eq!(expr.try_eval(&env), EvalResult::Value { value: -3 });
+        assert_eq!(expr.try_match(-3, &env), Ok(MatchResult::Match));
+        assert_eq!(expr.try_match(3, &env), Ok(MatchResult::Conflict));
+    }
+
+    #[test]
+    fn test_eval_const_composite() {
+        // (2 * a) + 3
+        let expr = DimExpr::Sum {
+            children: &[
+                DimExpr::Prod {
+                    children: &[DimExpr::Const { value: 2 }, DimExpr::Param { id: 0 }],
+                },
+                DimExpr::Const { value: 3 },
+            ],
+        };
+
+        let env = [Some(5)];
+        assert_eq!(expr.try_eval(&env), EvalResult::Value { value: 13 });
+        assert_eq!(expr.try_match(13, &env), Ok(MatchResult::Match));
+        assert_eq!(expr.try_match(42, &env), Ok(MatchResult::Conflict));
+
+        let env = [None];
+        assert_eq!(expr.try_eval(&env), EvalResult::UnboundParams { count: 1 });
+        assert_eq!(
+            expr.try_match(13, &env),
+            Ok(MatchResult::ParamConstraint { id: 0, value: 5 })
+        );
+        assert_eq!(expr.try_match(14, &env), Err("No integer solution."));
     }
 
     #[test]

--- a/crates/bunsen/src/contracts/macros.rs
+++ b/crates/bunsen/src/contracts/macros.rs
@@ -132,7 +132,7 @@ macro_rules! __define_shape_contract {
 ///
 /// ### With a Contract Expression:
 ///
-/// ```rust,no_run
+/// ```rust
 /// use bunsen::contracts::assert_shape_contract;
 ///
 /// let shape = [1, 2, 3, 4 * 2, 5 * 2, 3];
@@ -145,7 +145,7 @@ macro_rules! __define_shape_contract {
 /// ```
 /// ### With a pre-defined contract:
 ///
-/// ```rust,no_run
+/// ```rust
 /// use bunsen::contracts::{assert_shape_contract, define_shape_contract};
 ///
 /// let shape = [1, 2, 3, 4 * 2, 5 * 2, 3];
@@ -182,20 +182,20 @@ macro_rules! __assert_shape_contract {
 ///
 /// ### With a Contract Expression:
 ///
-/// ```rust,no_run
+/// ```rust
 /// use bunsen::contracts::assert_shape_contract_periodically;
 ///
-/// let shape = [1, 2, 3, 4 * 2, 5 * 2, 3];
+/// let shape = [1, 2, 3, 4 * 2, 5 * 2, 9];
 ///
 /// assert_shape_contract_periodically!(
-///   [..., "h" = "h_win" * "ws", "w" = "w_win" * "ws", "c"],
+///   [..., "h" = "h_win" * "ws", "w" = "w_win" * "ws", 3 * "c"],
 ///   &shape,
 ///   &[("ws", 2)],
 /// );
 /// ```
 /// ### With a pre-defined contract:
 ///
-/// ```rust,no_run
+/// ```rust
 /// use bunsen::contracts::{assert_shape_contract_periodically, define_shape_contract};
 ///
 /// let shape = [1, 2, 3, 4 * 2, 5 * 2, 3];
@@ -226,13 +226,13 @@ macro_rules! __assert_shape_contract_periodically {
 ///
 /// ### With a Contract Expression:
 ///
-/// ```rust,no_run
+/// ```rust
 /// use bunsen::contracts::unpack_shape_contract;
 ///
-/// let shape = [1, 2, 3, 4 * 2, 5 * 2, 3];
+/// let shape = [1, 2, 3, 4 * 2, 5 * 2, 9];
 ///
 /// let [h, h_win, w, w_win, c] = unpack_shape_contract!(
-///   [..., "h" = "h_win" * "ws", "w" = "w_win" * "ws", "c"],
+///   [..., "h" = "h_win" * "ws", "w" = "w_win" * "ws", 3 * "c"],
 ///   &shape,
 ///   &["h", "h_win", "w", "w_win", "c"],
 ///   &[("ws", 2)],
@@ -246,7 +246,7 @@ macro_rules! __assert_shape_contract_periodically {
 ///
 /// ### With a pre-defined contract:
 ///
-/// ```rust,no_run
+/// ```rust
 /// use bunsen::contracts::{define_shape_contract, unpack_shape_contract};
 ///
 /// let shape = [1, 2, 3, 4 * 2, 5 * 2, 3];
@@ -271,27 +271,19 @@ macro_rules! __assert_shape_contract_periodically {
 ///
 /// This also works with pre-defined contracts.
 ///
-/// ```rust,no_run
+/// ```rust
 /// use bunsen::contracts::unpack_shape_contract;
 ///
-/// let shape = [1, 2, 3, 4 * 2, 5 * 2, 3];
+/// let shape = [4, 12];
 ///
-/// let [h, h_win, w, w_win, ws, c] = unpack_shape_contract!(
-///   [..., "h" = "h_win" * "ws", "w" = "w_win" * "ws", "c"],
-///   &shape,
-///   &["h", "h_win", "w", "w_win", "ws", "c"],
-/// );
-/// assert_eq!(ws, 2);
-/// assert_eq!(h, 8);
-/// assert_eq!(h_win, 4);
-/// assert_eq!(w, 10);
-/// assert_eq!(w_win, 5);
-/// assert_eq!(c, 3);
+/// let [a, b] = unpack_shape_contract!(["a", "a" * "b"], &shape, &["a", "b"]);
+/// assert_eq!(a, 4);
+/// assert_eq!(b, 3);
 /// ```
 ///
 /// ### Special: When the keys are the expression:
 ///
-/// ```rust,no_run
+/// ```rust
 /// use bunsen::contracts::unpack_shape_contract;
 ///
 /// let shape = [4, 5, 3];

--- a/crates/bunsen/src/contracts/shape_contracts.rs
+++ b/crates/bunsen/src/contracts/shape_contracts.rs
@@ -384,17 +384,15 @@ impl<'a> ShapeContract<'a> {
         self._loc_try_assert_shape(&sv, env, Location::caller())
     }
 
-    fn _loc_try_assert_shape(
+    fn _key_index(
         &'a self,
-        shape: &ShapeView,
         env: StackEnvironment<'a>,
-        loc: &Location<'a>,
-    ) -> Result<(), String> {
-        let mut scratch: Vec<Option<isize>> = vec![None; self.index.len()];
+    ) -> Result<Vec<Option<isize>>, String> {
+        let mut key_index: Vec<Option<isize>> = vec![None; self.index.len()];
         for (k, v) in env.iter() {
             let v = *v as isize;
             match self.maybe_key_to_index(k) {
-                Some(param_id) => scratch[param_id] = Some(v),
+                Some(param_id) => key_index[param_id] = Some(v),
                 None => {
                     return Err(
                         format!("The key \"{k}\" is not indexed in the contract:\n{self}")
@@ -403,8 +401,17 @@ impl<'a> ShapeContract<'a> {
                 }
             }
         }
+        Ok(key_index)
+    }
 
-        self.format_resolve(shape, scratch.as_mut_slice(), loc)
+    fn _loc_try_assert_shape(
+        &'a self,
+        shape: &ShapeView,
+        env: StackEnvironment<'a>,
+        loc: &Location<'a>,
+    ) -> Result<(), String> {
+        let mut key_index = self._key_index(env)?;
+        self.format_resolve(shape, key_index.as_mut_slice(), loc)
     }
 
     /// Matches and unpacks `K` keys from a shape pattern.
@@ -557,22 +564,10 @@ impl<'a> ShapeContract<'a> {
     ) -> Result<[usize; K], String> {
         let selection = self.expect_keys_to_selection(keys);
 
-        let mut scratch: Vec<Option<isize>> = vec![None; self.index.len()];
-        for (k, v) in env.iter() {
-            let v = *v as isize;
-            match self.maybe_key_to_index(k) {
-                Some(param_id) => scratch[param_id] = Some(v),
-                None => {
-                    return Err(
-                        format!("The key \"{k}\" is not indexed in the contract:\n{self}")
-                            .to_string(),
-                    );
-                }
-            }
-        }
+        let mut key_index = self._key_index(env)?;
 
         let selected: [isize; K] =
-            self._loc_try_select(shape, &selection, scratch.as_mut_slice(), loc)?;
+            self._loc_try_select(shape, &selection, key_index.as_mut_slice(), loc)?;
 
         let result: [usize; K] = selected
             .into_iter()

--- a/crates/bunsen/src/contracts/shape_contracts.rs
+++ b/crates/bunsen/src/contracts/shape_contracts.rs
@@ -806,4 +806,21 @@ mod tests {
         assert_eq!(u_w, w);
         assert_eq!(u_z, z);
     }
+
+    #[test]
+    fn test_shape_contract_macro_const() {
+        use crate::contracts::shape_contract;
+
+        static CONTRACT: ShapeContract = shape_contract!["b", 3, 2 * "h" + 1];
+
+        let b = 2;
+        let h = 5;
+
+        let shape = [b, 3, 2 * h + 1];
+        CONTRACT.assert_shape(&shape, &[]);
+
+        let [u_b, u_h] = CONTRACT.unpack_shape(&shape, &["b", "h"], &[]);
+        assert_eq!(u_b, b);
+        assert_eq!(u_h, h);
+    }
 }

--- a/crates/bunsen/src/kits/bimm/swin/v2/blocks/window_attention/pos_bias.rs
+++ b/crates/bunsen/src/kits/bimm/swin/v2/blocks/window_attention/pos_bias.rs
@@ -174,14 +174,12 @@ impl<B: Backend> OffsetGridRelativePositionBias<B> {
         let lookup_table = self.cbp.forward(self.rel_coords_table.clone());
         assert_shape_contract_periodically!(
             [
-                "height" = "two" * "win_height" - "clip",
-                "width" = "two" * "win_width" - "clip",
+                "height" = 2 * "win_height" - 1,
+                "width" = 2 * "win_width" - 1,
                 "heads"
             ],
             &lookup_table.dims(),
             &[
-                ("two", 2),
-                ("clip", 1),
                 ("win_height", self.window_height()),
                 ("win_width", self.window_width()),
                 ("heads", self.num_heads()),

--- a/crates/bunsen/src/kits/sims/conway/life2d.rs
+++ b/crates/bunsen/src/kits/sims/conway/life2d.rs
@@ -141,9 +141,9 @@ pub fn next_interior_2d<B: Backend>(state: Tensor<B, 2, Bool>) -> Tensor<B, 2, B
 
     #[cfg(any(test, debug_assertions))]
     crate::contracts::assert_shape_contract_periodically!(
-        ["h" - "pad", "w" - "pad"],
+        ["h" - 2, "w" - 2],
         &inner.dims(),
-        &[("h", h), ("w", w), ("pad", 2)],
+        &[("h", h), ("w", w)],
     );
 
     // [H-2, W-2]

--- a/crates/bunsen/src/kits/sims/conway/life3d.rs
+++ b/crates/bunsen/src/kits/sims/conway/life3d.rs
@@ -105,7 +105,7 @@ pub fn next_interior_3d<B: Backend>(
     rules: &LifeRules,
 ) -> Tensor<B, 3, Bool> {
     #[cfg(debug_assertions)]
-    let [h, w, z] = crate::contracts::unpack_shape_contract!(["h", "w", "z"], &state.dims(),);
+    let [h, w, z] = crate::contracts::unpack_shape_contract!(["h", "w", "z"], &state.dims());
 
     // [H, W, Z]
     let is_live = state.clone().slice(s![1..-1, 1..-1, 1..-1,]);
@@ -145,9 +145,9 @@ pub fn next_interior_3d<B: Backend>(
     let update = spawns.bool_or(keeps);
     #[cfg(debug_assertions)]
     crate::contracts::assert_shape_contract_periodically!(
-        ["h" - "pad", "w" - "pad", "z" - "pad"],
+        ["h" - 2, "w" - 2, "z" - 2],
         &update.dims(),
-        &[("h", h), ("w", w), ("z", z), ("pad", 2)],
+        &[("h", h), ("w", w), ("z", z)],
     );
 
     update

--- a/crates/bunsen/src/kits/sims/lbm/d2q9/streaming.rs
+++ b/crates/bunsen/src/kits/sims/lbm/d2q9/streaming.rs
@@ -58,9 +58,9 @@ pub fn stream_interior_windows<B: Backend>(dist: Tensor<B, 4>) -> Tensor<B, 4> {
 
     #[cfg(debug_assertions)]
     crate::contracts::assert_shape_contract_periodically!(
-        ["H" - "PAD", "W" - "PAD", "VY", "VX"],
+        ["H" - 2, "W" - 2, "VY", "VX"],
         result.shape().as_slice(),
-        &[("H", h), ("W", w), ("PAD", 2), ("VY", 3), ("VX", 3)]
+        &[("H", h), ("W", w), ("VY", 3), ("VX", 3)]
     );
 
     result

--- a/crates/bunsen/src/kits/speech/silero_vad/blocks/fused_lstm.rs
+++ b/crates/bunsen/src/kits/speech/silero_vad/blocks/fused_lstm.rs
@@ -138,9 +138,9 @@ impl<B: Backend> FusedLstm<B> {
 
         #[cfg(any(test, debug_assertions))]
         assert_shape_contract_periodically!(
-            ["batch", "4" * "d_model"],
+            ["batch", 4 * "d_model"],
             &gates,
-            &[("batch", batch), ("4", 4), ("d_model", self.d_model())]
+            &[("batch", batch), ("d_model", self.d_model())]
         );
 
         /*

--- a/crates/bunsen/src/kits/speech/silero_vad/blocks/module.rs
+++ b/crates/bunsen/src/kits/speech/silero_vad/blocks/module.rs
@@ -490,9 +490,9 @@ impl<B: Backend> SileroVad<B> {
                     &[("batch", batch)],
                 );
                 assert_shape_contract_periodically!(
-                    ["2", "batch", "d_hidden"],
+                    [2, "batch", "d_hidden"],
                     &state,
-                    &[("2", 2), ("batch", batch), ("d_hidden", self.d_hidden())]
+                    &[("batch", batch), ("d_hidden", self.d_hidden())]
                 );
             }
             _ => {
@@ -571,9 +571,9 @@ impl<B: Backend> SileroVad<B> {
                     &[("batch", batch)],
                 );
                 assert_shape_contract_periodically!(
-                    ["2", "batch", "d_hidden"],
+                    [2, "batch", "d_hidden"],
                     &state,
-                    &[("2", 2), ("batch", batch), ("d_hidden", self.d_hidden())]
+                    &[("batch", batch), ("d_hidden", self.d_hidden())]
                 );
             }
             _ => {
@@ -623,9 +623,9 @@ impl<B: Backend> SileroVad<B> {
                     &["steps", "batch"],
                 );
                 crate::contracts::assert_shape_contract_periodically!(
-                    ["2", "batch", "d_hidden"],
+                    [2, "batch", "d_hidden"],
                     &state,
-                    &[("2", 2), ("batch", batch), ("d_hidden", self.d_hidden())]
+                    &[("batch", batch), ("d_hidden", self.d_hidden())]
                 );
             }
             _ => {
@@ -711,9 +711,9 @@ impl<B: Backend> SileroVad<B> {
             let [batch] =
                 crate::contracts::unpack_shape_contract!(["batch", "samples"], &chunk, &["batch"],);
             crate::contracts::assert_shape_contract_periodically!(
-                ["2", "batch", "d_hidden"],
+                [2, "batch", "d_hidden"],
                 &state,
-                &[("2", 2), ("batch", batch), ("d_hidden", self.d_hidden())]
+                &[("batch", batch), ("d_hidden", self.d_hidden())]
             );
         }
 
@@ -747,7 +747,7 @@ impl<B: Backend> SileroVad<B> {
     ) -> Tensor<B, 2> {
         #[cfg(any(test, debug_assertions))]
         let [batch] =
-            crate::contracts::unpack_shape_contract!(["batch", "samples"], &input, &["batch"],);
+            crate::contracts::unpack_shape_contract!(["batch", "samples"], &input, &["batch"]);
 
         // Reflect-pad, then add the channel axis.
         // [batch, 1, samples + pad]
@@ -762,9 +762,9 @@ impl<B: Backend> SileroVad<B> {
         let x = self.stft.forward(x);
         #[cfg(any(test, debug_assertions))]
         crate::contracts::assert_shape_contract_periodically!(
-            ["batch", "2" * "n_freq", "T"],
+            ["batch", 2 * "n_freq", "T"],
             &x,
-            &[("2", 2), ("batch", batch), ("n_freq", self.n_freq())],
+            &[("batch", batch), ("n_freq", self.n_freq())],
         );
 
         // [batch, n_freq, T]

--- a/crates/bunsen/src/kits/speech/ten_vad/blocks/module.rs
+++ b/crates/bunsen/src/kits/speech/ten_vad/blocks/module.rs
@@ -431,7 +431,7 @@ impl<B: Backend> TenVad<B> {
 
         #[cfg(any(test, debug_assertions))]
         // TODO: really?
-        crate::contracts::assert_shape_contract!(["a", "1"], &x, &[("a", a), ("1", 1)]);
+        crate::contracts::assert_shape_contract!(["a", 1], &x, &[("a", a)]);
         x
     }
 }

--- a/crates/bunsen/src/kits/speech/ten_vad/blocks/module.rs
+++ b/crates/bunsen/src/kits/speech/ten_vad/blocks/module.rs
@@ -375,9 +375,9 @@ impl<B: Backend> TenVad<B> {
         {
             use crate::contracts::assert_shape_contract;
             assert_shape_contract!(
-                ["a", "1", "2" * "d_hidden"],
+                ["a", 1, 2 * "d_hidden"],
                 &x,
-                &[("a", a), ("1", 1), ("2", 2), ("d_hidden", self.d_hidden())]
+                &[("a", a), ("d_hidden", self.d_hidden())]
             );
             assert_shape_contract!(
                 ["a", "d_hidden"],
@@ -400,10 +400,10 @@ impl<B: Backend> TenVad<B> {
         // TODO: debug the 1, 1 dims; relationship to batch, seq.
         #[cfg(any(test, debug_assertions))]
         let [a] = crate::contracts::unpack_shape_contract!(
-            ["a", "1", "2" * "d_hidden"],
+            ["a", 1, 2 * "d_hidden"],
             &x,
             &["a"],
-            &[("1", 1), ("2", 2), ("d_hidden", self.d_hidden())]
+            &[("d_hidden", self.d_hidden())]
         );
 
         let half_hidden = self.d_hidden() / 2;


### PR DESCRIPTION
- **refactor(bunsen): extract `_key_index` function to simplify shape-related operations**
- **feature(bunsen): add `Const` variant to `DimExpr` enum, implement evaluation, matching logic, and tests**
- **docs(bunsen): update examples to remove `no_run` flag and adjust constants in shape contracts**
- **refactor(bunsen): simplify shape contracts by removing redundant parameters and constants**
