### PR TITLE
chore: release v0.30.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,7 +963,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bunsen"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "bunsen",
  "bunsen-contracts-macros",
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-contracts-macros"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-firehose"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "burn",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-firehose-image"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "bunsen",
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-onnx-gen"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "burn",
  "burn-onnx",
@@ -1050,7 +1050,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-preview-chat-dataloader"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "arrow",
  "burn",
@@ -9100,7 +9100,7 @@ dependencies = [
 
 [[package]]
 name = "silero-bench"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "bunsen",
  "burn",
@@ -11111,7 +11111,7 @@ dependencies = [
 
 [[package]]
 name = "whisper-dev"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "bunsen",
  "burn",
@@ -12202,7 +12202,7 @@ dependencies = [
 
 [[package]]
 name = "zsl-data-cache"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "burn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ authors = [
 ]
 edition = "2024"
 rust-version = "1.94.1"
-version = "0.30.0"
+version = "0.30.1"
 repository = "https://github.com/zspacelabs/bunsen"
 license = "MIT or Apache-2.0"
 

--- a/crates/bunsen-firehose-image/Cargo.toml
+++ b/crates/bunsen-firehose-image/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [dependencies]
 burn = { workspace = true, features = ["dataset", "vision", "autotune"] }
-bunsen-firehose = { version = "0.30.0", path = "../bunsen-firehose" }
+bunsen-firehose = { version = "0.30.1", path = "../bunsen-firehose" }
 
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/bunsen/CHANGELOG.md
+++ b/crates/bunsen/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.1](https://github.com/zspacelabs/bunsen/compare/bunsen-v0.30.0...bunsen-v0.30.1) - 2026-07-24
+
+### Fixed
+
+- *(tensor)* correct range handling in `bounded_elem` by replacing `bool_or` with `bool_and`, add test coverage ([#146](https://github.com/zspacelabs/bunsen/pull/146))
+
+### Other
+
+- *(tensor)* remove redundant clone in `bool_or` operation within `bounded_elem` method ([#145](https://github.com/zspacelabs/bunsen/pull/145))
+
 ## [0.30.0](https://github.com/zspacelabs/bunsen/compare/bunsen-v0.29.1...bunsen-v0.30.0) - 2026-07-23
 
 ### Added

--- a/crates/bunsen/Cargo.toml
+++ b/crates/bunsen/Cargo.toml
@@ -113,8 +113,8 @@ flex = ["burn/flex"]
 
 
 [dependencies]
-bunsen-contracts-macros = { version = "0.30.0", path = "../bunsen-contracts-macros" }
-bunsen-onnx-gen = { version = "0.30.0", path = "../bunsen-onnx-gen", optional = true }
+bunsen-contracts-macros = { version = "0.30.1", path = "../bunsen-contracts-macros" }
+bunsen-onnx-gen = { version = "0.30.1", path = "../bunsen-onnx-gen", optional = true }
 
 tracing = { workspace = true, optional = true }
 tracing-test = { workspace = true, optional = true }


### PR DESCRIPTION



## 🤖 New release

* `bunsen-contracts-macros`: 0.30.0 -> 0.30.1
* `bunsen-onnx-gen`: 0.30.0 -> 0.30.1
* `bunsen`: 0.30.0 -> 0.30.1 (✓ API compatible changes)
* `bunsen-firehose`: 0.30.0 -> 0.30.1
* `bunsen-firehose-image`: 0.30.0 -> 0.30.1
* `bunsen-preview-chat-dataloader`: 0.30.0 -> 0.30.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `bunsen-contracts-macros`

<blockquote>

## [0.29.0](https://github.com/zspacelabs/bunsen/compare/bunsen-contracts-macros-v0.28.0...bunsen-contracts-macros-v0.29.0) - 2026-07-17

### Other

- crutcher/key index ([#130](https://github.com/zspacelabs/bunsen/pull/130))
</blockquote>

## `bunsen-onnx-gen`

<blockquote>

## [0.29.0](https://github.com/zspacelabs/bunsen/compare/bunsen-onnx-gen-v0.28.0...bunsen-onnx-gen-v0.29.0) - 2026-07-17

### Other

- Refactor and modularize TenVad implementation ([#126](https://github.com/zspacelabs/bunsen/pull/126))
- add ten-vad to onnx gen ([#124](https://github.com/zspacelabs/bunsen/pull/124))
</blockquote>

## `bunsen`

<blockquote>

## [0.30.1](https://github.com/zspacelabs/bunsen/compare/bunsen-v0.30.0...bunsen-v0.30.1) - 2026-07-24

### Fixed

- *(tensor)* correct range handling in `bounded_elem` by replacing `bool_or` with `bool_and`, add test coverage ([#146](https://github.com/zspacelabs/bunsen/pull/146))

### Other

- *(tensor)* remove redundant clone in `bool_or` operation within `bounded_elem` method ([#145](https://github.com/zspacelabs/bunsen/pull/145))
</blockquote>

## `bunsen-firehose`

<blockquote>

## [0.26.0](https://github.com/zspacelabs/bunsen/compare/bunsen-firehose-v0.25.0...bunsen-firehose-v0.26.0) - 2026-07-13

### Added

- *(silero-vad bench)* benchmark tool ([#105](https://github.com/zspacelabs/bunsen/pull/105))
</blockquote>

## `bunsen-firehose-image`

<blockquote>

## [0.22.0](https://github.com/zspacelabs/bunsen/compare/bunsen-firehose-image-v0.21.3...bunsen-firehose-image-v0.22.0) - 2026-06-05

### Other

- firehose docs ([#40](https://github.com/zspacelabs/bunsen/pull/40))
- crutcher/chatloader ([#38](https://github.com/zspacelabs/bunsen/pull/38))
- Partial impl of bunsen::data::cache ([#34](https://github.com/zspacelabs/bunsen/pull/34))
</blockquote>

## `bunsen-preview-chat-dataloader`

<blockquote>

## [0.22.0](https://github.com/zspacelabs/bunsen/compare/bunsen-preview-chat-dataloader-v0.21.3...bunsen-preview-chat-dataloader-v0.22.0) - 2026-06-05

### Other

- gate releases on release-PR merge; ready preview crate for publish ([#65](https://github.com/zspacelabs/bunsen/pull/65))
- Merge sub-workspaces ([#41](https://github.com/zspacelabs/bunsen/pull/41))
- Write docs for chat dataloader crate. ([#39](https://github.com/zspacelabs/bunsen/pull/39))
- crutcher/chatloader ([#38](https://github.com/zspacelabs/bunsen/pull/38))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).