### PR TITLE
fix(bunsen-bundled-whisper): keep fetched assets in OUT_DIR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,22 +52,13 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
 
-      # `bunsen-bundled-whisper`'s build script fetches ~435 MB: the
-      # pretrained checkpoint, and the ONNX export it is validated against.
-      # Both land in a gitignored `cache/`, so without this every run
-      # re-downloads them.
-      #
-      # Keyed on that build script, which is where the pinned SHA-256s live,
-      # so the entry invalidates exactly when the pinned assets change. The
-      # restore-key lets a pin change to one asset reuse the others — the
-      # build script re-verifies every digest and refetches only what moved.
-      - name: Cache model assets
-        uses: actions/cache@v4
-        with:
-          path: crates/public/bunsen-bundled-whisper/cache
-          key: whisper-assets-${{ hashFiles('crates/public/bunsen-bundled-whisper/build.rs') }}
-          restore-keys: |
-            whisper-assets-
+      # `bunsen-bundled-whisper`'s build script fetches ~435 MB of assets into
+      # its `OUT_DIR` (STYLE.md, "Fetched assets live in `OUT_DIR`"). rust-cache
+      # prunes workspace crates before saving, so a cold run fetches them again.
+      # That is accepted rather than cached: `cache-workspace-crates: true`
+      # would also cache the workspace's own build artifacts, test binaries
+      # included, and an `actions/cache` over an `OUT_DIR` path goes stale as
+      # soon as the hash in that path changes.
 
       - name: Docs
         run: cargo doc --no-deps --all-features

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -8,8 +8,16 @@ name: release-plz
 #                  creates the git tags + GitHub releases.
 #
 # Required configuration (one-time):
-#   * Repository secret CARGO_REGISTRY_TOKEN — a crates.io API token with publish
-#     scope for the bunsen* crates.
+#   * Repository secret CARGO_REGISTRY_TOKEN — a crates.io API token
+#     (https://crates.io/settings/tokens/new) with:
+#       - endpoint scopes: `publish-new` AND `publish-update` (`publish-new` is
+#         needed whenever the release adds a crate that isn't on crates.io yet);
+#       - crate scope: `bunsen*`;
+#       - a deliberate expiry. crates.io rejects an expired token with
+#         "403 Forbidden: authentication failed" (the same message as a bogus
+#         token), which is what a release run reports when the token has aged
+#         out. Rotate with `gh secret set CARGO_REGISTRY_TOKEN` and re-run the
+#         failed release job with `gh run rerun <run-id> --failed`.
 #   * Settings -> Actions -> General -> Workflow permissions: allow GitHub Actions
 #     to create and approve pull requests.
 #

--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,3 @@ target
 .claude/
 # Assets fetched by dev crates (see dev_crates/whisper-onnx-crosscheck)
 **/.cache/
-
-# Digest-pinned model assets fetched by the bundle's build script. Scoped to
-# the one crate on purpose: a bare `**/cache/` would also swallow
-# `crates/public/bunsen/src/data/cache`, which is source.
-/crates/public/bunsen-bundled-whisper/cache/

--- a/STYLE.md
+++ b/STYLE.md
@@ -133,42 +133,37 @@ asked for*, and leaves no way to have one without the other. A
 
 `download` marks a build that may reach the network. It is **off by default**
 — a plain `cargo build --workspace` never fetches. Assets are pinned to a
-digest, re-verified on every build, and cached outside `OUT_DIR`, so
-`cargo clean` does not force a re-download. An environment variable points the
-build at a local file instead.
+digest, re-verified on every build, and kept in `OUT_DIR`. An environment
+variable points the build at a local file instead.
 
 `bunsen-bundled-whisper` is the one exception, enumerated rather than implied:
-`checkpoint` is in its `default`, so a workspace build does fetch 145 MB on a
-cold cache. Naming the exception keeps the rule absolute everywhere else.
+`checkpoint` is in its `default`, so a workspace build does fetch 145 MB into
+a fresh `OUT_DIR`. Naming the exception keeps the rule absolute everywhere else.
 
