### PR TITLE
Switch to `PerformanceBackend` and enhance testing configurations

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,4 +2,4 @@
 public-dependency = true
 
 [env]
-RUST_TEST_THREADS = "2"
+RUST_TEST_THREADS = "6"

--- a/.idea/runConfigurations/Test.xml
+++ b/.idea/runConfigurations/Test.xml
@@ -6,7 +6,7 @@
     <envs />
     <option name="emulateTerminal" value="true" />
     <option name="channel" value="DEFAULT" />
-    <option name="requiredFeatures" value="true" />
+    <option name="requiredFeatures" value="false" />
     <option name="allFeatures" value="false" />
     <option name="withSudo" value="false" />
     <option name="buildTarget" value="REMOTE" />

--- a/.idea/runConfigurations/Test__cuda_.xml
+++ b/.idea/runConfigurations/Test__cuda_.xml
@@ -6,11 +6,11 @@
     <envs />
     <option name="emulateTerminal" value="true" />
     <option name="channel" value="DEFAULT" />
-    <option name="requiredFeatures" value="true" />
+    <option name="requiredFeatures" value="false" />
     <option name="allFeatures" value="false" />
     <option name="withSudo" value="false" />
     <option name="buildTarget" value="REMOTE" />
-    <option name="backtrace" value="SHORT" />
+    <option name="backtrace" value="FULL" />
     <option name="isRedirectInput" value="false" />
     <option name="redirectInputPath" value="" />
     <method v="2">

--- a/.idea/runConfigurations/Test__cuda_.xml
+++ b/.idea/runConfigurations/Test__cuda_.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Test (cuda)" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
     <option name="buildProfileId" value="test" />
-    <option name="command" value="test --workspace --features cuda" />
+    <option name="command" value="test --workspace --features cuda,downloads,gpu-tests" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs />
     <option name="emulateTerminal" value="true" />

--- a/.idea/runConfigurations/Test__metal_.xml
+++ b/.idea/runConfigurations/Test__metal_.xml
@@ -6,11 +6,11 @@
     <envs />
     <option name="emulateTerminal" value="true" />
     <option name="channel" value="DEFAULT" />
-    <option name="requiredFeatures" value="true" />
+    <option name="requiredFeatures" value="false" />
     <option name="allFeatures" value="false" />
     <option name="withSudo" value="false" />
     <option name="buildTarget" value="REMOTE" />
-    <option name="backtrace" value="SHORT" />
+    <option name="backtrace" value="FULL" />
     <option name="isRedirectInput" value="false" />
     <option name="redirectInputPath" value="" />
     <method v="2">

--- a/.idea/runConfigurations/Test__metal_.xml
+++ b/.idea/runConfigurations/Test__metal_.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Test (metal)" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
     <option name="buildProfileId" value="test" />
-    <option name="command" value="test --workspace --features metal" />
+    <option name="command" value="test --workspace --features metal,download,gpu-tests" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs />
     <option name="emulateTerminal" value="true" />

--- a/.idea/runConfigurations/Test__wgpu_.xml
+++ b/.idea/runConfigurations/Test__wgpu_.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Test (wgpu)" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
     <option name="buildProfileId" value="test" />
-    <option name="command" value="test --workspace --features wgpu" />
+    <option name="command" value="test --workspace --features wgpu,download,gpu-tests" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs />
     <option name="emulateTerminal" value="true" />

--- a/.idea/runConfigurations/Test__wgpu_.xml
+++ b/.idea/runConfigurations/Test__wgpu_.xml
@@ -6,11 +6,11 @@
     <envs />
     <option name="emulateTerminal" value="true" />
     <option name="channel" value="DEFAULT" />
-    <option name="requiredFeatures" value="true" />
+    <option name="requiredFeatures" value="false" />
     <option name="allFeatures" value="false" />
     <option name="withSudo" value="false" />
     <option name="buildTarget" value="REMOTE" />
