### PR TITLE
Add `bounded_elem` method to improve range checks in simulations

### DIFF
--- a/crates/bunsen/src/burner/tensor/tensor_op_ext.rs
+++ b/crates/bunsen/src/burner/tensor/tensor_op_ext.rs
@@ -1,6 +1,11 @@
+use std::ops::Range;
+
 use burn::{
     Tensor,
-    prelude::Backend,
+    prelude::{
+        Backend,
+        ElementConversion,
+    },
     tensor::{
         AsIndex,
         BasicOps,
@@ -55,15 +60,30 @@ where
 {
     /// Returns the square of the tensor.
     /// Backport of: <https://github.com/tracel-ai/burn/pull/5224>
-    fn square(self) -> Tensor<B, D, Int>;
+    fn square(self) -> Self;
+
+    /// Elementwise check if the value is in the `[start, end)` range.
+    fn bounded_elem<E: ElementConversion>(
+        self,
+        range: Range<E>,
+    ) -> Tensor<B, D, Bool>;
 }
 
 impl<B, const D: usize> TensorIntOpExt<B, D> for Tensor<B, D, Int>
 where
     B: Backend,
 {
-    fn square(self) -> Tensor<B, D, Int> {
+    fn square(self) -> Self {
         self.powi_scalar(2)
+    }
+
+    fn bounded_elem<E: ElementConversion>(
+        self,
+        range: Range<E>,
+    ) -> Tensor<B, D, Bool> {
+        self.clone()
+            .greater_equal_elem(range.start)
+            .bool_or(self.clone().lower_elem(range.end))
     }
 }
 

--- a/crates/bunsen/src/kits/sims/conway/life3d.rs
+++ b/crates/bunsen/src/kits/sims/conway/life3d.rs
@@ -18,7 +18,10 @@ use serde::{
     Serialize,
 };
 
-use crate::prelude::TensorBoolOpExt;
+use crate::prelude::{
+    TensorBoolOpExt,
+    TensorIntOpExt,
+};
 
 /// Fuzzes the state.
 ///
@@ -123,13 +126,12 @@ pub fn next_interior_3d<B: Backend>(
 
     let spawn_points = window_count
         .clone()
-        .greater_equal_elem(rules.spawn.start as i32)
-        .bool_and(window_count.clone().lower_elem(rules.spawn.end as i32))
+        .bounded_elem(rules.spawn.start as i32..rules.spawn.end as i32)
         .bool_and(is_live.clone().bool_not());
 
     let keep_points = window_count
         .clone()
-        .greater_equal_elem((rules.keep.start + 1) as i32)
+        .bounded_elem(rules.keep.start as i32..rules.keep.end as i32)
         .bool_and(window_count.lower_elem((rules.keep.end + 1) as i32))
         .bool_and(is_live);
 


### PR DESCRIPTION
This pull request introduces a new method, `bounded_elem`, to the `TensorIntOpExt` module. It refactors Conway simulations to utilize this method for more efficient and consistent range checks.