-### The `cache/` directory
+### Fetched assets live in `OUT_DIR`
 
-A fetched asset lands in `cache/`, beside the manifest of the crate that
-fetched it:
+A fetched asset lands in the build script's `OUT_DIR`, never beside the
+manifest:
 
 ```text
 crates/public/bunsen-bundled-whisper/
-    build.rs                     the URLs and their pinned digests
-    cache/                       what the digests name
+    build.rs                                  the URLs and their pinned digests
+target/<profile>/build/bunsen-bundled-whisper-<hash>/out/
+                                              what the digests name
 ```
 
-Beside the manifest, not under `OUT_DIR` — `cargo clean` would otherwise cost
-a re-download, and these are measured in hundreds of megabytes. Not hidden
-either: a directory that large is easier to reason about when it is visible.
+`OUT_DIR` is the one directory a build script may write to. `cargo publish`
+builds the packaged crate and fails if the build touched anything else in the
+package — a `cache/` beside the manifest is exactly that — and a crate unpacked
+from crates.io must not write into `~/.cargo/registry` either. The cost is that
+`cargo clean` discards the assets with everything else, and a cold CI run
+fetches them again. The override variables (`WHISPER_BASE_PT` and friends) are
+the way to supply a local copy instead.
 
-Its `.gitignore` entry is a **full path**, not a `**/` glob. `cache` is an
-ordinary module name — `bunsen::data::cache` is source — and a glob would
-quietly untrack it:
-
-```text
-prefer:  /crates/public/bunsen-bundled-whisper/cache/
-not:     **/cache/                     (also matches src/data/cache)
-```
-
-A build cache does **not** substitute for this. `Swatinem/rust-cache` prunes
-anything it does not recognize as a dependency from `target/`, so assets kept
-there are deleted before the cache is written; CI gives `cache/` its own entry,
-keyed on the `build.rs` that pins the digests.
+Do not add a cache step for them. `Swatinem/rust-cache` prunes workspace crates
+from `target/` before it saves, so the assets do not ride along; a separate
+`actions/cache` over an `OUT_DIR` path goes stale the moment the hash in that
+path changes, which every toolchain or lockfile update does.
 
 ### Model assets
 

--- a/crates/public/bunsen-bundled-whisper/build.rs
+++ b/crates/public/bunsen-bundled-whisper/build.rs
@@ -10,21 +10,23 @@
 //! breaks air-gapped CI, and makes builds non-reproducible. So:
 //!
 //! * A fetch only happens under the feature that needs the asset.
-//! * Assets land in a `cache/` directory beside the manifest, not `OUT_DIR`, so
-//!   `cargo clean` does not force a 145 MB re-download. It is deliberately not
-//!   hidden: 416 MB is worth being able to see.
-//! * Every asset is pinned to a SHA-256 and re-verified on each build. A cache
-//!   entry that fails is deleted and re-fetched once.
+//! * Assets land in `OUT_DIR`, the one directory a build script may write to.
+//!   `cargo publish` verifies that the build left the package source untouched,
+//!   and a crate unpacked from crates.io must not write into the registry — so
+//!   a `cache/` beside the manifest is not an option, and `cargo clean` does
+//!   cost a re-download. The override variables below are the way around that.
+//! * Every asset is pinned to a SHA-256 and re-verified on each build. A cached
+//!   copy that fails is deleted and re-fetched once.
 //! * `WHISPER_BASE_PT`, `WHISPER_MULTILINGUAL_TIKTOKEN`,
 //!   `WHISPER_GPT2_TIKTOKEN`, `WHISPER_ONNX_ENCODER` and `WHISPER_ONNX_DECODER`
 //!   point the build at local files instead, for working offline or against a
 //!   different export.
 //!
 //! **`checkpoint` is on by default**, so building this crate — including as
