### PR TITLE
feat(audio): add `audio` support module with `load_audio_mono_sr` imp…

### DIFF
--- a/crates/bunsen/Cargo.toml
+++ b/crates/bunsen/Cargo.toml
@@ -78,8 +78,15 @@ cache = [
     "downloader/default-tls",
 ]
 
+## Enables audio io support features.
+audio = [
+    "std",
+    "dep:hound",
+]
+
 ## Enables testing support features.
 testing = [
+    "audio",
     "flex",
     "dep:tracing",
     "dep:tracing-test",
@@ -144,11 +151,11 @@ spanned_error_message = { workspace = true, optional = true }
 xot = { workspace = true, optional = true }
 xee-xpath = { workspace = true, optional = true }
 
+hound = { workspace = true, optional = true }
 
 [dev-dependencies]
 bunsen = { path = ".", features = ["testing"] }
 burn = { workspace = true, features = ["autodiff"] }
-hound = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/bunsen/src/kits/speech/silero_vad/cross_test.rs
+++ b/crates/bunsen/src/kits/speech/silero_vad/cross_test.rs
@@ -1,7 +1,5 @@
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
-
     use burn::{
         Tensor,
         prelude::TensorData,
@@ -10,11 +8,6 @@ mod tests {
             Tolerance,
             backend::BackendTypes,
         },
-    };
-    use hound::{
-        SampleFormat,
-        WavReader,
-        WavSpec,
     };
 
     use crate::{
@@ -27,7 +20,10 @@ mod tests {
             reference::ReferenceModel,
         },
         prelude::*,
-        support::testing::PerformanceBackend,
+        support::{
+            audio::load_audio_mono_sr,
+            testing::PerformanceBackend,
+        },
     };
 
     #[test]
@@ -131,53 +127,5 @@ mod tests {
         chunk_probs.assert_approx_eq(&expected, Tolerance::<f32>::default());
 
         Ok(())
-    }
-
-    /// Loads a mono audio file.
-    ///
-    /// # Arguments
-    /// * `filename` - path to an audio file.
-    /// * `sample_rate` - sample rate of the audio file.
-    pub fn load_audio_mono_sr<P: AsRef<Path>>(
-        filename: P,
-        sample_rate: usize,
-    ) -> BunsenResult<(WavSpec, Vec<f32>)> {
-        let filename = filename.as_ref();
-
-        let mut reader = WavReader::open(filename).map_err(BunsenError::external)?;
-        let spec = reader.spec();
-
-        if spec.channels != 1 {
-            return Err(BunsenError::Invalid(
-                "The audio must be single-channel".to_string(),
-            ));
-        }
-        if spec.sample_rate as usize != sample_rate {
-            return Err(BunsenError::Invalid(format!(
-                "Expected sample_rate = {}, but found {}",
-                sample_rate, spec.sample_rate
-            )));
-        }
-
-        let spec = reader.spec();
-        let samples: Vec<f32> = match (spec.sample_format, spec.bits_per_sample) {
-            (SampleFormat::Float, 32) => reader
-                .samples::<f32>()
-                .map(|s| s.unwrap())
-                .collect::<Vec<f32>>(),
-            (SampleFormat::Int, bits) => {
-                let scale = (1i64 << (bits - 1)) as f32;
-                reader
-                    .samples::<i32>()
-                    .collect::<Result<Vec<i32>, _>>()
-                    .map_err(BunsenError::external)?
-                    .into_iter()
-                    .map(|s| s as f32 / scale)
-                    .collect()
-            }
-            _ => unreachable!("hound rejects other formats at open"),
-        };
-
-        Ok((spec, samples))
     }
 }

--- a/crates/bunsen/src/support/audio.rs
+++ b/crates/bunsen/src/support/audio.rs
@@ -1,0 +1,76 @@
+//! # Audio Support
+
+use std::path::Path;
+
+use hound::{
+    SampleFormat,
+    WavReader,
+    WavSpec,
+};
+
+use crate::errors::{
+    BunsenError,
+    BunsenResult,
+};
+
+/// Loads a mono audio file.
+///
+/// # Arguments
+/// * `filename` - path to an audio file.
+/// * `sample_rate` - sample rate of the audio file.
+pub fn load_audio_mono_sr(
+    filename: impl AsRef<Path>,
+    sample_rate: usize,
+) -> BunsenResult<(WavSpec, Vec<f32>)> {
+    let filename = filename.as_ref();
+
+    let mut reader = WavReader::open(filename).map_err(BunsenError::external)?;
+    let spec = reader.spec();
+
+    if spec.channels != 1 {
+        return Err(BunsenError::Invalid(
+            "The audio must be single-channel".to_string(),
+        ));
+    }
+    if spec.sample_rate as usize != sample_rate {
+        return Err(BunsenError::Invalid(format!(
+            "Expected sample_rate = {}, but found {}",
+            sample_rate, spec.sample_rate
+        )));
+    }
+
+    let spec = reader.spec();
+    let samples: Vec<f32> = match (spec.sample_format, spec.bits_per_sample) {
+        (SampleFormat::Float, 32) => reader
+            .samples::<f32>()
+            .map(|s| s.unwrap())
+            .collect::<Vec<f32>>(),
+        (SampleFormat::Int, bits) => {
+            let scale = (1i64 << (bits - 1)) as f32;
+            reader
+                .samples::<i32>()
+                .collect::<Result<Vec<i32>, _>>()
+                .map_err(BunsenError::external)?
+                .into_iter()
+                .map(|s| s as f32 / scale)
+                .collect()
+        }
+        _ => unreachable!("hound rejects other formats at open"),
+    };
+
+    Ok((spec, samples))
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_load_audio_mono_sr() {
+        let wav_path = concat!(env!("CARGO_MANIFEST_DIR"), "/testdata/silero/test.wav");
+        let sample_rate = 16000;
+
+        let (spec, samples) = super::load_audio_mono_sr(wav_path, sample_rate).unwrap();
+        assert_eq!(spec.channels, 1);
+        assert_eq!(spec.sample_rate, sample_rate as u32);
+        assert_eq!(samples.len(), 960000);
+    }
+}

--- a/crates/bunsen/src/support/mod.rs
+++ b/crates/bunsen/src/support/mod.rs
@@ -1,10 +1,12 @@
 #![allow(unused)]
 //! # Bunsen / Client Support Utilities
 
+pub mod arrays;
+pub mod math;
 pub mod validators;
 
 #[cfg(feature = "testing")]
 pub mod testing;
 
-pub mod arrays;
-pub mod math;
+#[cfg(feature = "audio")]
+pub mod audio;


### PR DESCRIPTION
…lementation and integrate optional `hound` dependency

* Move `load_audio_mono_sr` function into a dedicated `audio` support module.
* Update `Cargo.toml` to include the new optional `audio` feature and `hound` dependency.
* Refactor tests in `silero_vad` to utilize the new `load_audio_mono_sr` module.