### PR TITLE
chore(release): resume the v0.31.0 release

### DIFF
--- a/crates/public/bunsen-bundled-whisper/CHANGELOG.md
+++ b/crates/public/bunsen-bundled-whisper/CHANGELOG.md
@@ -18,6 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Refactor `MelFilterbank` into `MelFilterbankConfig` for improved configuration and validation. Rewrite tests for API updates and streamline related logic for cleaner organization. ([#165](https://github.com/zspacelabs/bunsen/pull/165))
 
+### Fixed
+
+- The build script kept its fetched assets in a `cache/` beside the manifest,
+  which `cargo publish` verification rejects: a build script may write only to
+  `OUT_DIR`. Assets now land there. This is the crate's first published
+  version, cut from the commit that carries the fix
+  ([#174](https://github.com/zspacelabs/bunsen/pull/174)).
+
 ### Added
 
 - `vocab` fetches, digest-pins and caches Whisper's two `.tiktoken` rank

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -32,6 +32,16 @@ git_release_enable = true
 # `bunsen-preview-chat-dataloader` (manifest 0.21.3, never published) to attempt
 # a 0.21.3 back-publish. With releases gated on the release PR, a newly-added
 # crate first publishes at the *next* bumped version, alongside the others.
+#
+# The gate is the merged PR's branch name: `release` runs only when the commit
+# at the head of `main` came from a PR whose branch starts with `release-plz-`
+# (the `pr_branch_prefix` default). That also matters for recovery. If a
+# release dies part-way — some crates published, the rest not — `release-pr`
+# sees "local version > registry version", only refreshes changelogs, and opens
+# nothing; an ordinary fix PR does not trigger `release` either. To resume,
+# merge any PR from a branch named `release-plz-*`: `release` then publishes
+# whatever is still missing at the manifest version. Squash merges are fine —
+# release-plz handles them explicitly.
 release_always = false
 
 


### PR DESCRIPTION
## Why

The v0.31.0 release (#147) published `bunsen-bundled-silero` and failed on `bunsen-bundled-whisper`. The fix (#174) merged from an ordinary branch, and release-plz is now stuck on both sides:

- `release`: `skipping release: current commit is not from a release PR`
- `release-pr`: `local version (0.31.0) > registry version (0.30.1). Only changelog will be updated` … `the repository is already up-to-date` → no PR

With `release_always = false`, `release` runs only when the head commit came from a PR whose branch starts with `release-plz-`. **This branch has that prefix**, so squash-merging this PR runs `release` at the merge commit, which publishes the six crates still missing at 0.31.0 and creates their tags and GitHub releases. Squash merges are handled explicitly in release-plz's `should_release`.

## What

- `release-plz.toml`: the comment on `release_always = false` now documents the branch-name gate and this recovery.
- `crates/public/bunsen-bundled-whisper/CHANGELOG.md`: a `### Fixed` entry for #174 under 0.31.0. release-plz's regeneration did not add it, and whisper's 0.31.0 is cut from a commit that includes the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113DqzgdZ5d1UHDfZDFsdHp
