### PR TITLE
Replace `bounded_elem` with improved range-checking methods

### DIFF
--- a/crates/bunsen/src/burner/mod.rs
+++ b/crates/bunsen/src/burner/mod.rs
@@ -56,6 +56,9 @@
 //!   (exchange two tensors in place), `release` (move a tensor out of a field,
 //!   leaving an empty tensor behind), and `select_dim` (select one index along
 //!   a dimension and squeeze it, dropping the rank by one).
+//! - [`TensorOrderedOpExt`](tensor::TensorOrderedOpExt) &mdash; ordered
+//!   tensors: `in_range/in_range_scalar` for elementwise `[start, end)` range
+//!   checks producing `Bool` masks.
 //! - [`TensorIntOpExt`](tensor::TensorIntOpExt) &mdash; `Int` tensors:
 //!   `square`, and `bounded_elem` for elementwise `[start, end)` range checks
 //!   producing `Bool` masks.

--- a/crates/bunsen/src/burner/tensor/mod.rs
+++ b/crates/bunsen/src/burner/tensor/mod.rs
@@ -16,10 +16,13 @@
 //!   dimension and squeeze it, reducing the rank by one (e.g. extract one row
 //!   or column of a matrix as a vector).
 //!
+//! [`TensorOrderedOpExt`] — ordered type (Int, Float) tensors:
+//! - [`in_range`](TensorOrderedOpExt::in_range) - elementwise `Range<E>` test.
+//! - [`in_range_scalar`](TensorOrderedOpExt::in_range_scalar) - elementwise
+//!   `Range<E>` test.
+//!
 //! [`TensorIntOpExt`] — `Int` tensors:
 //! * [`square`](TensorIntOpExt::square) — elementwise square.
-//! * [`bounded_elem`](TensorIntOpExt::in_range_scalar) — elementwise `[start,
-//!   end)` range check, producing a `Bool` tensor.
 //!
 //! [`TensorBoolOpExt`] — `Bool` tensors:
 //! * [`count_dim`](TensorBoolOpExt::count_dim) /

--- a/crates/bunsen/src/burner/tensor/mod.rs
+++ b/crates/bunsen/src/burner/tensor/mod.rs
@@ -18,7 +18,7 @@
 //!
 //! [`TensorIntOpExt`] — `Int` tensors:
 //! * [`square`](TensorIntOpExt::square) — elementwise square.
-//! * [`bounded_elem`](TensorIntOpExt::bounded_elem) — elementwise `[start,
+//! * [`bounded_elem`](TensorIntOpExt::in_range_scalar) — elementwise `[start,
 //!   end)` range check, producing a `Bool` tensor.
 //!
 //! [`TensorBoolOpExt`] — `Bool` tensors:

--- a/crates/bunsen/src/burner/tensor/tensor_op_ext.rs
+++ b/crates/bunsen/src/burner/tensor/tensor_op_ext.rs
@@ -10,6 +10,7 @@ use burn::{
         AsIndex,
         BasicOps,
         Bool,
+        Float,
         Int,
     },
 };
@@ -69,6 +70,76 @@ where
     }
 }
 
+/// Tensor Extension trait for ordered operations.
+pub trait TensorOrderedOpExt<B, const D: usize, K>
+where
+    B: Backend,
+    K: BasicOps<B>,
+{
+    /// Elementwise check if the value is in the `[start, end)` range.
+    fn in_range_scalar<E: ElementConversion>(
+        self,
+        range: Range<E>,
+    ) -> Tensor<B, D, Bool>;
+
+    /// Elementwise check if the value is in the `[start, end)` range.
+    fn in_range(
+        self,
+        start: Tensor<B, D, K>,
+        end: Tensor<B, D, K>,
+    ) -> Tensor<B, D, Bool>;
+}
+
+// Impls duplicated because burn doesn't expose Ordered<B>
+impl<B, const D: usize> TensorOrderedOpExt<B, D, Float> for Tensor<B, D>
+where
+    B: Backend,
+{
+    fn in_range_scalar<E: ElementConversion>(
+        self,
+        range: Range<E>,
+    ) -> Tensor<B, D, Bool> {
+        self.clone()
+            .greater_equal_elem(range.start)
+            .bool_and(self.lower_elem(range.end))
+    }
+
+    fn in_range(
+        self,
+        start: Tensor<B, D>,
+        end: Tensor<B, D>,
+    ) -> Tensor<B, D, Bool> {
+        assert_eq!(self.shape(), start.shape());
+        assert_eq!(self.shape(), end.shape());
+        self.clone().greater_equal(start).bool_and(self.lower(end))
+    }
+}
+
+// Impls duplicated because burn doesn't expose Ordered<B>
+impl<B, const D: usize> TensorOrderedOpExt<B, D, Int> for Tensor<B, D, Int>
+where
+    B: Backend,
+{
+    fn in_range_scalar<E: ElementConversion>(
+        self,
+        range: Range<E>,
+    ) -> Tensor<B, D, Bool> {
+        self.clone()
+            .greater_equal_elem(range.start)
+            .bool_and(self.lower_elem(range.end))
+    }
+
+    fn in_range(
+        self,
+        start: Tensor<B, D, Int>,
+        end: Tensor<B, D, Int>,
+    ) -> Tensor<B, D, Bool> {
+        assert_eq!(self.shape(), start.shape());
+        assert_eq!(self.shape(), end.shape());
+        self.clone().greater_equal(start).bool_and(self.lower(end))
+    }
+}
+
 /// Operation Extensions for `Tensor<B, D, Int>`.
 pub trait TensorIntOpExt<B, const D: usize>
 where
