### PR TITLE
feat(bunsen): introduce dtype inspection and boundary casting for Whi…

### DIFF
--- a/crates/public/bunsen/src/burner/module/has_dtype.rs
+++ b/crates/public/bunsen/src/burner/module/has_dtype.rs
@@ -1,0 +1,10 @@
+use burn::tensor::DType;
+
+/// This target/semantic [`DType`].
+///
+/// This is not a guarantee that all internal params are this dtype;
+/// only that callers should assume this dtype is appropriate for inputs.
+pub trait HasDType {
+    /// The semantic [`DType`] of the module.
+    fn dtype(&self) -> DType;
+}

--- a/crates/public/bunsen/src/burner/module/mod.rs
+++ b/crates/public/bunsen/src/burner/module/mod.rs
@@ -3,9 +3,12 @@
 #[cfg(feature = "reflection")]
 pub mod reflection;
 
+mod has_dtype;
 mod module_init;
 mod type_mapper;
 
+#[doc(inline)]
+pub use has_dtype::*;
 #[doc(inline)]
 pub use module_init::*;
 #[doc(inline)]

--- a/crates/public/bunsen/src/burner/tensor/dynamic/dyn_tensor.rs
+++ b/crates/public/bunsen/src/burner/tensor/dynamic/dyn_tensor.rs
@@ -19,6 +19,7 @@ use burn::{
 use crate::{
     burner::{
         descriptors::TensorKindDesc,
+        module::HasDType,
         tensor::dynamic::RankHandler,
     },
     errors::{
@@ -85,6 +86,12 @@ where
 {
     fn from(val: Tensor<B, R, K>) -> Self {
         DynTensor::new(val)
+    }
+}
+
+impl<B: Backend> HasDType for DynTensor<B> {
+    fn dtype(&self) -> DType {
+        self.dtype
     }
 }
 

--- a/crates/public/bunsen/src/burner/tensor/float_dtype.rs
+++ b/crates/public/bunsen/src/burner/tensor/float_dtype.rs
@@ -1,0 +1,42 @@
+use burn::{
+    prelude::Backend,
+    tensor::{
+        DType,
+        Element,
+    },
+};
+
+/// The backend's default float [`DType`]: `B::FloatElem`'s.
+///
+/// This is what a `Tensor<B, D>` built without a dtype of its own gets —
+/// `Tensor::random`, `Tensor::zeros`, `Tensor::from_data` — so it is the
+/// dtype an operation between a model's output and a freshly-built tensor
+/// needs both sides to be in.
+///
+/// A module whose parameters were loaded at some other precision computes in
+/// *that* precision; this is the dtype its **interface** speaks. Casting a
+/// result to it at the module boundary lets the caller stay in the backend's
+/// float without knowing what the checkpoint shipped as.
+pub fn backend_float_dtype<B: Backend>() -> DType {
+    <B::FloatElem as Element>::dtype()
+}
+
+#[cfg(test)]
+mod tests {
+    use burn::tensor::DType;
+
+    use super::*;
+    use crate::support::testing::CpuBackend;
+
+    /// The helper agrees with what an undtyped tensor actually gets: that
+    /// equality is the whole point of it.
+    #[test]
+    fn test_matches_a_default_tensor() {
+        type B = CpuBackend;
+        let device = Default::default();
+
+        let t: burn::Tensor<B, 1> = burn::Tensor::zeros([2], &device);
+        assert_eq!(backend_float_dtype::<B>(), t.dtype());
+        assert_eq!(backend_float_dtype::<B>(), DType::F32);
+    }
+}

--- a/crates/public/bunsen/src/burner/tensor/mod.rs
+++ b/crates/public/bunsen/src/burner/tensor/mod.rs
@@ -43,6 +43,13 @@
 //! }
 //! ```
 //!
+//! ## Free Functions
+//!
+//! [`backend_float_dtype`] — the backend's default float `DType`
+//! (`B::FloatElem`'s): what an undtyped `Tensor<B, D>` gets, and so the
+//! dtype a module's interface speaks when its parameters were loaded at
+//! some other precision.
+//!
 //! ## `TensorData` Views
 //!
 //! [`TensorDataView`] and [`TensorDataViewMut`] wrap a
@@ -52,9 +59,12 @@
 pub mod dynamic;
 
 mod data_view;
+mod float_dtype;
 mod tensor_op_ext;
 
 #[doc(inline)]
 pub use data_view::*;
+#[doc(inline)]
+pub use float_dtype::*;
 #[doc(inline)]
 pub use tensor_op_ext::*;

--- a/crates/public/bunsen/src/kits/sims/lbm/d2q9/simulation.rs
+++ b/crates/public/bunsen/src/kits/sims/lbm/d2q9/simulation.rs
@@ -21,7 +21,10 @@ use super::{
     outflow_clipping_stream,
     with_spherical_reflection,
 };
-use crate::burner::tensor::TensorOpExt;
+use crate::burner::{
+    module::HasDType,
+    tensor::TensorOpExt,
+};
 
 /// Introspection trait for [`LBMD2Q9State`]
 pub trait LBMMeta {
@@ -136,6 +139,12 @@ impl<B: Backend> LBMMeta for LBMD2Q9State<B> {
     fn shape(&self) -> [usize; 2] {
         let [h, w, _, _] = self.dist.dims();
         [h, w]
+    }
+}
+
+impl<B: Backend> HasDType for LBMD2Q9State<B> {
+    fn dtype(&self) -> DType {
+        self.dist.dtype()
     }
 }
 

--- a/crates/public/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs
+++ b/crates/public/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs
@@ -16,7 +16,10 @@ use burn::{
         Backend,
         s,
     },
-    tensor::Distribution,
+    tensor::{
+        DType,
+        Distribution,
+    },
 };
 
 use super::WHISPER_DEFAULT_D_MODEL;
@@ -212,13 +215,28 @@ impl<B: Backend> AudioEncoderMeta for AudioEncoder<B> {
 }
 
 impl<B: Backend> AudioEncoder<B> {
+    /// The dtype the encoder's parameters were loaded in, and so the one it
+    /// computes in. `OpenAI`'s checkpoints ship in fp16.
+    pub fn dtype(&self) -> DType {
+        self.positional_embedding.dtype()
+    }
+
     /// Forward pass through the audio encoder.
     ///
     /// # Arguments
-    /// * `x`: The input audio spectrogram `[batch, n_mels, seq]`.
+    /// * `x`: The input audio spectrogram `[batch, n_mels, seq]`, in any float
+    ///   dtype. The mel front end works in the backend's default float;
+    ///   [`forward_head`](Self::forward_head) casts to [`dtype`](Self::dtype).
     ///
     /// # Returns
-    /// `[batch, seq, n_audio_states]`.
+    /// `[batch, seq, n_audio_states]`, in the encoder's
+    /// [`dtype`](Self::dtype).
+    ///
+    /// These features are not an interface value: they are the decoder's
+    /// input, and the source of its cross-attention cache. Widening them
+    /// here would only have the decoder narrow them again, and would put
+    /// the bulk of that cache at the wrong precision, so they stay in the
+    /// model's.
     pub fn forward(
         &self,
         x: Tensor<B, 3>,
@@ -236,8 +254,13 @@ impl<B: Backend> AudioEncoder<B> {
 
     /// Forward pass through the audio encoder head.
     ///
+    /// The encoder's one tensor entry point: `x` is cast to
+    /// [`dtype`](Self::dtype) here, and everything downstream of it is in
+    /// the model's precision.
+    ///
     /// # Arguments
-    /// * `x`: The input audio spectrogram `[batch, n_mels, seq]`.
+    /// * `x`: The input audio spectrogram `[batch, n_mels, seq]`, in any float
+    ///   dtype.
     ///
     /// # Returns
     /// `[batch, seq, d_model]`.
@@ -245,6 +268,8 @@ impl<B: Backend> AudioEncoder<B> {
         &self,
         x: Tensor<B, 3>,
     ) -> Tensor<B, 3> {
+        let x = x.cast(self.dtype());
+
         #[cfg(any(debug_assertions, test))]
         let [batch] = crate::contracts::unpack_shape_contract!(
             ["batch", "n_mels", "seq_len"],

--- a/crates/public/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs
+++ b/crates/public/bunsen/src/kits/speech/whisper/blocks/audio_encoder.rs
@@ -31,7 +31,10 @@ use crate::{
         ConvSeq1dMeta,
     },
     burner::{
-        module::ModuleInit,
+        module::{
+            HasDType,
+            ModuleInit,
+        },
         store::FixPytorchLoadMappers,
     },
     errors::BunsenResult,
@@ -214,13 +217,13 @@ impl<B: Backend> AudioEncoderMeta for AudioEncoder<B> {
     }
 }
 
-impl<B: Backend> AudioEncoder<B> {
-    /// The dtype the encoder's parameters were loaded in, and so the one it
-    /// computes in. `OpenAI`'s checkpoints ship in fp16.
-    pub fn dtype(&self) -> DType {
+impl<B: Backend> HasDType for AudioEncoder<B> {
+    fn dtype(&self) -> DType {
         self.positional_embedding.dtype()
     }
+}
 
+impl<B: Backend> AudioEncoder<B> {
     /// Forward pass through the audio encoder.
     ///
     /// # Arguments

--- a/crates/public/bunsen/src/kits/speech/whisper/blocks/text_decoder.rs
+++ b/crates/public/bunsen/src/kits/speech/whisper/blocks/text_decoder.rs
@@ -17,6 +17,7 @@ use burn::{
     },
     tensor::{
         Bool,
+        DType,
         Distribution,
         Int,
         TensorData,
@@ -28,6 +29,7 @@ use crate::{
     burner::{
         module::ModuleInit,
         store::FixPytorchLoadMappers,
+        tensor::backend_float_dtype,
     },
     errors::BunsenResult,
     kits::speech::whisper::blocks::{
@@ -193,19 +195,39 @@ impl<B: Backend> TextDecoderMeta for TextDecoder<B> {
 }
 
 impl<B: Backend> TextDecoder<B> {
+    /// The dtype the decoder's parameters were loaded in, and so the one it
+    /// computes in. `OpenAI`'s checkpoints ship in fp16.
+    ///
+    /// The encoder features, the cross-attention cache and the
+    /// self-attention cache are all at this precision; the logits are not
+    /// (see [`forward`](Self::forward)).
+    pub fn dtype(&self) -> DType {
+        self.token_embedding.weight.dtype()
+    }
+
     /// Runs the decoder.
     ///
     /// # Arguments
-    /// * `x`: `[batch, seq]`.
-    /// * `xa`: `[batch, seq, d_model]`.
+    /// * `x`: `[batch, seq]` token ids.
+    /// * `xa`: `[batch, seq, d_model]` encoder features, in any float dtype;
+    ///   cast to [`dtype`](Self::dtype) here.
     ///
     /// # Returns
-    /// `[batch, seq, n_vocab]`.
+    /// `[batch, seq, n_vocab]` logits, in the backend's default float
+    /// ([`backend_float_dtype`]) whatever the decoder's own precision. This
+    /// is the model's outward edge: everything past it — the log-softmax,
+    /// the samplers, the [`LogitFilter`]s, the host reads — works in the
+    /// backend's float, and upstream likewise takes its logits to `float()`
+    /// before the search sees them.
+    ///
+    /// [`LogitFilter`]: crate::kits::speech::whisper::logit_filters::LogitFilter
     pub fn forward(
         &self,
         x: Tensor<B, 2, Int>,
         xa: Tensor<B, 3>,
     ) -> Tensor<B, 3> {
+        let xa = xa.cast(self.dtype());
+
         let [_batch, seq_len] = x.dims();
         assert!(
             seq_len <= self.max_context(),
@@ -227,10 +249,9 @@ impl<B: Backend> TextDecoder<B> {
 
         let x = self.ln.forward(x);
 
-        unembed(&self.token_embedding, x)
-
         // denorm [batch, seq_len, n_vocab]
         // Needs softmax / beamsearch.
+        unembed(&self.token_embedding, x).cast(backend_float_dtype::<B>())
     }
 
     /// Opens an incremental decode cache against a fixed encoder output.
@@ -239,7 +260,8 @@ impl<B: Backend> TextDecoder<B> {
     /// they are reused unchanged for the whole decode.
     ///
     /// # Arguments
-    /// * `xa`: `[batch, cross_len, d_model]` encoder output.
+    /// * `xa`: `[batch, cross_len, d_model]` encoder output, in any float
+    ///   dtype; the cache is built in [`dtype`](Self::dtype).
     pub fn new_cache(
         &self,
         xa: Tensor<B, 3>,
@@ -263,6 +285,12 @@ impl<B: Backend> TextDecoder<B> {
         group: usize,
     ) -> TextDecoderCache<B> {
         assert!(group >= 1, "at least one row per audio");
+
+        // The cross-attention cache is the bulk of the decode's state and is
+        // scored against this decoder's weights on every step, so it is
+        // built in the decoder's precision whatever the caller handed in.
+        let xa = xa.cast(self.dtype());
+
         TextDecoderCache {
             self_kv: self.blocks.iter().map(|_| None).collect(),
             cross_kv: self
@@ -295,7 +323,8 @@ impl<B: Backend> TextDecoder<B> {
     ///   output, so it is not passed again.
     ///
     /// # Returns
-    /// `[batch, seq_new, n_vocab]` — logits for the new token(s) only.
+    /// `[batch, seq_new, n_vocab]` — logits for the new token(s) only, in
+    /// the backend's default float, as [`forward`](Self::forward).
     pub fn forward_cached(
         &self,
         x: Tensor<B, 2, Int>,
@@ -338,7 +367,7 @@ impl<B: Backend> TextDecoder<B> {
 
         cache.pos += seq_new;
 
-        unembed(&self.token_embedding, self.ln.forward(h))
+        unembed(&self.token_embedding, self.ln.forward(h)).cast(backend_float_dtype::<B>())
     }
 
     fn embed(
@@ -391,6 +420,12 @@ pub struct TextDecoderCache<B: Backend> {
 }
 
 impl<B: Backend> TextDecoderCache<B> {
+    /// The dtype of the cached keys and values: the decoder's, which
+    /// [`TextDecoder::new_cache_grouped`] casts to whatever it was handed.
+    pub fn dtype(&self) -> DType {
+        self.cross_kv[0].dtype()
+    }
+
     /// The number of tokens consumed so far.
     pub fn pos(&self) -> usize {
         self.pos
@@ -467,7 +502,10 @@ mod tests {
     use super::*;
     use crate::{
         contracts::assert_shape_contract,
-        support::testing::PerformanceBackend,
+        support::testing::{
+            CpuBackend,
+            PerformanceBackend,
+        },
     };
 
     #[test]
@@ -620,6 +658,57 @@ mod tests {
         mixed
             .to_data_as::<F>()
             .assert_approx_eq::<F>(&whole.to_data_as::<F>(), Tolerance::permissive());
+    }
+
+    /// **Both caches are the decoder's precision**, whatever the encoder
+    /// features were handed over in.
+    ///
+    /// The cross-attention cache is the bulk of a decode's state and the
+    /// self-attention cache is scored against it every step; a cache at the
+    /// caller's precision rather than the model's would be re-cast on every
+    /// use at best, and silently wrong at worst.
+    #[test]
+    #[serial]
+    fn test_caches_take_the_decoders_dtype() {
+        use burn::{
+            module::Module,
+            prelude::Device,
+            tensor::Distribution,
+        };
+
+        use crate::burner::{
+            module::DTypeMapper,
+            tensor::backend_float_dtype,
+        };
+
+        type B = CpuBackend;
+        let device: Device<B> = Default::default();
+
+        let float = backend_float_dtype::<B>();
+        let decoder: TextDecoder<B> = TextDecoderConfig::new(32, 128, 8, 1).init(&device);
+        let decoder = decoder.map(&mut DTypeMapper::new(DType::F16));
+        assert_eq!(decoder.dtype(), DType::F16);
+
+        // Features at the *caller's* precision, as a caller that widened
+        // them, or built them by hand, would have.
+        let xa: Tensor<B, 3> = Tensor::random([1, 4, 128], Distribution::Default, &device);
+        assert_eq!(xa.dtype(), float);
+
+        let mut cache = decoder.new_cache(xa);
+        assert_eq!(cache.dtype(), DType::F16, "cross-attention cache");
+        for kv in &cache.cross_kv {
+            assert_eq!(kv.dtype(), DType::F16);
+        }
+
+        let tokens: Tensor<B, 2, Int> =
+            Tensor::from_data(TensorData::new(vec![3i64, 5], [1, 2]), &device);
+        let logits = decoder.forward_cached(tokens, &mut cache);
+
+        assert_eq!(logits.dtype(), float, "logits are the interface's");
+        assert!(cache.self_kv.iter().any(|kv| kv.is_some()));
+        for kv in cache.self_kv.iter().flatten() {
+            assert_eq!(kv.dtype(), DType::F16, "self-attention cache");
+        }
     }
 
     /// `reset` rewinds the decode while keeping the encoder projections, so a

--- a/crates/public/bunsen/src/kits/speech/whisper/blocks/text_decoder.rs
+++ b/crates/public/bunsen/src/kits/speech/whisper/blocks/text_decoder.rs
@@ -27,7 +27,10 @@ use burn::{
 use super::WHISPER_DEFAULT_D_MODEL;
 use crate::{
     burner::{
-        module::ModuleInit,
+        module::{
+            HasDType,
+            ModuleInit,
+        },
         store::FixPytorchLoadMappers,
         tensor::backend_float_dtype,
     },
@@ -194,17 +197,13 @@ impl<B: Backend> TextDecoderMeta for TextDecoder<B> {
     }
 }
 
-impl<B: Backend> TextDecoder<B> {
-    /// The dtype the decoder's parameters were loaded in, and so the one it
-    /// computes in. `OpenAI`'s checkpoints ship in fp16.
-    ///
-    /// The encoder features, the cross-attention cache and the
-    /// self-attention cache are all at this precision; the logits are not
-    /// (see [`forward`](Self::forward)).
-    pub fn dtype(&self) -> DType {
+impl<B: Backend> HasDType for TextDecoder<B> {
+    fn dtype(&self) -> DType {
         self.token_embedding.weight.dtype()
     }
+}
 
+impl<B: Backend> TextDecoder<B> {
     /// Runs the decoder.
     ///
     /// # Arguments
@@ -419,13 +418,13 @@ pub struct TextDecoderCache<B: Backend> {
     pos: usize,
 }
 
-impl<B: Backend> TextDecoderCache<B> {
-    /// The dtype of the cached keys and values: the decoder's, which
-    /// [`TextDecoder::new_cache_grouped`] casts to whatever it was handed.
-    pub fn dtype(&self) -> DType {
+impl<B: Backend> HasDType for TextDecoderCache<B> {
+    fn dtype(&self) -> DType {
         self.cross_kv[0].dtype()
     }
+}
 
+impl<B: Backend> TextDecoderCache<B> {
     /// The number of tokens consumed so far.
     pub fn pos(&self) -> usize {
         self.pos

--- a/crates/public/bunsen/src/kits/speech/whisper/blocks/whisper_model.rs
+++ b/crates/public/bunsen/src/kits/speech/whisper/blocks/whisper_model.rs
@@ -6,6 +6,7 @@ use burn::{
         Backend,
         Int,
     },
+    tensor::DType,
 };
 
 use super::{
@@ -269,14 +270,39 @@ impl<B: Backend> WhisperMeta for Whisper<B> {
 }
 
 impl<B: Backend> Whisper<B> {
+    /// The dtype the model's parameters were loaded in, and so the one it
+    /// computes in. `OpenAI`'s checkpoints ship in fp16.
+    ///
+    /// This is **not** the dtype of the model's interface. Log-mels go in at
+    /// whatever float the front end produced and are cast here; logits come
+    /// out in the backend's default float
+    /// ([`backend_float_dtype`](crate::burner::tensor::backend_float_dtype)).
+    /// What stays at this precision is everything between: the encoder
+    /// features, and the cross- and self-attention caches projected from
+    /// them.
+    ///
+    /// # Panics
+    /// If the encoder and the decoder were loaded at different precisions,
+    /// which no checkpoint and no
+    /// [`DTypeMapper`](crate::burner::module::DTypeMapper) produces.
+    pub fn dtype(&self) -> DType {
+        let (encoder, decoder) = (self.encoder.dtype(), self.decoder.dtype());
+        assert_eq!(
+            encoder, decoder,
+            "the encoder and the decoder are at different precisions",
+        );
+        encoder
+    }
+
     /// Forward pass through the Whisper model.
     ///
     /// # Arguments
-    /// * `mel`: The input audio spectrogram `[batch, n_mels, seq]`.
+    /// * `mel`: The input audio spectrogram `[batch, n_mels, seq]`, in any
+    ///   float dtype.
     /// * `tokens`: `[batch, seq]`.
     ///
     /// # Returns
-    /// `[batch, seq, vocab_size]`.
+    /// `[batch, seq, vocab_size]` logits, in the backend's default float.
     pub fn forward(
         &self,
         mel: Tensor<B, 3>,
@@ -288,10 +314,13 @@ impl<B: Backend> Whisper<B> {
     /// Forward pass through the Whisper encoder.
     ///
     /// # Arguments
-    /// * `mel`: The input audio spectrogram `[batch, n_mels, seq]`.
+    /// * `mel`: The input audio spectrogram `[batch, n_mels, seq]`, in any
+    ///   float dtype; the mel front end works in the backend's default.
     ///
     /// # Returns
-    /// `[batch, seq, n_audio_states]`.
+    /// `[batch, seq, n_audio_states]`, in the model's [`dtype`](Self::dtype)
+    /// — these features feed the decoder and its cross-attention cache, and
+    /// are not an interface value. See [`AudioEncoder::forward`].
     pub fn forward_encoder(
         &self,
         mel: Tensor<B, 3>,
@@ -303,10 +332,11 @@ impl<B: Backend> Whisper<B> {
     ///
     /// # Arguments
     /// * `tokens`: `[batch, seq]`.
-    /// * `encoder_output`: `[batch, seq, d_model]`.
+    /// * `encoder_output`: `[batch, seq, d_model]`, in any float dtype.
     ///
     /// # Returns
-    /// `[batch, seq, vocab_size]`.
+    /// `[batch, seq, vocab_size]` logits, in the backend's default float.
+    /// See [`TextDecoder::forward`].
     pub fn forward_decoder(
         &self,
         tokens: Tensor<B, 2, Int>,
@@ -324,12 +354,16 @@ mod tests {
             Device,
             TensorData,
         },
-        tensor::DType,
+        tensor::Distribution,
     };
     use serial_test::serial;
 
     use super::*;
     use crate::{
+        burner::{
+            module::DTypeMapper,
+            tensor::backend_float_dtype,
+        },
         contracts::assert_shape_contract,
         support::testing::{
             CpuBackend,
@@ -433,6 +467,107 @@ mod tests {
         assert_eq!(model.sample_rate(), 8_000);
         assert_eq!(model.front_end().hop(), 80);
         assert_eq!(model.token_layout().timestamp_tokens, 751);
+    }
+
+    /// **The dtype boundary.** A checkpoint at a precision the caller does
+    /// not share must not push that precision onto the caller, and must not
+    /// be widened to meet them: mels go in at the backend's float, logits
+    /// come back at it, and the model computes in its own throughout.
+    ///
+    /// This is what lets a fp16 checkpoint be used straight off
+    /// [`Whisper::load_pretrained`], with the mel front end left in f32.
+    #[test]
+    #[serial]
+    fn test_dtype_is_cast_at_the_interface() {
+        type B = CpuBackend;
+        let device: Device<B> = Default::default();
+
+        let float = backend_float_dtype::<B>();
+        let model: Whisper<B> = WhisperApiConfig::new(8, 32, 64, 16, 1, 12, 1)
+            .try_init(&device)
+            .unwrap();
+        assert_eq!(model.dtype(), float, "init builds at the backend's float");
+
+        let half = model.map(&mut DTypeMapper::new(DType::F16));
+        assert_eq!(half.dtype(), DType::F16);
+
+        // The mel front end's output: the backend's float, not the model's.
+        let mel: Tensor<B, 3> = Tensor::random([1, 8, 16], Distribution::Default, &device);
+        let tokens: Tensor<B, 2, Int> = Tensor::zeros([1, 4], &device);
+        assert_eq!(mel.dtype(), float);
+
+        // In at the backend's float, out at it, with the model's own
+        // precision in between.
+        let xa = half.forward_encoder(mel.clone());
+        assert_eq!(xa.dtype(), DType::F16, "features stay in the model's dtype");
+        assert_eq!(
+            half.forward_decoder(tokens.clone(), xa.clone()).dtype(),
+            float
+        );
+        assert_eq!(half.forward(mel, tokens.clone()).dtype(), float);
+
+        // Both caches are the model's, including from features a caller
+        // widened behind the model's back.
+        let cache = half.decoder.new_cache(xa.clone());
+        assert_eq!(cache.dtype(), DType::F16, "cross-attention cache");
+        let widened = half.decoder.new_cache(xa.cast(float));
+        assert_eq!(widened.dtype(), DType::F16, "and from f32 features");
+
+        let mut cache = cache;
+        assert_eq!(
+            half.decoder.forward_cached(tokens, &mut cache).dtype(),
+            float,
+        );
+    }
+
+    /// The cast is a *conversion*, not a reinterpretation: the same weights
+    /// at two precisions take the same audio to the same logits.
+    ///
+    /// This is the failure the boundary casts exist to prevent, and it is a
+    /// silent one — f32 mels fed to f16 weights do not error, they just
+    /// return numbers that are wrong. Wrong by the width of the signal:
+    /// when this pairing was broken during development it disagreed by ~29
+    /// on logits of magnitude ~48, against the 0.013 it agrees to now.
+    #[test]
+    #[serial]
+    fn test_half_precision_tracks_full() {
+        use burn::tensor::{
+            Tolerance,
+            backend::BackendTypes,
+        };
+
+        use crate::burner::tensor::TensorElemOpExt;
+
+        type B = CpuBackend;
+        type F = <B as BackendTypes>::FloatElem;
+
+        let device: Device<B> = Default::default();
+
+        // `Param::clone` on a *lazily* initialized parameter clones the
+        // initializer rather than the value, and a random initializer then
+        // gives the clone different weights — two models, not one model at
+        // two precisions. Mapping onto the dtype it already has forces
+        // every parameter first, which is what makes the clone a copy.
+        let full: Whisper<B> = WhisperApiConfig::new(8, 32, 64, 16, 1, 12, 1)
+            .try_init(&device)
+            .unwrap()
+            .map(&mut DTypeMapper::new(backend_float_dtype::<B>()));
+        let half = full.clone().map(&mut DTypeMapper::new(DType::F16));
+
+        let mel: Tensor<B, 3> = Tensor::random([1, 8, 16], Distribution::Default, &device);
+        let tokens: Tensor<B, 2, Int> = Tensor::zeros([1, 4], &device);
+
+        // fp16 carries a bit over three decimal digits, and this is a whole
+        // encoder and decoder deep: the agreement is precision-limited.
+        // Measured at 1.3e-2 absolute on a magnitude of 48; set with
+        // headroom over that, and still an order of magnitude tighter than
+        // any real defect.
+        full.forward(mel.clone(), tokens.clone())
+            .to_data_as::<F>()
+            .assert_approx_eq::<F>(
+                &half.forward(mel, tokens).to_data_as::<F>(),
+                Tolerance::rel_abs(1e-2, 5e-2),
+            );
     }
 
     #[test]

--- a/crates/public/bunsen/src/kits/speech/whisper/blocks/whisper_model.rs
+++ b/crates/public/bunsen/src/kits/speech/whisper/blocks/whisper_model.rs
@@ -16,7 +16,10 @@ use super::{
 };
 use crate::{
     burner::{
-        module::ModuleInit,
+        module::{
+            HasDType,
+            ModuleInit,
+        },
         store::FixPytorchLoadMappers,
     },
     kits::speech::whisper::blocks::{
@@ -269,7 +272,7 @@ impl<B: Backend> WhisperMeta for Whisper<B> {
     }
 }
 
-impl<B: Backend> Whisper<B> {
+impl<B: Backend> HasDType for Whisper<B> {
     /// The dtype the model's parameters were loaded in, and so the one it
     /// computes in. `OpenAI`'s checkpoints ship in fp16.
     ///
@@ -284,8 +287,7 @@ impl<B: Backend> Whisper<B> {
     /// # Panics
     /// If the encoder and the decoder were loaded at different precisions,
     /// which no checkpoint and no
-    /// [`DTypeMapper`](crate::burner::module::DTypeMapper) produces.
-    pub fn dtype(&self) -> DType {
+    fn dtype(&self) -> DType {
         let (encoder, decoder) = (self.encoder.dtype(), self.decoder.dtype());
         assert_eq!(
             encoder, decoder,
@@ -293,7 +295,9 @@ impl<B: Backend> Whisper<B> {
         );
         encoder
     }
+}
 
+impl<B: Backend> Whisper<B> {
     /// Forward pass through the Whisper model.
     ///
     /// # Arguments
@@ -475,7 +479,8 @@ mod tests {
     /// come back at it, and the model computes in its own throughout.
     ///
     /// This is what lets a fp16 checkpoint be used straight off
-    /// [`Whisper::load_pretrained`], with the mel front end left in f32.
+    /// [`Whisper::load_pretrained_16khz_fp16_base`], with the mel front end
+    /// left in f32.
     #[test]
     #[serial]
     fn test_dtype_is_cast_at_the_interface() {

--- a/crates/public/bunsen/src/kits/speech/whisper/pretrained/load.rs
+++ b/crates/public/bunsen/src/kits/speech/whisper/pretrained/load.rs
@@ -50,8 +50,9 @@ impl<B: Backend> Whisper<B> {
     /// that precision, which is what the model then computes in. It is not
     /// what its interface speaks: the mel front end's log-mels are cast
     /// down on the way in and the logits are cast back up on the way out
-    /// (see [`Whisper::dtype`]), so a caller stays in the backend's float
-    /// and nothing here needs re-typing.
+    /// (see [`HasDType::dtype()`](`crate::burner::module::HasDType`), so a
+    /// caller stays in the backend's float and nothing here needs
+    /// re-typing.
     ///
     /// To run the model itself at another precision — comparing against an
     /// f32 reference graph, or on a device without fp16 — map it:
@@ -61,12 +62,14 @@ impl<B: Backend> Whisper<B> {
     /// # use bunsen::{burner::module::DTypeMapper, kits::speech::whisper::Whisper};
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let device = Default::default();
-    /// let (model, cfg) = Whisper::<Wgpu>::load_pretrained(&device)?;
+    /// let (model, cfg) = Whisper::<Wgpu>::load_pretrained_16khz_fp16_base(&device)?;
     /// let model = model.map(&mut DTypeMapper::new(DType::F32));
     /// # Ok(())
     /// # }
     /// ```
-    pub fn load_pretrained(device: &B::Device) -> BunsenResult<(Self, WhisperApiConfig)> {
+    pub fn load_pretrained_16khz_fp16_base(
+        device: &B::Device
+    ) -> BunsenResult<(Self, WhisperApiConfig)> {
         PytorchWhisperScanner::new().load::<B, _>(bundled::base_pt(), device)
     }
 }

--- a/crates/public/bunsen/src/kits/speech/whisper/pretrained/load.rs
+++ b/crates/public/bunsen/src/kits/speech/whisper/pretrained/load.rs
@@ -46,10 +46,15 @@ impl<B: Backend> Whisper<B> {
     /// cached asset was deleted after the build.
     ///
     /// # Note
-    /// `OpenAI` ships these checkpoints in **fp16**. The weights load at that
-    /// precision, while the mel front end produces the backend's default
-    /// float; feeding f32 input to an f16 model does not error, it just
-    /// returns wrong numbers. Cast the model before use:
+    /// `OpenAI` ships these checkpoints in **fp16**, and the weights load at
+    /// that precision, which is what the model then computes in. It is not
+    /// what its interface speaks: the mel front end's log-mels are cast
+    /// down on the way in and the logits are cast back up on the way out
+    /// (see [`Whisper::dtype`]), so a caller stays in the backend's float
+    /// and nothing here needs re-typing.
+    ///
+    /// To run the model itself at another precision — comparing against an
+    /// f32 reference graph, or on a device without fp16 — map it:
     ///
     /// ```no_run
     /// # use burn::{module::Module, tensor::DType, backend::Wgpu};

--- a/crates/public/bunsen/src/ops/transformers/attention/attn_kv_pair.rs
+++ b/crates/public/bunsen/src/ops/transformers/attention/attn_kv_pair.rs
@@ -1,6 +1,7 @@
 use burn::{
     Tensor,
     prelude::Backend,
+    tensor::DType,
 };
 
 /// Projected, head-split keys and values: `[batch, heads, seq, d_k]`.
@@ -18,6 +19,11 @@ pub struct AttnKvPair<B: Backend> {
 }
 
 impl<B: Backend> AttnKvPair<B> {
+    /// The data type of the keys and values.
+    pub fn dtype(&self) -> DType {
+        self.key.dtype()
+    }
+
     /// The number of cached positions.
     pub fn seq_len(&self) -> usize {
         self.key.dims()[2]

--- a/crates/public/bunsen/src/ops/transformers/attention/attn_kv_pair.rs
+++ b/crates/public/bunsen/src/ops/transformers/attention/attn_kv_pair.rs
@@ -4,6 +4,8 @@ use burn::{
     tensor::DType,
 };
 
+use crate::burner::module::HasDType;
+
 /// Projected, head-split keys and values: `[batch, heads, seq, d_k]`.
 ///
 /// Built by [`project_kv_pair`](super::project_kv_pair). Self-attention grows
@@ -18,12 +20,13 @@ pub struct AttnKvPair<B: Backend> {
     pub value: Tensor<B, 4>,
 }
 
-impl<B: Backend> AttnKvPair<B> {
-    /// The data type of the keys and values.
-    pub fn dtype(&self) -> DType {
+impl<B: Backend> HasDType for AttnKvPair<B> {
+    fn dtype(&self) -> DType {
         self.key.dtype()
     }
+}
 
+impl<B: Backend> AttnKvPair<B> {
     /// The number of cached positions.
     pub fn seq_len(&self) -> usize {
         self.key.dims()[2]

--- a/crates/validation/whisper-model-validation/src/audio/mod.rs
+++ b/crates/validation/whisper-model-validation/src/audio/mod.rs
@@ -340,7 +340,7 @@ pub fn clip_mels<B: Backend>(
 /// float. Feeding f32 input to an f16 model does not error, it just
 /// returns wrong numbers, so the cast is load-bearing.
 pub fn bunsen_model<B: Backend>(device: &Device<B>) -> Whisper<B> {
-    let (model, cfg) = Whisper::load_pretrained(device).expect("load base.pt");
+    let (model, cfg) = Whisper::load_pretrained_16khz_fp16_base(device).expect("load base.pt");
 
     assert_eq!(cfg.n_mels, N_MELS, "not a `base` model");
     assert_eq!(

--- a/crates/validation/whisper-model-validation/src/staged.rs
+++ b/crates/validation/whisper-model-validation/src/staged.rs
@@ -63,7 +63,8 @@ fn test_bunsen_encoder_matches_reference() {
 
     let reference = reference::EncoderModel::<B>::load_pretrained(&device).forward(mels.clone());
 
-    let (model, cfg) = Whisper::<B>::load_pretrained(&device).expect("load base.pt");
+    let (model, cfg) =
+        Whisper::<B>::load_pretrained_16khz_fp16_base(&device).expect("load base.pt");
     assert_eq!(cfg.n_mels, N_MELS, "the checkpoint is not a `base` model");
 
     // OpenAI ships these checkpoints in fp16. The reference graph is f32,
@@ -91,7 +92,7 @@ fn test_bunsen_encoder_matches_reference() {
 /// Loads bunsen's Whisper from the fetched checkpoint, in f32.
 fn load_bunsen() -> (Whisper<B>, burn::prelude::Device<B>) {
     let device: burn::prelude::Device<B> = Default::default();
-    let (model, _) = Whisper::<B>::load_pretrained(&device).expect("load base.pt");
+    let (model, _) = Whisper::<B>::load_pretrained_16khz_fp16_base(&device).expect("load base.pt");
 
     // OpenAI ships these checkpoints in fp16; the reference graph is f32.
     // Feeding f32 input to an f16 model does not error here, it just

--- a/examples/whisper-cli/src/whisper_clap.rs
+++ b/examples/whisper-cli/src/whisper_clap.rs
@@ -82,6 +82,7 @@ impl WhisperDriverArgs {
         Whisper::<B>::load_pretrained_16khz_fp16_base(device)
     }
 
+    /// Load and setup the [`WhisperStreamDriver`].
     pub fn init_driver<B: Backend>(
         &self,
         device: &B::Device,

--- a/examples/whisper-cli/src/whisper_clap.rs
+++ b/examples/whisper-cli/src/whisper_clap.rs
@@ -79,7 +79,7 @@ impl WhisperDriverArgs {
         &self,
         device: &B::Device,
     ) -> BunsenResult<(Whisper<B>, WhisperApiConfig)> {
-        Whisper::<B>::load_pretrained(device)
+        Whisper::<B>::load_pretrained_16khz_fp16_base(device)
     }
 
     pub fn init_driver<B: Backend>(

--- a/examples/whisper-cli/src/whisper_clap.rs
+++ b/examples/whisper-cli/src/whisper_clap.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use bunsen::{
-    burner::module::DTypeMapper,
     errors::BunsenResult,
     kits::speech::{
         silero_vad::SileroVad,
@@ -20,11 +19,7 @@ use bunsen::{
         },
     },
 };
-use burn::{
-    module::Module,
-    prelude::Backend,
-    tensor::DType,
-};
+use burn::prelude::Backend;
 
 #[derive(clap::Args, Debug)]
 pub struct WhisperDriverArgs {
@@ -75,15 +70,16 @@ pub struct WhisperDriverArgs {
 }
 
 impl WhisperDriverArgs {
+    /// Loads the bundled checkpoint at the precision it ships in.
+    ///
+    /// The checkpoint is fp16 while the mel front end works in the backend's
+    /// float, but the model casts at its own edges — mels in, logits out —
+    /// so nothing here has to re-type it.
     pub fn load_model<B: Backend>(
         &self,
         device: &B::Device,
     ) -> BunsenResult<(Whisper<B>, WhisperApiConfig)> {
-        let (model, cfg) = Whisper::<B>::load_pretrained(device)?;
-        // The checkpoint ships in fp16 while the mel front end works in the
-        // backend's float; cast the model up, where precision is cheap.
-        let model = model.map(&mut DTypeMapper::new(DType::F32));
-        Ok((model, cfg))
+        Whisper::<B>::load_pretrained(device)
     }
 
     pub fn init_driver<B: Backend>(


### PR DESCRIPTION
…sper model and components

- Added `dtype` methods to `Whisper`, `AudioEncoder`, `TextDecoder`, and other components to reflect loaded precision.
- Implemented boundary casting between the backend's default float and the model's computation precision.
- Updated Whisper interface comments and tests to validate type consistency across encoder, decoder, and interface boundaries.