### PR TITLE
fix(bunsen-firehose): enable burn/std so the crates build outside the workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,16 @@ jobs:
 
       - name: No default features build.
         run: cargo test -p bunsen --no-default-features
+
+      # `cargo publish` verifies each crate outside the workspace, with only
+      # its own dependencies. Every other step here builds several crates at
+      # once, and Cargo unifies their features, so a crate that forgets a
+      # feature still builds as long as a sibling turns it on. That is how
+      # `bunsen-firehose` relied on `bunsen` enabling `burn/std` and failed to
+      # publish at v0.31.0. One `cargo check` per crate reproduces the isolated
+      # resolution; several `-p` flags in one invocation would unify again.
+      - name: Published crates build in isolation
+        run: |
+          for manifest in crates/public/*/Cargo.toml; do
+            cargo check --manifest-path "$manifest" --lib
+          done

--- a/crates/public/bunsen-firehose-image/Cargo.toml
+++ b/crates/public/bunsen-firehose-image/Cargo.toml
@@ -14,7 +14,7 @@ description = "bimm-firehose image processing support"
 workspace = true
 
 [dependencies]
-burn = { workspace = true, features = ["dataset", "vision"] }
+burn = { workspace = true, features = ["std", "dataset", "vision"] }
 bunsen-firehose = { version = "0.31.0", path = "../bunsen-firehose" }
 
 serde = { workspace = true, features = ["derive"] }

--- a/crates/public/bunsen-firehose/Cargo.toml
+++ b/crates/public/bunsen-firehose/Cargo.toml
@@ -14,7 +14,7 @@ description = "bunsen dataloader / processing pipeline"
 workspace = true
 
 [dependencies]
-burn = { workspace = true, features = ["dataset", "vision"] }
+burn = { workspace = true, features = ["std", "dataset", "vision"] }
 
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }


### PR DESCRIPTION
## Why

The resumed v0.31.0 release (#175) published `bunsen-bundled-whisper`, `bunsen-contracts-macros`, `bunsen`, and `bunsen-arrow-dataloaders`, then failed verifying `bunsen-firehose`:

```
error[E0433]: cannot find `data` in `burn`
 --> src/burn/path_scanning.rs:6:11
  |
6 | use burn::data::dataset::{
  |           ^^^^ could not find `data` in `burn`
```

burn-core gates its `data` module on the `std` feature, and burn's `dataset` feature does not imply it. Both firehose crates asked burn for `dataset` and `vision` only. In the workspace, `bunsen` enables `burn/std` and feature unification hides the gap; `cargo publish` verifies each crate with only its own dependencies, where it surfaces.

## What

- `bunsen-firehose`, `bunsen-firehose-image`: add `std` to the burn features.
- `ci.yml`: a new step runs `cargo check --lib` on each crate under `crates/public/`, one invocation per crate. That reproduces the isolated resolution: it fails on `main` today with the error above, and passes with this change. Several `-p` flags in one invocation would unify features again, which is why it is a loop.

## Verified

- `cargo check -p bunsen-firehose` fails without the change with CI's exact error and passes with it.
- `cargo package -p bunsen-firehose -p bunsen-firehose-image --allow-dirty` passes verification for both, with firehose-image resolving the unpublished firehose through Cargo's local overlay.
- The new CI loop passes locally for all seven published crates.

## Release

The branch carries the `release-plz-` prefix, so squash-merging runs `release` at the merge commit and publishes the two remaining crates at 0.31.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113DqzgdZ5d1UHDfZDFsdHp