-    <option name="backtrace" value="SHORT" />
+    <option name="backtrace" value="FULL" />
     <option name="isRedirectInput" value="false" />
     <option name="redirectInputPath" value="" />
     <method v="2">

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3041,6 +3041,7 @@ dependencies = [
 name = "dl-test"
 version = "0.0.0"
 dependencies = [
+ "bunsen",
  "bunsen-arrow-dataloaders",
  "burn",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,12 @@ exported-private-dependencies = "allow"
 double_must_use = "allow"
 doc_markdown = "warn"
 
+[profile.dev]
+opt-level = 2
+# Keep panics for math overflows active
+overflow-checks = true
+# Keep your `debug_assert!` macros working
+debug-assertions = true
 
 [workspace.dependencies]
 log = { version = "0.4", default-features = false }

--- a/crates/public/bunsen-arrow-dataloaders/examples/dl-test/Cargo.toml
+++ b/crates/public/bunsen-arrow-dataloaders/examples/dl-test/Cargo.toml
@@ -8,13 +8,14 @@ publish = false
 workspace = true
 
 [dependencies]
+bunsen = { path = "../../../bunsen" }
 bunsen-arrow-dataloaders = { path = "../.." }
 zsl-data-cache = { path = "../../../../../examples/zsl-data-cache" }
 wordchipper = { workspace = true, features = ["client"] }
 wordchipper-cli-util = { workspace = true }
 
 rand = { workspace = true }
-burn = { workspace = true, features = ["cuda"] }
+burn = { workspace = true }
 log = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 

--- a/crates/public/bunsen-arrow-dataloaders/examples/dl-test/src/main.rs
+++ b/crates/public/bunsen-arrow-dataloaders/examples/dl-test/src/main.rs
@@ -6,6 +6,7 @@ use std::{
     },
 };
 
+use bunsen::support::testing::PerformanceBackend;
 use bunsen_arrow_dataloaders::{
     dataloaders::chat::ChatDataLoader,
     tokens::{
@@ -13,12 +14,9 @@ use bunsen_arrow_dataloaders::{
         TokenBatchIteratorOptions,
     },
 };
-use burn::{
-    backend::Cuda,
-    tensor::{
-        AsIndex,
-        Slice,
-    },
+use burn::tensor::{
+    AsIndex,
+    Slice,
 };
 use clap::Parser;
 use rand::{
@@ -151,7 +149,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         eos: vec![],
     };
 
-    type B = Cuda;
+    type B = PerformanceBackend;
 
     let device = Default::default();
 

--- a/crates/public/bunsen/src/kits/bimm/resnet/blocks/resnet_model.rs
+++ b/crates/public/bunsen/src/kits/bimm/resnet/blocks/resnet_model.rs
@@ -596,20 +596,8 @@ mod tests {
     #[test]
     #[serial]
     #[cfg(feature = "store")]
-    #[cfg(feature = "cuda")]
     fn test_load_pytorch_prefab_cuda() -> BunsenResult<()> {
-        type B = burn::backend::Cuda;
-        let prefab = "resnet34";
-        let pretrained = "tv_in1k";
-        test_load_pytorch::<B>(&prefab, &pretrained)
-    }
-
-    #[test]
-    #[serial]
-    #[cfg(feature = "store")]
-    #[cfg(feature = "cuda")]
-    fn test_load_pytorch_prefab_cuda_bf16() -> BunsenResult<()> {
-        type B = burn::backend::Cuda<burn::tensor::bf16>;
+        type B = PerformanceBackend;
         let prefab = "resnet34";
         let pretrained = "tv_in1k";
         test_load_pytorch::<B>(&prefab, &pretrained)


### PR DESCRIPTION

This pull request implements the following changes:
- Replaces the development backend with `PerformanceBackend`, enabling better debugging and optimization workflows.
- Configures default debug profiles to align with updated backend settings.
- Introduces optimizations for test threading to improve performance across the workspace.
- Adds `download` and `gpu-tests` features to WGPU, Metal, and CUDA test run configurations, expanding testing capabilities.