-//! part of `cargo build --workspace` — fetches 145 MB on a cold cache. That is
-//! deliberate for a crate whose whole purpose is to bundle weights, but it
-//! does mean a clean CI run pays for it. `--no-default-features` opts out, and
-//! `WHISPER_BASE_PT` points at a local copy.
+//! part of `cargo build --workspace` — fetches 145 MB into a fresh `OUT_DIR`.
+//! That is deliberate for a crate whose whole purpose is to bundle weights, but
+//! it does mean a clean CI run pays for it. `--no-default-features` opts out,
+//! and `WHISPER_BASE_PT` points at a local copy.
 
 // Each feature uses its own constants and helpers; the rest are dead in that
 // build. Enumerating `cfg` on every item would be noisier than this.
@@ -212,12 +214,14 @@ fn generate_reference() {
     }
 }
 
-/// The asset cache, beside the manifest rather than in `OUT_DIR` so a
-/// `cargo clean` does not force a re-download.
+/// Where fetched assets land: `OUT_DIR`.
+///
+/// The only directory a build script may write to. `cargo publish` fails
+/// verification if the build touched the package source, and a crate unpacked
+/// from crates.io must not write into `~/.cargo/registry`. The cost is that
+/// `cargo clean` discards the assets along with everything else.
 fn cache_dir() -> PathBuf {
-    let cache = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("cache");
-    fs::create_dir_all(&cache).expect("create the asset cache");
-    cache
+    PathBuf::from(env::var_os("OUT_DIR").expect("cargo sets OUT_DIR for build scripts"))
 }
 
 /// Returns a path to an asset, honouring an override or fetching it.

--- a/crates/public/bunsen-bundled-whisper/src/lib.rs
+++ b/crates/public/bunsen-bundled-whisper/src/lib.rs
@@ -3,7 +3,7 @@
 //! **This crate hosts nothing.** `OpenAI`'s `base.pt` is 145 MB and the ONNX
 //! export is ~290 MB, all far too large to commit — so unlike the Silero
 //! bundle, whose graph ships in the crate, this one *fetches* its assets, pins
-//! each to a SHA-256, and caches them under `cache/`. The two `.tiktoken`
+//! each to a SHA-256, and keeps them in `OUT_DIR`. The two `.tiktoken`
 //! vocabularies are small enough to commit, and are fetched anyway so that
 //! every Whisper asset arrives the same way.
 //!


### PR DESCRIPTION
## Why

The v0.31.0 release run published `bunsen-bundled-silero` and then failed on `bunsen-bundled-whisper`:

```
error: failed to verify package tarball
Caused by:
  Source directory was modified by build.rs during cargo publish. Build scripts should not modify anything outside of OUT_DIR.
  Added: .../target/package/bunsen-bundled-whisper-0.31.0/cache
```

The build script downloaded the checkpoint into a `cache/` beside the manifest. `cargo publish` builds the packaged crate and rejects any build-script write inside the package source, and a crate unpacked from crates.io would have written 435 MB into `~/.cargo/registry` for every downstream user.

## What

- `build.rs`: fetched assets land in `OUT_DIR`, uniformly. The per-asset override variables (`WHISPER_BASE_PT` and friends) are unchanged.
- `.gitignore`: the `cache/` entry is gone with the directory.
- `ci.yml`: the `actions/cache` step over `cache/` is removed. rust-cache prunes workspace crates before saving, so a cold CI run fetches the assets again; the comment records why that is accepted rather than cached.
- `STYLE.md`: the "cache/ directory" section is rewritten as "Fetched assets live in `OUT_DIR`".
- `release-plz.yml`: the setup comment now names the crates.io token scopes (`publish-new` + `publish-update`, crate scope `bunsen*`) and the expiry failure mode that took down the first attempt.

## Verified

`cargo package -p bunsen-bundled-whisper --allow-dirty` runs the same verification step. It now builds the packaged crate, fetches the checkpoint into `OUT_DIR`, and passes. `cargo clippy -p bunsen-bundled-whisper --all-targets -- -D warnings` is clean.

## Release note

This branch is not a `release-plz-*` branch, so merging it does not trigger a release. The six crates still unpublished at 0.31.0 ship with the next release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113DqzgdZ5d1UHDfZDFsdHp
