### PR TITLE
chore: release v0.30.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,7 +963,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bunsen"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "bunsen",
  "bunsen-contracts-macros",
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-contracts-macros"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-firehose"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "burn",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-firehose-image"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "bunsen",
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-onnx-gen"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "burn",
  "burn-onnx",
@@ -1050,7 +1050,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-preview-chat-dataloader"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "arrow",
  "burn",
@@ -9100,7 +9100,7 @@ dependencies = [
 
 [[package]]
 name = "silero-bench"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "bunsen",
  "burn",
@@ -11111,7 +11111,7 @@ dependencies = [
 
 [[package]]
 name = "whisper-dev"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "bunsen",
  "burn",
@@ -12202,7 +12202,7 @@ dependencies = [
 
 [[package]]
 name = "zsl-data-cache"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "burn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ authors = [
 ]
 edition = "2024"
 rust-version = "1.94.1"
-version = "0.29.1"
+version = "0.30.0"
 repository = "https://github.com/zspacelabs/bunsen"
 license = "MIT or Apache-2.0"
 

--- a/crates/bunsen-firehose-image/Cargo.toml
+++ b/crates/bunsen-firehose-image/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [dependencies]
 burn = { workspace = true, features = ["dataset", "vision", "autotune"] }
-bunsen-firehose = { version = "0.29.1", path = "../bunsen-firehose" }
+bunsen-firehose = { version = "0.30.0", path = "../bunsen-firehose" }
 
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/bunsen/CHANGELOG.md
+++ b/crates/bunsen/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.0](https://github.com/zspacelabs/bunsen/compare/bunsen-v0.29.1...bunsen-v0.30.0) - 2026-07-23
+
+### Added
+
+- *(tensor)* add comprehensive tensor operation extensions, including traits for `swap`, `release`, `select_dim`, range masks, counting, and more ([#143](https://github.com/zspacelabs/bunsen/pull/143))
+- *(tensor)* add `select_dim` method to `TensorOpExt` for slicing and squeezing dimensions, and update related implementations ([#142](https://github.com/zspacelabs/bunsen/pull/142))
+- *(tensor)* add `bounded_elem` method to `TensorIntOpExt`, refactor Conway simulations to use it for range checks ([#138](https://github.com/zspacelabs/bunsen/pull/138))
+- *(stft)* initial stft sliding support. ([#134](https://github.com/zspacelabs/bunsen/pull/134))
+
+### Other
+
+- *(signal)* remove redundant intermediate variables in cosine window implementation ([#140](https://github.com/zspacelabs/bunsen/pull/140))
+- *(life3d)* extract range utilities into `range_util` module and simplify range handling with utility methods ([#141](https://github.com/zspacelabs/bunsen/pull/141))
+- Refactor life3d state update logic and range handling ([#139](https://github.com/zspacelabs/bunsen/pull/139))
+- Add boolean and integer tensor operation extensions ([#137](https://github.com/zspacelabs/bunsen/pull/137))
+- crutcher/l3d ([#136](https://github.com/zspacelabs/bunsen/pull/136))
+- *(bunsen)* optimize state updates with inplace operations in simulations ([#135](https://github.com/zspacelabs/bunsen/pull/135))
+
 ## [0.29.1](https://github.com/zspacelabs/bunsen/compare/bunsen-v0.29.0...bunsen-v0.29.1) - 2026-07-19
 
 ### Other

--- a/crates/bunsen/Cargo.toml
+++ b/crates/bunsen/Cargo.toml
@@ -113,8 +113,8 @@ flex = ["burn/flex"]
 
 
 [dependencies]
-bunsen-contracts-macros = { version = "0.29.1", path = "../bunsen-contracts-macros" }
-bunsen-onnx-gen = { version = "0.29.1", path = "../bunsen-onnx-gen", optional = true }
+bunsen-contracts-macros = { version = "0.30.0", path = "../bunsen-contracts-macros" }
+bunsen-onnx-gen = { version = "0.30.0", path = "../bunsen-onnx-gen", optional = true }
 
 tracing = { workspace = true, optional = true }
 tracing-test = { workspace = true, optional = true }


### PR DESCRIPTION



## 🤖 New release

* `bunsen-contracts-macros`: 0.29.1 -> 0.30.0
* `bunsen-onnx-gen`: 0.29.1 -> 0.30.0
* `bunsen`: 0.29.1 -> 0.30.0 (⚠ API breaking changes)
* `bunsen-firehose`: 0.29.1 -> 0.30.0
* `bunsen-firehose-image`: 0.29.1 -> 0.30.0
* `bunsen-preview-chat-dataloader`: 0.29.1 -> 0.30.0

### ⚠ `bunsen` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function bunsen::ops::arange::float_vec_linspace, previously in file /tmp/.tmpJRB4pe/bunsen/src/ops/arange.rs:77
  function bunsen::ops::arange::float_arange, previously in file /tmp/.tmpJRB4pe/bunsen/src/ops/arange.rs:115
  function bunsen::ops::arange::float_vec_arange, previously in file /tmp/.tmpJRB4pe/bunsen/src/ops/arange.rs:30
  function bunsen::ops::arange::float_linspace, previously in file /tmp/.tmpJRB4pe/bunsen/src/ops/arange.rs:140
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `bunsen-contracts-macros`

<blockquote>

## [0.29.0](https://github.com/zspacelabs/bunsen/compare/bunsen-contracts-macros-v0.28.0...bunsen-contracts-macros-v0.29.0) - 2026-07-17

### Other

- crutcher/key index ([#130](https://github.com/zspacelabs/bunsen/pull/130))
</blockquote>

## `bunsen-onnx-gen`

<blockquote>

## [0.29.0](https://github.com/zspacelabs/bunsen/compare/bunsen-onnx-gen-v0.28.0...bunsen-onnx-gen-v0.29.0) - 2026-07-17

### Other

- Refactor and modularize TenVad implementation ([#126](https://github.com/zspacelabs/bunsen/pull/126))
- add ten-vad to onnx gen ([#124](https://github.com/zspacelabs/bunsen/pull/124))
</blockquote>

## `bunsen`

<blockquote>

## [0.30.0](https://github.com/zspacelabs/bunsen/compare/bunsen-v0.29.1...bunsen-v0.30.0) - 2026-07-23

### Added

- *(tensor)* add comprehensive tensor operation extensions, including traits for `swap`, `release`, `select_dim`, range masks, counting, and more ([#143](https://github.com/zspacelabs/bunsen/pull/143))
- *(tensor)* add `select_dim` method to `TensorOpExt` for slicing and squeezing dimensions, and update related implementations ([#142](https://github.com/zspacelabs/bunsen/pull/142))
- *(tensor)* add `bounded_elem` method to `TensorIntOpExt`, refactor Conway simulations to use it for range checks ([#138](https://github.com/zspacelabs/bunsen/pull/138))
- *(stft)* initial stft sliding support. ([#134](https://github.com/zspacelabs/bunsen/pull/134))

### Other

- *(signal)* remove redundant intermediate variables in cosine window implementation ([#140](https://github.com/zspacelabs/bunsen/pull/140))
- *(life3d)* extract range utilities into `range_util` module and simplify range handling with utility methods ([#141](https://github.com/zspacelabs/bunsen/pull/141))
- Refactor life3d state update logic and range handling ([#139](https://github.com/zspacelabs/bunsen/pull/139))
- Add boolean and integer tensor operation extensions ([#137](https://github.com/zspacelabs/bunsen/pull/137))
- crutcher/l3d ([#136](https://github.com/zspacelabs/bunsen/pull/136))
- *(bunsen)* optimize state updates with inplace operations in simulations ([#135](https://github.com/zspacelabs/bunsen/pull/135))
</blockquote>

## `bunsen-firehose`

<blockquote>

## [0.26.0](https://github.com/zspacelabs/bunsen/compare/bunsen-firehose-v0.25.0...bunsen-firehose-v0.26.0) - 2026-07-13

### Added

- *(silero-vad bench)* benchmark tool ([#105](https://github.com/zspacelabs/bunsen/pull/105))
</blockquote>

## `bunsen-firehose-image`

<blockquote>

## [0.22.0](https://github.com/zspacelabs/bunsen/compare/bunsen-firehose-image-v0.21.3...bunsen-firehose-image-v0.22.0) - 2026-06-05

### Other

- firehose docs ([#40](https://github.com/zspacelabs/bunsen/pull/40))
- crutcher/chatloader ([#38](https://github.com/zspacelabs/bunsen/pull/38))
- Partial impl of bunsen::data::cache ([#34](https://github.com/zspacelabs/bunsen/pull/34))
</blockquote>

## `bunsen-preview-chat-dataloader`

<blockquote>

## [0.22.0](https://github.com/zspacelabs/bunsen/compare/bunsen-preview-chat-dataloader-v0.21.3...bunsen-preview-chat-dataloader-v0.22.0) - 2026-06-05

### Other

- gate releases on release-PR merge; ready preview crate for publish ([#65](https://github.com/zspacelabs/bunsen/pull/65))
- Merge sub-workspaces ([#41](https://github.com/zspacelabs/bunsen/pull/41))
- Write docs for chat dataloader crate. ([#39](https://github.com/zspacelabs/bunsen/pull/39))
- crutcher/chatloader ([#38](https://github.com/zspacelabs/bunsen/pull/38))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).