@@ -77,12 +148,6 @@ where
     /// Returns the square of the tensor.
     /// Backport of: <https://github.com/tracel-ai/burn/pull/5224>
     fn square(self) -> Self;
-
-    /// Elementwise check if the value is in the `[start, end)` range.
-    fn bounded_elem<E: ElementConversion>(
-        self,
-        range: Range<E>,
-    ) -> Tensor<B, D, Bool>;
 }
 
 impl<B, const D: usize> TensorIntOpExt<B, D> for Tensor<B, D, Int>
@@ -91,15 +156,6 @@ where
 {
     fn square(self) -> Self {
         self.powi_scalar(2)
-    }
-
-    fn bounded_elem<E: ElementConversion>(
-        self,
-        range: Range<E>,
-    ) -> Tensor<B, D, Bool> {
-        self.clone()
-            .greater_equal_elem(range.start)
-            .bool_and(self.lower_elem(range.end))
     }
 }
 
@@ -197,14 +253,28 @@ mod tests {
     }
 
     #[test]
-    fn test_bounded_elem() {
+    fn test_in_range_scalar() {
         let device = Default::default();
         let x: Tensor<B, 1, Int> = Tensor::from_data([0, 1, 2, 3], &device);
 
-        let b = x.bounded_elem(1..3);
+        let b = x.in_range_scalar(1..3);
 
         b.to_data()
             .assert_eq(&TensorData::from([false, true, true, false]), false);
+    }
+
+    #[test]
+    fn test_in_range() {
+        let device = Default::default();
+        let x: Tensor<B, 1, Int> = Tensor::from_data([0, 0, 0, 0], &device);
+
+        let start: Tensor<B, 1, Int> = Tensor::from_data([-1, 0, 0, 3], &device);
+        let end: Tensor<B, 1, Int> = Tensor::from_data([0, 0, 2, 3], &device);
+
+        let b = x.in_range(start, end);
+
+        b.to_data()
+            .assert_eq(&TensorData::from([false, false, true, false]), false);
     }
 
     #[test]

--- a/crates/bunsen/src/kits/sims/conway/life3d.rs
+++ b/crates/bunsen/src/kits/sims/conway/life3d.rs
@@ -25,7 +25,7 @@ use crate::{
     },
     prelude::{
         TensorBoolOpExt,
-        TensorIntOpExt,
+        TensorOrderedOpExt,
     },
 };
 
@@ -122,7 +122,7 @@ pub fn next_interior_3d<B: Backend>(
     let is_live = state.clone().slice(s![1..-1, 1..-1, 1..-1]);
 
     // [H-2, W-2, Z-2]
-    let win_counts = state
+    let win_counts: Tensor<B, 3, Int> = state
         .clone()
         .unfold::<4, _>(0, 3, 1)
         .unfold::<5, _>(1, 3, 1)
@@ -133,8 +133,8 @@ pub fn next_interior_3d<B: Backend>(
     let spawn_range = range_into(&rules.spawn);
     let keep_range = shift_range(range_into(&rules.keep), 1);
 
-    let spawn_points = win_counts.clone().bounded_elem(spawn_range);
-    let keep_points = win_counts.bounded_elem(keep_range);
+    let spawn_points = win_counts.clone().in_range_scalar(spawn_range);
+    let keep_points = win_counts.in_range_scalar(keep_range);
 
     let update = spawn_points.mask_where(is_live, keep_points);
 


### PR DESCRIPTION
Refactor tensor range-checking by replacing `bounded_elem` with `in_range_scalar` for scalar checks and adding a new `in_range` method to enhance flexibility.