### PR TITLE
chore: release v0.32.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,7 +901,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bunsen"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "assert_float_eq",
  "bunsen",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-arrow-dataloaders"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "arrow",
  "burn",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-bundled-silero"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "burn",
  "burn-onnx",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-bundled-whisper"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "burn",
  "burn-onnx",
@@ -977,7 +977,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-contracts-macros"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-firehose"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "burn",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "bunsen-firehose-image"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "bunsen",
@@ -1513,7 +1513,7 @@ dependencies = [
 
 [[package]]
 name = "burn_bug_repro"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "bunsen",
  "burn",
@@ -1840,7 +1840,7 @@ dependencies = [
 
 [[package]]
 name = "clap-common"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "bunsen",
  "burn",
@@ -8300,7 +8300,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "silero-bench"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "bunsen",
  "burn",
@@ -8311,7 +8311,7 @@ dependencies = [
 
 [[package]]
 name = "silero-model-validation"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "bunsen",
  "bunsen-bundled-silero",
@@ -10164,7 +10164,7 @@ dependencies = [
 
 [[package]]
 name = "whisper-cli"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "bunsen",
  "burn",
@@ -10175,7 +10175,7 @@ dependencies = [
 
 [[package]]
 name = "whisper-dev"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "bunsen",
  "burn",
@@ -10184,7 +10184,7 @@ dependencies = [
 
 [[package]]
 name = "whisper-model-validation"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "bunsen",
  "bunsen-bundled-whisper",
@@ -11264,7 +11264,7 @@ dependencies = [
 
 [[package]]
 name = "zsl-data-cache"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "burn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ authors = [
 ]
 edition = "2024"
 rust-version = "1.94.1"
-version = "0.31.0"
+version = "0.32.0"
 repository = "https://github.com/zspacelabs/bunsen"
 license = "MIT or Apache-2.0"
 

--- a/crates/public/bunsen-arrow-dataloaders/CHANGELOG.md
+++ b/crates/public/bunsen-arrow-dataloaders/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.0](https://github.com/zspacelabs/bunsen/compare/bunsen-arrow-dataloaders-v0.31.0...bunsen-arrow-dataloaders-v0.32.0) - 2026-09-07
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.31.0](https://github.com/zspacelabs/bunsen/compare/bunsen-arrow-dataloaders-v0.30.1...bunsen-arrow-dataloaders-v0.31.0) - 2026-09-03
 
 ### Added

--- a/crates/public/bunsen-firehose-image/Cargo.toml
+++ b/crates/public/bunsen-firehose-image/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [dependencies]
 burn = { workspace = true, features = ["std", "dataset", "vision"] }
-bunsen-firehose = { version = "0.31.0", path = "../bunsen-firehose" }
+bunsen-firehose = { version = "0.32.0", path = "../bunsen-firehose" }
 
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/public/bunsen/CHANGELOG.md
+++ b/crates/public/bunsen/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.0](https://github.com/zspacelabs/bunsen/compare/bunsen-v0.31.0...bunsen-v0.32.0) - 2026-09-07
+
+### Added
+
+- *(cli)* modularize `whisper-cli`, add `clap-common` crate, and introduce `transcribe` command ([#182](https://github.com/zspacelabs/bunsen/pull/182))
+- *(bunsen)* enhance `DynTensorEnv` with deep copy support and improved tests ([#180](https://github.com/zspacelabs/bunsen/pull/180))
+- *(bunsen)* introduce `DynTensorEnv` for dynamic tensor binding and management ([#179](https://github.com/zspacelabs/bunsen/pull/179))
+
+### Other
+
+- crutcher/dte iter ([#181](https://github.com/zspacelabs/bunsen/pull/181))
+- crutcher/dyn tensor ([#177](https://github.com/zspacelabs/bunsen/pull/177))
+
 ## [0.31.0](https://github.com/zspacelabs/bunsen/compare/bunsen-v0.30.1...bunsen-v0.31.0) - 2026-09-03
 
 ### Added

--- a/crates/public/bunsen/Cargo.toml
+++ b/crates/public/bunsen/Cargo.toml
@@ -166,14 +166,14 @@ testing = [
 ]
 
 [dependencies]
-bunsen-contracts-macros = { version = "0.31.0", path = "../bunsen-contracts-macros" }
+bunsen-contracts-macros = { version = "0.32.0", path = "../bunsen-contracts-macros" }
 
-bunsen-bundled-silero = { version = "0.31.0",
+bunsen-bundled-silero = { version = "0.32.0",
     path = "../bunsen-bundled-silero",
     optional = true
 }
 
-bunsen-bundled-whisper = { version = "0.31.0",
+bunsen-bundled-whisper = { version = "0.32.0",
     path = "../bunsen-bundled-whisper",
     optional = true
 }


### PR DESCRIPTION



## 🤖 New release

* `bunsen-bundled-silero`: 0.31.0 -> 0.32.0
* `bunsen-bundled-whisper`: 0.31.0 -> 0.32.0
* `bunsen-contracts-macros`: 0.31.0 -> 0.32.0
* `bunsen`: 0.31.0 -> 0.32.0 (⚠ API breaking changes)
* `bunsen-arrow-dataloaders`: 0.31.0 -> 0.32.0 (✓ API compatible changes)
* `bunsen-firehose`: 0.31.0 -> 0.32.0
* `bunsen-firehose-image`: 0.31.0 -> 0.32.0

### ⚠ `bunsen` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/enum_missing.ron

Failed in:
  enum bunsen::kits::speech::whisper::driver::WhisperEmission, previously in file /tmp/.tmpfWtDj9/bunsen/src/kits/speech/whisper/driver/whisper_emission.rs:121

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/enum_variant_added.ron

Failed in:
  variant BunsenError:SliceError in /tmp/.tmpOLklC3/bunsen/crates/public/bunsen/src/errors/mod.rs:33
  variant BunsenError:InvalidArgument in /tmp/.tmpOLklC3/bunsen/crates/public/bunsen/src/errors/mod.rs:37
  variant BunsenError:UnsupportedRank in /tmp/.tmpOLklC3/bunsen/crates/public/bunsen/src/errors/mod.rs:44
  variant BunsenError:SliceError in /tmp/.tmpOLklC3/bunsen/crates/public/bunsen/src/errors/mod.rs:33
  variant BunsenError:InvalidArgument in /tmp/.tmpOLklC3/bunsen/crates/public/bunsen/src/errors/mod.rs:37
  variant BunsenError:UnsupportedRank in /tmp/.tmpOLklC3/bunsen/crates/public/bunsen/src/errors/mod.rs:44
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `bunsen-bundled-silero`

<blockquote>

## [0.31.0](https://github.com/zspacelabs/bunsen/compare/bunsen-bundled-silero-v0.30.1...bunsen-bundled-silero-v0.31.0) - 2026-09-03

### Added

- *(whisper)* the stream driver, all eleven phases, and whisper-cli ([#167](https://github.com/zspacelabs/bunsen/pull/167))
- [**breaking**] Whisper reference parity, and split bundled assets from model validation ([#163](https://github.com/zspacelabs/bunsen/pull/163))

### Other

- Refactor beam search decoder: rename variables for clarity, consolidate tail clipping, and optimize test structure. Update device handling to `PerformanceBackend`. ([#173](https://github.com/zspacelabs/bunsen/pull/173))
</blockquote>

## `bunsen-bundled-whisper`

<blockquote>

## [0.31.0](https://github.com/zspacelabs/bunsen/compare/bunsen-bundled-whisper-v0.30.1...bunsen-bundled-whisper-v0.31.0) - 2026-09-03

### Added

- *(whisper)* the stream driver, all eleven phases, and whisper-cli ([#167](https://github.com/zspacelabs/bunsen/pull/167))
- [**breaking**] Whisper reference parity, and split bundled assets from model validation ([#163](https://github.com/zspacelabs/bunsen/pull/163))

### Other

- Refactor `MelFilterbank` into `MelFilterbankConfig` for improved configuration and validation. Rewrite tests for API updates and streamline related logic for cleaner organization. ([#165](https://github.com/zspacelabs/bunsen/pull/165))

### Fixed

- The build script kept its fetched assets in a `cache/` beside the manifest,
  which `cargo publish` verification rejects: a build script may write only to
  `OUT_DIR`. Assets now land there. This is the crate's first published
  version, cut from the commit that carries the fix
  ([#174](https://github.com/zspacelabs/bunsen/pull/174)).

### Added

- `vocab` fetches, digest-pins and caches Whisper's two `.tiktoken` rank
  files and exposes them as `multilingual_tiktoken()` and `gpt2_tiktoken()`.
  The URLs are pinned to the `openai/whisper` commit that last changed them,
  not to `main`. `WHISPER_MULTILINGUAL_TIKTOKEN` and `WHISPER_GPT2_TIKTOKEN`
  point the build at local copies. Off by default and independent of
  `checkpoint`, like `onnx_gen`; `bunsen/whisper-weights` turns it on.
- Initial release, mirroring `bunsen-bundled-silero`. Two independent halves,
  each behind its own off-by-default feature:
  - `checkpoint` fetches, digest-pins and caches OpenAI's multilingual Whisper
    `base.pt` and exposes it as `base_pt()`. This is what
    `bunsen::kits::speech::whisper::Whisper::load_pretrained` reads.
  - `onnx_gen` fetches the `onnx-community/whisper-base` export and generates
    `onnx_gen::{encoder, decoder}` from it — the reference implementation
    `whisper-model-validation` compares against.

  Both were previously inside `whisper-model-validation`'s own `build.rs`. The
  checkpoint is what `bunsen` loads, so it belongs beside the library; the
  reference moved with it so that one crate owns every Whisper asset and the
  validation crate is only the comparison.

  Unlike the Silero bundle, nothing here is committed: the assets total ~435 MB,
  so they are fetched and cached, and the weights are a path rather than bytes.
</blockquote>

## `bunsen-contracts-macros`

<blockquote>

## [0.29.0](https://github.com/zspacelabs/bunsen/compare/bunsen-contracts-macros-v0.28.0...bunsen-contracts-macros-v0.29.0) - 2026-07-17

### Other

- crutcher/key index ([#130](https://github.com/zspacelabs/bunsen/pull/130))
</blockquote>

## `bunsen`

<blockquote>

## [0.32.0](https://github.com/zspacelabs/bunsen/compare/bunsen-v0.31.0...bunsen-v0.32.0) - 2026-09-07

### Added

- *(cli)* modularize `whisper-cli`, add `clap-common` crate, and introduce `transcribe` command ([#182](https://github.com/zspacelabs/bunsen/pull/182))
- *(bunsen)* enhance `DynTensorEnv` with deep copy support and improved tests ([#180](https://github.com/zspacelabs/bunsen/pull/180))
- *(bunsen)* introduce `DynTensorEnv` for dynamic tensor binding and management ([#179](https://github.com/zspacelabs/bunsen/pull/179))

### Other

- crutcher/dte iter ([#181](https://github.com/zspacelabs/bunsen/pull/181))
- crutcher/dyn tensor ([#177](https://github.com/zspacelabs/bunsen/pull/177))
</blockquote>

## `bunsen-arrow-dataloaders`

<blockquote>

## [0.32.0](https://github.com/zspacelabs/bunsen/compare/bunsen-arrow-dataloaders-v0.31.0...bunsen-arrow-dataloaders-v0.32.0) - 2026-09-07

### Other

- update Cargo.toml dependencies
</blockquote>

## `bunsen-firehose`

<blockquote>

## [0.31.0](https://github.com/zspacelabs/bunsen/compare/bunsen-firehose-v0.30.1...bunsen-firehose-v0.31.0) - 2026-09-03

### Added

- [**breaking**] Whisper reference parity, and split bundled assets from model validation ([#163](https://github.com/zspacelabs/bunsen/pull/163))
</blockquote>

## `bunsen-firehose-image`

<blockquote>

## [0.31.0](https://github.com/zspacelabs/bunsen/compare/bunsen-firehose-image-v0.30.1...bunsen-firehose-image-v0.31.0) - 2026-09-03

### Added

- [**breaking**] Whisper reference parity, and split bundled assets from model validation ([#163](https://github.com/zspacelabs/bunsen/pull/163))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).