### PR TITLE
feat(bunsen): introduce `DynTensorEnv` for dynamic tensor binding and management

### DIFF
--- a/.idea/bunsen.iml
+++ b/.idea/bunsen.iml
@@ -39,7 +39,7 @@
       <sourceFolder url="file://$MODULE_DIR$/crates/dev/zsl-data-cache/examples/pull_shards/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/crates/dev/zsl-data-cache/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/crates/dev/burn-rmexp-dyntensor/src" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/crates/dev/burn-rmexp-tensorlib/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/dev/tensor-library-exp/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/crates/public/bunsen/target" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
       <excludeFolder url="file://$MODULE_DIR$/demos/bimm/crates/bimm/target" />

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,6 +912,7 @@ dependencies = [
  "burn-store",
  "crc",
  "criterion",
+ "dashmap",
  "directories-next",
  "document-features",
  "downloader",
@@ -2866,6 +2867,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4070,6 +4085,12 @@ checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash 0.8.12",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,8 @@ regex-macro = "0.3.0"
 serde = "1.0.228"
 serde_json = "1.0.145"
 
+dashmap = "6.2.1"
+
 dirs = "6.0.0"
 clap = "4.5.51"
 downloader = { version = "0.2.7", default-features = false }

--- a/crates/public/bunsen/Cargo.toml
+++ b/crates/public/bunsen/Cargo.toml
@@ -196,6 +196,8 @@ directories-next = { workspace = true, optional = true }
 # features=["tui"] incompatible with conflicting indicatif versions.
 downloader = { workspace = true, default-features = false, optional = true }
 
+dashmap = { workspace = true }
+
 num-traits = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }

--- a/crates/public/bunsen/src/burner/tensor/dynamic/dyn_tensor_env.rs
+++ b/crates/public/bunsen/src/burner/tensor/dynamic/dyn_tensor_env.rs
@@ -1,0 +1,128 @@
+use std::collections::HashSet;
+
+use burn::prelude::Backend;
+use dashmap::DashMap;
+
+use crate::prelude::dynamic::DynTensor;
+
+/// [`DynTensor`] Binding Environment.
+#[derive(Debug, Clone, Default)]
+pub struct DynTensorEnv<B: Backend> {
+    map: DashMap<String, DynTensor<B>>,
+}
+
+impl<B: Backend> DynTensorEnv<B> {
+    /// Get the number of tensors in the environment.
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    /// Get the keys of the tensors in the environment.
+    pub fn keys(&self) -> HashSet<String> {
+        self.map.iter().map(|r| r.key().to_string()).collect()
+    }
+
+    /// Bind a [`DynTensor`] to the environment.
+    pub fn bind(
+        &mut self,
+        name: impl AsRef<str>,
+        tensor: impl Into<DynTensor<B>>,
+    ) {
+        self.map.insert(name.as_ref().to_string(), tensor.into());
+    }
+
+    /// Drop a [`DynTensor`] from the environment.
+    ///
+    /// # Returns
+    ///
+    /// The dropped [`DynTensor`], or `None` if the tensor does not exist.
+    pub fn drop(
+        &mut self,
+        name: impl AsRef<str>,
+    ) -> Option<DynTensor<B>> {
+        self.map.remove(name.as_ref()).map(|(_, v)| v)
+    }
+
+    /// Check if a [`DynTensor`] exists in the environment.
+    pub fn contains_key(
+        &self,
+        name: impl AsRef<str>,
+    ) -> bool {
+        self.map.contains_key(name.as_ref())
+    }
+
+    /// Get a reference to a [`DynTensor`] from the environment.
+    pub fn get_ref(
+        &self,
+        name: impl AsRef<str>,
+    ) -> Option<dashmap::mapref::one::Ref<'_, String, DynTensor<B>>> {
+        self.map.get(name.as_ref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use burn::{
+        Tensor,
+        prelude::{
+            Bool,
+            Float,
+        },
+        tensor::Int,
+    };
+
+    use super::*;
+    use crate::{
+        prelude::*,
+        support::testing::CpuBackend,
+    };
+
+    #[test]
+    fn test_dyn_tensor_env() {
+        type B = CpuBackend;
+        let device = Default::default();
+
+        let mut env = DynTensorEnv::<B>::default();
+
+        let int_tensor: Tensor<B, 2, Int> = Tensor::arange(0..6, &device).reshape([2, 3]);
+        let float_tensor: Tensor<B, 3> = Tensor::arange(0..24, &device).reshape([2, 3, 4]).float();
+        let bool_tensor: Tensor<B, 1, Bool> = Tensor::zeros([2], &device);
+
+        env.bind("foo", int_tensor.clone());
+
+        let float_dyn_tensor: DynTensor<B> = float_tensor.clone().into();
+        env.bind("bar", float_dyn_tensor);
+
+        env.bind("baz", bool_tensor.clone());
+
+        let mut expected: HashSet<String> = Default::default();
+        expected.insert("foo".to_string());
+        expected.insert("bar".to_string());
+        expected.insert("baz".to_string());
+
+        assert_eq!(&env.keys(), &expected);
+
+        assert_eq!(env.contains_key("foo"), true);
+        env.get_ref("foo")
+            .unwrap()
+            .downcast_clone::<2, Int>()
+            .unwrap()
+            .to_data_as::<i32>()
+            .assert_eq(&int_tensor.to_data_as::<i32>(), true);
+
+        env.get_ref("bar")
+            .unwrap()
+            .downcast_clone::<3, Float>()
+            .unwrap()
+            .to_data_as::<f32>()
+            .assert_eq(&float_tensor.to_data_as::<f32>(), true);
+
+        env.get_ref("baz")
+            .unwrap()
+            .downcast_clone::<1, Bool>()
+            .unwrap()
+            .to_data_as::<bool>()
+            .assert_eq(&bool_tensor.to_data_as::<bool>(), true);
+    }
+}

--- a/crates/public/bunsen/src/burner/tensor/dynamic/dyn_tensor_env.rs
+++ b/crates/public/bunsen/src/burner/tensor/dynamic/dyn_tensor_env.rs
@@ -17,6 +17,11 @@ impl<B: Backend> DynTensorEnv<B> {
         self.map.len()
     }
 
+    /// Check if the environment is empty.
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
     /// Get the keys of the tensors in the environment.
     pub fn keys(&self) -> HashSet<String> {
         self.map.iter().map(|r| r.key().to_string()).collect()

--- a/crates/public/bunsen/src/burner/tensor/dynamic/mod.rs
+++ b/crates/public/bunsen/src/burner/tensor/dynamic/mod.rs
@@ -3,8 +3,11 @@
 
 mod dispatch_rank;
 mod dyn_tensor;
+mod dyn_tensor_env;
 
 #[doc(inline)]
 pub use dispatch_rank::*;
 #[doc(inline)]
 pub use dyn_tensor::*;
+#[doc(inline)]
+pub use dyn_tensor_env::*;


### PR DESCRIPTION
Added a new `DynTensorEnv` struct enabling dynamic tensor binding, retrieval, and management using `DashMap`. Includes unit tests to validate functionality. Updated dependencies to include `dashmap`.
